### PR TITLE
fix(journal-server): should't return error when the number of connect…

### DIFF
--- a/src/journal-server/src/server/tcp/connection.rs
+++ b/src/journal-server/src/server/tcp/connection.rs
@@ -86,7 +86,7 @@ impl ConnectionManager {
 
     pub fn connect_check(&self) -> Result<(), Error> {
         // Verify the connection limit
-        if self.connections.len() >= self.max_connection_num {
+        if self.connections.len() > self.max_connection_num {
             return Err(Error::ConnectionExceed {
                 total: self.max_connection_num,
             });


### PR DESCRIPTION
Should't return error when the number of connections is equal to MAX_CONNECTION_COUNT