### PR TITLE
fix: warning message for unused code

### DIFF
--- a/src/journal-server/src/record/header.rs
+++ b/src/journal-server/src/record/header.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use bytes::Bytes;
-
+#[allow(dead_code)]
 pub struct Header {
     pub key: String,
     pub value: Bytes,

--- a/src/journal-server/src/server/tcp/connection.rs
+++ b/src/journal-server/src/server/tcp/connection.rs
@@ -100,6 +100,7 @@ impl ConnectionManager {
 
 static CONNECTION_ID_BUILD: AtomicU64 = AtomicU64::new(1);
 
+#[allow(dead_code)]
 pub struct Connection {
     pub connection_id: u64,
     pub addr: SocketAddr,

--- a/src/journal-server/src/storage.rs
+++ b/src/journal-server/src/storage.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+#[allow(dead_code)]
 pub trait StorageFormat {
     fn create_segment(&self);
     fn append(&self);

--- a/src/journal-server/src/storage.rs
+++ b/src/journal-server/src/storage.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #[allow(dead_code)]
 pub trait StorageFormat {
     fn create_segment(&self);

--- a/src/mqtt-broker/src/observability/slow/qos.rs
+++ b/src/mqtt-broker/src/observability/slow/qos.rs
@@ -29,6 +29,7 @@ pub struct SlowMessage {
     create_time: u128,
 }
 
+#[allow(dead_code)]
 pub fn try_record_slow_message(
     _: Arc<CacheManager>,
     client_id: String,

--- a/src/mqtt-broker/tests/share_sub_test.rs
+++ b/src/mqtt-broker/tests/share_sub_test.rs
@@ -38,7 +38,7 @@ mod tests {
         // simple_test(topic.clone(), sub_topic.clone(), sub_qos, "3".to_string()).await;
     }
     
-
+    #[allow(dead_code)]
     async fn simple_test(
         pub_topic: String,
         sub_topic: String,

--- a/src/placement-center/src/core/share_sub.rs
+++ b/src/placement-center/src/core/share_sub.rs
@@ -125,7 +125,8 @@ impl ShareSubLeader {
         }
         return Ok(());
     }
-
+    
+    #[allow(dead_code)]
     pub fn delete_node(&self, cluster_name: &String, broker_id: u64) -> Result<(), CommonError> {
         let mut node_sub_info = match self.read_node_sub_info(cluster_name) {
             Ok(data) => data,

--- a/src/placement-center/src/raft/metadata.rs
+++ b/src/placement-center/src/raft/metadata.rs
@@ -31,6 +31,7 @@ pub enum NodeState {
 }
 
 #[derive(Clone, Default, Debug)]
+#[allow(dead_code)]
 pub struct RaftGroupMetadata {
     pub local: BrokerNode,
     pub leader: Option<BrokerNode>,
@@ -39,6 +40,7 @@ pub struct RaftGroupMetadata {
     pub peers: HashMap<u64, BrokerNode>,
 }
 
+#[allow(dead_code)]
 impl RaftGroupMetadata {
     pub fn new() -> RaftGroupMetadata {
         let config = placement_center_conf();

--- a/src/placement-center/src/server/http/server.rs
+++ b/src/placement-center/src/server/http/server.rs
@@ -36,6 +36,7 @@ pub const ROUTE_CLUSTER: &str = "/cluster";
 pub const ROUTE_CLUSTER_NODE: &str = "/cluster/node";
 
 #[derive(Clone)]
+#[allow(dead_code)]
 pub struct HttpServerState {
     pub raft_metadata: Arc<RwLock<RaftGroupMetadata>>,
     pub raft_storage: Arc<RwLock<RaftMachineStorage>>,

--- a/src/placement-center/src/storage/journal/segment.rs
+++ b/src/placement-center/src/storage/journal/segment.rs
@@ -95,6 +95,7 @@ impl SegmentStorage {
         }
     }
 
+    #[allow(dead_code)]
     pub fn list_by_cluster(
         &self,
         cluster_name: &String,
@@ -121,6 +122,7 @@ impl SegmentStorage {
         }
     }
 
+    #[allow(dead_code)]
     pub fn list_by_shard(
         &self,
         cluster_name: &String,

--- a/src/placement-center/src/storage/rocksdb.rs
+++ b/src/placement-center/src/storage/rocksdb.rs
@@ -226,6 +226,7 @@ impl RocksDBEngine {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 mod tests {
     use super::RocksDBEngine;
     use crate::storage::keys::key_name_by_last_index;

--- a/src/placement-center/src/storage/rocksdb.rs
+++ b/src/placement-center/src/storage/rocksdb.rs
@@ -226,7 +226,6 @@ impl RocksDBEngine {
 }
 
 #[cfg(test)]
-#[allow(dead_code)]
 mod tests {
     use super::RocksDBEngine;
     use crate::storage::keys::key_name_by_last_index;

--- a/src/protocol/tests/mqtt_frame.rs
+++ b/src/protocol/tests/mqtt_frame.rs
@@ -123,6 +123,7 @@ mod tests {
     }
 
     /// Build the connect content package for the mqtt4 protocol
+    #[allow(dead_code)]
     fn build_mqtt4_pg_connect_ack() -> MQTTPacketWrapper {
         let ack: ConnAck = ConnAck {
             session_present: false,


### PR DESCRIPTION
## What's changed and what's your intention?

_Fixed all the warning message for unused code_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Removed the warning message in compilation.
- Update your code and rebuild the poject, warning messages should be disappeared.
- #[allow(dead_code)] added for unused code.
- It is better to remove this kind of unused code rather than tag it with #[allow(dead_code)].

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
close  #442 
