### PR TITLE
test: add validation to the Set method in the GrpcKvService file; refine the cluster_node_test test case

### DIFF
--- a/src/clients/tests/kv_test.rs
+++ b/src/clients/tests/kv_test.rs
@@ -44,6 +44,32 @@ mod tests {
             }
         }
 
+        let request_key_empty = SetRequest {
+            key: "".to_string(),
+            value: value.clone(),
+        };
+        match placement_set(client_poll.clone(), addrs.clone(), request_key_empty).await{
+            Ok(_) => {
+                panic!("Expected an error when key is empty, but got ok");
+            }
+            Err(e) => {
+                assert!(e.to_string().contains("key or value"));
+            }
+        }
+
+        let request_value_empty = SetRequest{
+            key: key.clone(),
+            value: "".to_string(),
+        };
+        match placement_set(client_poll.clone(), addrs.clone(), request_value_empty).await{
+            Ok(_) => {
+                panic!("Expected an error when value is empty, but got ok");
+            }
+            Err(e) => {
+                assert!(e.to_string().contains("key or value"));
+            }
+        }
+
         let exist_req = ExistsRequest { key: key.clone() };
         match placement_exists(client_poll.clone(), addrs.clone(), exist_req).await {
             Ok(da) => {

--- a/src/mqtt-broker/src/storage/cluster.rs
+++ b/src/mqtt-broker/src/storage/cluster.rs
@@ -220,7 +220,43 @@ mod tests {
     use std::sync::Arc;
 
     #[tokio::test]
-    async fn cluster_node_test() {}
+    async fn cluster_node_test() {
+        let path = format!(
+            "{}/../../config/mqtt-server.toml",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        init_broker_mqtt_conf_by_path(&path);
+
+        let client_poll: Arc<ClientPool> = Arc::new(ClientPool::new(10));
+        let cluster_storage = ClusterStorage::new(client_poll);
+
+        cluster_storage.register_node()
+            .await
+            .unwrap();
+
+        let register_node_list = cluster_storage
+            .node_list()
+            .await
+            .unwrap();
+        assert!(!register_node_list.is_empty());
+
+        cluster_storage
+            .heartbeat()
+            .await
+            .unwrap();
+
+        cluster_storage
+            .unregister_node()
+            .await
+            .unwrap();
+
+        let node_list_after_unregister = cluster_storage
+            .node_list()
+            .await
+            .unwrap();
+        assert!(node_list_after_unregister.is_empty());
+
+    }
 
     #[tokio::test]
     async fn cluster_config_test() {


### PR DESCRIPTION
### What's changed and what's your intention?
- Add validation to the Set method in the GrpcKvService file
- Refine the cluster_node_test test case in file: src/mqtt-broker/src/storage/cluster.rs
- 
### Refer to a related PR or issue link (optional)
- https://github.com/robustmq/robustmq/issues/487
- https://github.com/robustmq/robustmq/issues/440