### PR TITLE
chore: renamed MQTT* types to Mqtt*

### DIFF
--- a/src/clients/src/placement/mqtt/inner.rs
+++ b/src/clients/src/placement/mqtt/inner.rs
@@ -15,10 +15,10 @@
 // use common_base::error::common::CommonError;
 // use mobc::Connection;
 
-// use super::MQTTServiceManager;
+// use super::MqttServiceManager;
 
 // pub(crate) async fn inner_call<R, Resp, ClientFunction, Fut, DecodeFunction, EncodeFunction>(
-//     client: Connection<MQTTServiceManager>,
+//     client: Connection<MqttServiceManager>,
 //     request: Vec<u8>,
 //     decode_fn: DecodeFunction,
 //     client_fn: ClientFunction,
@@ -28,7 +28,7 @@
 //     R: prost::Message + Default,
 //     Resp: prost::Message,
 //     DecodeFunction: FnOnce(&[u8]) -> Result<R, prost::DecodeError>,
-//     ClientFunction: FnOnce(Connection<MQTTServiceManager>, R) -> Fut,
+//     ClientFunction: FnOnce(Connection<MqttServiceManager>, R) -> Fut,
 //     Fut: std::future::Future<Output = Result<tonic::Response<Resp>, tonic::Status>>,
 //     EncodeFunction: FnOnce(&Resp) -> Vec<u8>,
 // {

--- a/src/clients/src/placement/mqtt/mod.rs
+++ b/src/clients/src/placement/mqtt/mod.rs
@@ -38,7 +38,7 @@ mod inner;
 async fn mqtt_client(
     client_poll: Arc<ClientPool>,
     addr: String,
-) -> Result<Connection<MQTTServiceManager>, CommonError> {
+) -> Result<Connection<MqttServiceManager>, CommonError> {
     match client_poll
         .placement_center_mqtt_services_client(addr)
         .await
@@ -125,7 +125,7 @@ pub(crate) async fn mqtt_interface_call(
                             client,
                             request.clone(),
                             |data| DeleteTopicRequest::decode(data),
-                            |mut client: Connection<MQTTServiceManager>, request| async move {
+                            |mut client: Connection<MqttServiceManager>, request| async move {
                                 client.delete_topic(request).await
                             },
                             CommonReply::encode_to_vec,
@@ -261,18 +261,18 @@ pub(crate) async fn mqtt_interface_call(
 }
 
 #[derive(Clone)]
-pub struct MQTTServiceManager {
+pub struct MqttServiceManager {
     pub addr: String,
 }
 
-impl MQTTServiceManager {
+impl MqttServiceManager {
     pub fn new(addr: String) -> Self {
         Self { addr }
     }
 }
 
 #[tonic::async_trait]
-impl Manager for MQTTServiceManager {
+impl Manager for MqttServiceManager {
     type Connection = MqttServiceClient<Channel>;
     type Error = CommonError;
 
@@ -297,7 +297,7 @@ impl Manager for MQTTServiceManager {
 }
 
 pub(crate) async fn client_call<R, Resp, ClientFunction, Fut, DecodeFunction, EncodeFunction>(
-    client: Connection<MQTTServiceManager>,
+    client: Connection<MqttServiceManager>,
     request: Vec<u8>,
     decode_fn: DecodeFunction,
     client_fn: ClientFunction,
@@ -307,7 +307,7 @@ where
     R: prost::Message + Default,
     Resp: prost::Message,
     DecodeFunction: FnOnce(&[u8]) -> Result<R, prost::DecodeError>,
-    ClientFunction: FnOnce(Connection<MQTTServiceManager>, R) -> Fut,
+    ClientFunction: FnOnce(Connection<MqttServiceManager>, R) -> Fut,
     Fut: std::future::Future<Output = Result<tonic::Response<Resp>, tonic::Status>>,
     EncodeFunction: FnOnce(&Resp) -> Vec<u8>,
 {

--- a/src/clients/src/poll.rs
+++ b/src/clients/src/poll.rs
@@ -21,7 +21,7 @@ use crate::mqtt::admin::MqttBrokerAdminServiceManager;
 use crate::mqtt::placement::MqttBrokerPlacementServiceManager;
 use crate::placement::journal::JournalServiceManager;
 use crate::placement::kv::KvServiceManager;
-use crate::placement::mqtt::MQTTServiceManager;
+use crate::placement::mqtt::MqttServiceManager;
 use crate::placement::openraft::OpenRaftServiceManager;
 use crate::placement::placement::PlacementServiceManager;
 
@@ -32,7 +32,7 @@ pub struct ClientPool {
     placement_center_inner_pools: DashMap<String, Pool<PlacementServiceManager>>,
     placement_center_journal_service_pools: DashMap<String, Pool<JournalServiceManager>>,
     placement_center_kv_service_pools: DashMap<String, Pool<KvServiceManager>>,
-    placement_center_mqtt_service_pools: DashMap<String, Pool<MQTTServiceManager>>,
+    placement_center_mqtt_service_pools: DashMap<String, Pool<MqttServiceManager>>,
     placement_center_openraft_service_pools: DashMap<String, Pool<OpenRaftServiceManager>>,
 
     // mqtt broker
@@ -163,12 +163,12 @@ impl ClientPool {
     pub async fn placement_center_mqtt_services_client(
         &self,
         addr: String,
-    ) -> Result<Connection<MQTTServiceManager>, CommonError> {
+    ) -> Result<Connection<MqttServiceManager>, CommonError> {
         let module = "MqttServices".to_string();
         let key = format!("{}_{}_{}", "PlacementCenter", module, addr);
 
         if !self.placement_center_mqtt_service_pools.contains_key(&key) {
-            let manager = MQTTServiceManager::new(addr.clone());
+            let manager = MqttServiceManager::new(addr.clone());
             let pool = Pool::builder()
                 .max_open(self.max_open_connection)
                 .build(manager);

--- a/src/clients/tests/mqtt/mqtt_acl_test.rs
+++ b/src/clients/tests/mqtt/mqtt_acl_test.rs
@@ -20,7 +20,7 @@ mod tests {
     use clients::poll::ClientPool;
     use common_base::tools::unique_id;
     use metadata_struct::acl::mqtt_acl::{
-        MQTTAcl, MQTTAclAction, MQTTAclPermission, MQTTAclResourceType,
+        MqttAcl, MqttAclAction, MqttAclPermission, MqttAclResourceType,
     };
     use protocol::placement_center::generate::mqtt::{
         CreateAclRequest, DeleteAclRequest, ListAclRequest, ListBlacklistRequest,
@@ -34,13 +34,13 @@ mod tests {
         let addrs = vec![get_placement_addr()];
         let cluster_name: String = format!("test_cluster_{}", unique_id());
 
-        let acl = MQTTAcl {
-            resource_type: MQTTAclResourceType::User,
+        let acl = MqttAcl {
+            resource_type: MqttAclResourceType::User,
             resource_name: "loboxu".to_string(),
             topic: "tp-1".to_string(),
             ip: "*".to_string(),
-            action: MQTTAclAction::All,
-            permission: MQTTAclPermission::Deny,
+            action: MqttAclAction::All,
+            permission: MqttAclPermission::Deny,
         };
 
         let request = CreateAclRequest {
@@ -63,7 +63,7 @@ mod tests {
             Ok(data) => {
                 let mut flag = false;
                 for raw in data.acls {
-                    let tmp = serde_json::from_slice::<MQTTAcl>(raw.as_slice()).unwrap();
+                    let tmp = serde_json::from_slice::<MqttAcl>(raw.as_slice()).unwrap();
                     if tmp.resource_type == acl.resource_type
                         && tmp.resource_name == acl.resource_name
                         && tmp.topic == acl.topic
@@ -102,7 +102,7 @@ mod tests {
             Ok(data) => {
                 let mut flag = false;
                 for raw in data.blacklists {
-                    let tmp = serde_json::from_slice::<MQTTAcl>(raw.as_slice())
+                    let tmp = serde_json::from_slice::<MqttAcl>(raw.as_slice())
                         .unwrap_or_else(|e| panic!("{e} {:02x?}", raw.as_slice()));
                     if tmp.resource_type == acl.resource_type
                         && tmp.resource_name == acl.resource_name

--- a/src/clients/tests/mqtt/mqtt_blacklist_test.rs
+++ b/src/clients/tests/mqtt/mqtt_blacklist_test.rs
@@ -19,7 +19,7 @@ mod tests {
     use clients::placement::mqtt::call::{create_blacklist, delete_blacklist, list_blacklist};
     use clients::poll::ClientPool;
     use common_base::tools::now_second;
-    use metadata_struct::acl::mqtt_blacklist::{MQTTAclBlackList, MQTTAclBlackListType};
+    use metadata_struct::acl::mqtt_blacklist::{MqttAclBlackList, MqttAclBlackListType};
     use protocol::placement_center::generate::mqtt::{
         CreateBlacklistRequest, DeleteBlacklistRequest, ListBlacklistRequest,
     };
@@ -32,8 +32,8 @@ mod tests {
         let addrs = vec![get_placement_addr()];
         let cluster_name: String = "test_cluster".to_string();
 
-        let blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::User,
+        let blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::User,
             resource_name: "loboxu".to_string(),
             end_time: now_second() + 100,
             desc: "loboxu test".to_string(),
@@ -59,7 +59,7 @@ mod tests {
             Ok(data) => {
                 let mut flag = false;
                 for raw in data.blacklists {
-                    let tmp = serde_json::from_slice::<MQTTAclBlackList>(raw.as_slice()).unwrap();
+                    let tmp = serde_json::from_slice::<MqttAclBlackList>(raw.as_slice()).unwrap();
                     if tmp.blacklist_type == blacklist.blacklist_type
                         && tmp.resource_name == blacklist.resource_name
                         && tmp.end_time == blacklist.end_time
@@ -97,7 +97,7 @@ mod tests {
             Ok(data) => {
                 let mut flag = false;
                 for raw in data.blacklists {
-                    let tmp = serde_json::from_slice::<MQTTAclBlackList>(raw.as_slice()).unwrap();
+                    let tmp = serde_json::from_slice::<MqttAclBlackList>(raw.as_slice()).unwrap();
                     if tmp.blacklist_type == blacklist.blacklist_type
                         && tmp.resource_name == blacklist.resource_name
                         && tmp.end_time == blacklist.end_time

--- a/src/clients/tests/mqtt/mqtt_session_test.rs
+++ b/src/clients/tests/mqtt/mqtt_session_test.rs
@@ -21,7 +21,7 @@ mod tests {
         placement_update_session,
     };
     use clients::poll::ClientPool;
-    use metadata_struct::mqtt::session::MQTTSession;
+    use metadata_struct::mqtt::session::MqttSession;
     use protocol::placement_center::generate::mqtt::{
         CreateSessionRequest, DeleteSessionRequest, ListSessionRequest, UpdateSessionRequest,
     };
@@ -40,7 +40,7 @@ mod tests {
         let session_expiry: u64 = 10000;
         let last_will_delay_interval: u64 = 10000;
 
-        let mut mqtt_session: MQTTSession = MQTTSession::new(
+        let mut mqtt_session: MqttSession = MqttSession::new(
             &client_id,
             session_expiry,
             true,
@@ -52,7 +52,7 @@ mod tests {
         let request = CreateSessionRequest {
             cluster_name: cluster_name.clone(),
             client_id: client_id.clone(),
-            session: MQTTSession::encode(&mqtt_session),
+            session: MqttSession::encode(&mqtt_session),
         };
 
         match placement_create_session(client_poll.clone(), addrs.clone(), request).await {
@@ -72,7 +72,7 @@ mod tests {
             Ok(data) => {
                 let mut flag: bool = false;
                 for raw in data.sessions {
-                    let session = serde_json::from_slice::<MQTTSession>(raw.as_slice()).unwrap();
+                    let session = serde_json::from_slice::<MqttSession>(raw.as_slice()).unwrap();
                     if mqtt_session == session {
                         flag = true;
                     }
@@ -115,7 +115,7 @@ mod tests {
             Ok(data) => {
                 let mut flag: bool = false;
                 for raw in data.sessions {
-                    let session = serde_json::from_slice::<MQTTSession>(raw.as_slice()).unwrap();
+                    let session = serde_json::from_slice::<MqttSession>(raw.as_slice()).unwrap();
                     if mqtt_session == session {
                         flag = true;
                     }
@@ -150,7 +150,7 @@ mod tests {
             Ok(data) => {
                 let mut flag: bool = false;
                 for raw in data.sessions {
-                    let session = serde_json::from_slice::<MQTTSession>(raw.as_slice()).unwrap();
+                    let session = serde_json::from_slice::<MqttSession>(raw.as_slice()).unwrap();
                     if mqtt_session == session {
                         flag = true;
                     }

--- a/src/clients/tests/mqtt/mqtt_topic_test.rs
+++ b/src/clients/tests/mqtt/mqtt_topic_test.rs
@@ -22,8 +22,8 @@ mod tests {
         placement_set_topic_retain_message,
     };
     use clients::poll::ClientPool;
-    use metadata_struct::mqtt::message::MQTTMessage;
-    use metadata_struct::mqtt::topic::MQTTTopic;
+    use metadata_struct::mqtt::message::MqttMessage;
+    use metadata_struct::mqtt::topic::MqttTopic;
     use protocol::mqtt::common::{qos, Publish};
     use protocol::placement_center::generate::mqtt::{
         CreateTopicRequest, DeleteTopicRequest, ListTopicRequest, SetTopicRetainMessageRequest,
@@ -42,7 +42,7 @@ mod tests {
         let payload: String = "test_message".to_string();
         let retain_message_expired_at: u64 = 10000;
 
-        let mut mqtt_topic: MQTTTopic = MQTTTopic {
+        let mut mqtt_topic: MqttTopic = MqttTopic {
             topic_id: topic_id.clone(),
             topic_name: topic_name.clone(),
             retain_message: None,
@@ -71,7 +71,7 @@ mod tests {
                 assert!(!data.topics.is_empty());
                 let mut flag: bool = false;
                 for raw in data.topics {
-                    let topic = serde_json::from_slice::<MQTTTopic>(raw.as_slice()).unwrap();
+                    let topic = serde_json::from_slice::<MqttTopic>(raw.as_slice()).unwrap();
                     if topic == mqtt_topic {
                         flag = true;
                     }
@@ -92,8 +92,8 @@ mod tests {
             topic: Bytes::from(topic_name.clone()),
             payload: Bytes::from(payload.clone()),
         };
-        let retain_message = MQTTMessage::build_message(&client_id, &publish, &None, 600);
-        mqtt_topic = MQTTTopic {
+        let retain_message = MqttMessage::build_message(&client_id, &publish, &None, 600);
+        mqtt_topic = MqttTopic {
             topic_id: topic_id.clone(),
             topic_name: topic_name.clone(),
             retain_message: Some(retain_message.encode()),
@@ -124,7 +124,7 @@ mod tests {
                 assert!(!data.topics.is_empty());
                 let mut flag: bool = false;
                 for raw in data.topics {
-                    let topic = serde_json::from_slice::<MQTTTopic>(raw.as_slice()).unwrap();
+                    let topic = serde_json::from_slice::<MqttTopic>(raw.as_slice()).unwrap();
                     if topic == mqtt_topic {
                         flag = true;
                     }
@@ -158,7 +158,7 @@ mod tests {
                 assert!(data.topics.is_empty());
                 let mut flag: bool = false;
                 for raw in data.topics {
-                    let topic = serde_json::from_slice::<MQTTTopic>(raw.as_slice()).unwrap();
+                    let topic = serde_json::from_slice::<MqttTopic>(raw.as_slice()).unwrap();
                     if topic == mqtt_topic {
                         flag = true;
                     }

--- a/src/clients/tests/mqtt/mqtt_user_test.rs
+++ b/src/clients/tests/mqtt/mqtt_user_test.rs
@@ -20,7 +20,7 @@ mod tests {
         placement_create_user, placement_delete_user, placement_list_user,
     };
     use clients::poll::ClientPool;
-    use metadata_struct::mqtt::user::MQTTUser;
+    use metadata_struct::mqtt::user::MqttUser;
     use protocol::placement_center::generate::mqtt::{
         CreateUserRequest, DeleteUserRequest, ListUserRequest,
     };
@@ -35,7 +35,7 @@ mod tests {
         let password: String = "123456".to_string();
         let cluster_name: String = "test_cluster".to_string();
 
-        let mqtt_user: MQTTUser = MQTTUser {
+        let mqtt_user: MqttUser = MqttUser {
             username: user_name.clone(),
             password: password.clone(),
             is_superuser: false,
@@ -63,7 +63,7 @@ mod tests {
             Ok(data) => {
                 let mut flag: bool = false;
                 for raw in data.users {
-                    let user = serde_json::from_slice::<MQTTUser>(raw.as_slice()).unwrap();
+                    let user = serde_json::from_slice::<MqttUser>(raw.as_slice()).unwrap();
                     if mqtt_user == user {
                         flag = true;
                     }
@@ -98,7 +98,7 @@ mod tests {
             Ok(data) => {
                 let mut flag: bool = false;
                 for raw in data.users {
-                    let user = serde_json::from_slice::<MQTTUser>(raw.as_slice()).unwrap();
+                    let user = serde_json::from_slice::<MqttUser>(raw.as_slice()).unwrap();
                     if mqtt_user == user {
                         flag = true;
                     }

--- a/src/common/metadata-struct/src/acl/mqtt_acl.rs
+++ b/src/common/metadata-struct/src/acl/mqtt_acl.rs
@@ -18,42 +18,42 @@ use common_base::error::common::CommonError;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
-pub struct MQTTAcl {
-    pub resource_type: MQTTAclResourceType,
+pub struct MqttAcl {
+    pub resource_type: MqttAclResourceType,
     pub resource_name: String,
     pub topic: String,
     pub ip: String,
-    pub action: MQTTAclAction,
-    pub permission: MQTTAclPermission,
+    pub action: MqttAclAction,
+    pub permission: MqttAclPermission,
 }
 
-impl MQTTAcl {
+impl MqttAcl {
     pub fn encode(&self) -> Result<Vec<u8>, CommonError> {
         Ok(serde_json::to_vec(&self)?)
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
-pub enum MQTTAclResourceType {
+pub enum MqttAclResourceType {
     ClientId,
     User,
 }
 
-impl fmt::Display for MQTTAclResourceType {
+impl fmt::Display for MqttAclResourceType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "{}",
             match self {
-                MQTTAclResourceType::ClientId => "ClientId",
-                MQTTAclResourceType::User => "User",
+                MqttAclResourceType::ClientId => "ClientId",
+                MqttAclResourceType::User => "User",
             }
         )
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
-pub enum MQTTAclAction {
+pub enum MqttAclAction {
     All,
     Subscribe,
     Publish,
@@ -63,7 +63,7 @@ pub enum MQTTAclAction {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
-pub enum MQTTAclPermission {
+pub enum MqttAclPermission {
     Allow,
     Deny,
 }

--- a/src/common/metadata-struct/src/acl/mqtt_blacklist.rs
+++ b/src/common/metadata-struct/src/acl/mqtt_blacklist.rs
@@ -18,21 +18,21 @@ use common_base::error::common::CommonError;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
-pub struct MQTTAclBlackList {
-    pub blacklist_type: MQTTAclBlackListType,
+pub struct MqttAclBlackList {
+    pub blacklist_type: MqttAclBlackListType,
     pub resource_name: String,
     pub end_time: u64,
     pub desc: String,
 }
 
-impl MQTTAclBlackList {
+impl MqttAclBlackList {
     pub fn encode(&self) -> Result<Vec<u8>, CommonError> {
         Ok(serde_json::to_vec(&self)?)
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
-pub enum MQTTAclBlackListType {
+pub enum MqttAclBlackListType {
     ClientId,
     User,
     Ip,
@@ -41,18 +41,18 @@ pub enum MQTTAclBlackListType {
     IPCIDR,
 }
 
-impl fmt::Display for MQTTAclBlackListType {
+impl fmt::Display for MqttAclBlackListType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
             "{}",
             match self {
-                MQTTAclBlackListType::ClientId => "ClientId",
-                MQTTAclBlackListType::User => "User",
-                MQTTAclBlackListType::Ip => "Ip",
-                MQTTAclBlackListType::ClientIdMatch => "ClientIdMatch",
-                MQTTAclBlackListType::UserMatch => "UserMatch",
-                MQTTAclBlackListType::IPCIDR => "IPCIDR",
+                MqttAclBlackListType::ClientId => "ClientId",
+                MqttAclBlackListType::User => "User",
+                MqttAclBlackListType::Ip => "Ip",
+                MqttAclBlackListType::ClientIdMatch => "ClientIdMatch",
+                MqttAclBlackListType::UserMatch => "UserMatch",
+                MqttAclBlackListType::IPCIDR => "IPCIDR",
             }
         )
     }

--- a/src/common/metadata-struct/src/mqtt/cluster.rs
+++ b/src/common/metadata-struct/src/mqtt/cluster.rs
@@ -17,17 +17,17 @@ use serde::{Deserialize, Serialize};
 
 // Dynamic configuration of MQTT cluster latitude
 #[derive(Serialize, Deserialize, Default, Clone)]
-pub struct MQTTClusterDynamicConfig {
-    pub protocol: MQTTClusterDynamicConfigProtocol,
-    pub feature: MQTTClusterDynamicConfigFeature,
-    pub security: MQTTClusterDynamicConfigSecurity,
-    pub network: MQTTClusterDynamicConfigNetwork,
-    pub slow: MQTTClusterDynamicSlowSub,
+pub struct MqttClusterDynamicConfig {
+    pub protocol: MqttClusterDynamicConfigProtocol,
+    pub feature: MqttClusterDynamicConfigFeature,
+    pub security: MqttClusterDynamicConfigSecurity,
+    pub network: MqttClusterDynamicConfigNetwork,
+    pub slow: MqttClusterDynamicSlowSub,
 }
 
 // MQTT cluster protocol related dynamic configuration
 #[derive(Serialize, Deserialize, Default, Clone)]
-pub struct MQTTClusterDynamicConfigProtocol {
+pub struct MqttClusterDynamicConfigProtocol {
     pub session_expiry_interval: u32,
     pub topic_alias_max: u16,
     pub max_qos: QoS,
@@ -41,14 +41,14 @@ pub struct MQTTClusterDynamicConfigProtocol {
 
 // MQTT cluster security related dynamic configuration
 #[derive(Serialize, Deserialize, Default, Clone)]
-pub struct MQTTClusterDynamicConfigSecurity {
+pub struct MqttClusterDynamicConfigSecurity {
     pub is_self_protection_status: bool,
     pub secret_free_login: bool,
 }
 
 // MQTT cluster network related dynamic configuration
 #[derive(Serialize, Deserialize, Default, Clone)]
-pub struct MQTTClusterDynamicConfigNetwork {
+pub struct MqttClusterDynamicConfigNetwork {
     pub tcp_max_connection_num: u64,
     pub tcps_max_connection_num: u64,
     pub websocket_max_connection_num: u64,
@@ -59,7 +59,7 @@ pub struct MQTTClusterDynamicConfigNetwork {
 
 // MQTT cluster Feature related dynamic configuration
 #[derive(Serialize, Deserialize, Default, Clone)]
-pub struct MQTTClusterDynamicConfigFeature {
+pub struct MqttClusterDynamicConfigFeature {
     pub retain_available: AvailableFlag,
     pub wildcard_subscription_available: AvailableFlag,
     pub subscription_identifiers_available: AvailableFlag,
@@ -67,17 +67,17 @@ pub struct MQTTClusterDynamicConfigFeature {
 }
 
 #[derive(Serialize, Deserialize, Default, Clone)]
-pub struct MQTTClusterDynamicSlowSub {
+pub struct MqttClusterDynamicSlowSub {
     pub enable: bool,
     pub whole_ms: u128,
     pub internal_ms: u32,
     pub response_ms: u32,
 }
 
-impl MQTTClusterDynamicConfig {
+impl MqttClusterDynamicConfig {
     pub fn new() -> Self {
-        MQTTClusterDynamicConfig {
-            protocol: MQTTClusterDynamicConfigProtocol {
+        MqttClusterDynamicConfig {
+            protocol: MqttClusterDynamicConfigProtocol {
                 session_expiry_interval: 1800,
                 topic_alias_max: 65535,
                 max_qos: QoS::ExactlyOnce,
@@ -88,17 +88,17 @@ impl MQTTClusterDynamicConfig {
                 client_pkid_persistent: false,
                 max_message_expiry_interval: 3600,
             },
-            feature: MQTTClusterDynamicConfigFeature {
+            feature: MqttClusterDynamicConfigFeature {
                 retain_available: AvailableFlag::Enable,
                 wildcard_subscription_available: AvailableFlag::Enable,
                 subscription_identifiers_available: AvailableFlag::Enable,
                 shared_subscription_available: AvailableFlag::Enable,
             },
-            security: MQTTClusterDynamicConfigSecurity {
+            security: MqttClusterDynamicConfigSecurity {
                 secret_free_login: false,
                 is_self_protection_status: false,
             },
-            network: MQTTClusterDynamicConfigNetwork {
+            network: MqttClusterDynamicConfigNetwork {
                 tcp_max_connection_num: 1000,
                 tcps_max_connection_num: 1000,
                 websocket_max_connection_num: 1000,
@@ -106,7 +106,7 @@ impl MQTTClusterDynamicConfig {
                 response_max_try_mut_times: 128,
                 response_try_mut_sleep_time_ms: 100,
             },
-            slow: MQTTClusterDynamicSlowSub {
+            slow: MqttClusterDynamicSlowSub {
                 enable: false,
                 whole_ms: 0,
                 internal_ms: 0,

--- a/src/common/metadata-struct/src/mqtt/message.rs
+++ b/src/common/metadata-struct/src/mqtt/message.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use crate::adapter::record::Record;
 
 #[derive(Clone, Serialize, Deserialize, Default, Debug)]
-pub struct MQTTMessage {
+pub struct MqttMessage {
     pub client_id: String,
     pub dup: bool,
     pub qos: QoS,
@@ -40,9 +40,9 @@ pub struct MQTTMessage {
     pub create_time: u64,
 }
 
-impl MQTTMessage {
+impl MqttMessage {
     pub fn build_system_topic_message(topic_name: String, payload: String) -> Option<Record> {
-        let mut message = MQTTMessage::default();
+        let mut message = MqttMessage::default();
         message.client_id = "-".to_string();
         message.dup = false;
         message.qos = QoS::AtMostOnce;
@@ -67,8 +67,8 @@ impl MQTTMessage {
         publish: &Publish,
         publish_properties: &Option<PublishProperties>,
         expiry_interval: u64,
-    ) -> MQTTMessage {
-        let mut message = MQTTMessage::default();
+    ) -> MqttMessage {
+        let mut message = MqttMessage::default();
         message.client_id = client_id.clone();
         message.dup = publish.dup;
         message.qos = publish.qos;
@@ -104,7 +104,7 @@ impl MQTTMessage {
         expiry_interval: u64,
     ) -> Option<Record> {
         let msg =
-            MQTTMessage::build_message(client_id, publish, publish_properties, expiry_interval);
+            MqttMessage::build_message(client_id, publish, publish_properties, expiry_interval);
         match serde_json::to_vec(&msg) {
             Ok(data) => Some(Record::build_b(data)),
 
@@ -115,8 +115,8 @@ impl MQTTMessage {
         }
     }
 
-    pub fn decode_record(record: Record) -> Result<MQTTMessage, CommonError> {
-        let data: MQTTMessage = match serde_json::from_slice(record.data.as_slice()) {
+    pub fn decode_record(record: Record) -> Result<MqttMessage, CommonError> {
+        let data: MqttMessage = match serde_json::from_slice(record.data.as_slice()) {
             Ok(da) => da,
             Err(e) => {
                 return Err(CommonError::CommmonError(e.to_string()));

--- a/src/common/metadata-struct/src/mqtt/node_extend.rs
+++ b/src/common/metadata-struct/src/mqtt/node_extend.rs
@@ -15,7 +15,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Serialize, Deserialize)]
-pub struct MQTTNodeExtend {
+pub struct MqttNodeExtend {
     pub grpc_addr: String,
     pub http_addr: String,
     pub mqtt_addr: String,

--- a/src/common/metadata-struct/src/mqtt/session.rs
+++ b/src/common/metadata-struct/src/mqtt/session.rs
@@ -16,7 +16,7 @@ use common_base::tools::now_second;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
-pub struct MQTTSession {
+pub struct MqttSession {
     pub client_id: String,
     pub session_expiry: u64,
     pub is_contain_last_will: bool,
@@ -29,14 +29,14 @@ pub struct MQTTSession {
     pub distinct_time: Option<u64>,
 }
 
-impl MQTTSession {
+impl MqttSession {
     pub fn new(
         client_id: &String,
         session_expiry: u64,
         is_contain_last_will: bool,
         last_will_delay_interval: Option<u64>,
-    ) -> MQTTSession {
-        let mut session = MQTTSession::default();
+    ) -> MqttSession {
+        let mut session = MqttSession::default();
         session.client_id = client_id.clone();
         session.session_expiry = session_expiry;
         session.is_contain_last_will = is_contain_last_will;

--- a/src/common/metadata-struct/src/mqtt/topic.rs
+++ b/src/common/metadata-struct/src/mqtt/topic.rs
@@ -15,16 +15,16 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
-pub struct MQTTTopic {
+pub struct MqttTopic {
     pub topic_id: String,
     pub topic_name: String,
     pub retain_message: Option<Vec<u8>>,
     pub retain_message_expired_at: Option<u64>,
 }
 
-impl MQTTTopic {
+impl MqttTopic {
     pub fn new(topic_id: String, topic_name: String) -> Self {
-        MQTTTopic {
+        MqttTopic {
             topic_id,
             topic_name,
             retain_message: None,

--- a/src/common/metadata-struct/src/mqtt/user.rs
+++ b/src/common/metadata-struct/src/mqtt/user.rs
@@ -15,13 +15,13 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
-pub struct MQTTUser {
+pub struct MqttUser {
     pub username: String,
     pub password: String,
     pub is_superuser: bool,
 }
 
-impl MQTTUser {
+impl MqttUser {
     pub fn encode(&self) -> Vec<u8> {
         serde_json::to_vec(&self).unwrap()
     }

--- a/src/mqtt-broker/src/handler/connection.rs
+++ b/src/mqtt-broker/src/handler/connection.rs
@@ -20,7 +20,7 @@ use clients::poll::ClientPool;
 use common_base::error::common::CommonError;
 use common_base::tools::{now_second, unique_id};
 use dashmap::DashMap;
-use metadata_struct::mqtt::cluster::MQTTClusterDynamicConfig;
+use metadata_struct::mqtt::cluster::MqttClusterDynamicConfig;
 use protocol::mqtt::common::{Connect, ConnectProperties};
 
 use super::cache::CacheManager;
@@ -129,7 +129,7 @@ impl Connection {
 pub fn build_connection(
     connect_id: u64,
     client_id: &String,
-    cluster: &MQTTClusterDynamicConfig,
+    cluster: &MqttClusterDynamicConfig,
     connect: &Connect,
     connect_properties: &Option<ConnectProperties>,
     addr: &SocketAddr,
@@ -241,7 +241,7 @@ pub async fn disconnect_connection(
 
 #[cfg(test)]
 mod test {
-    use metadata_struct::mqtt::cluster::MQTTClusterDynamicConfig;
+    use metadata_struct::mqtt::cluster::MqttClusterDynamicConfig;
     use protocol::mqtt::common::{Connect, ConnectProperties};
 
     use super::{
@@ -253,7 +253,7 @@ mod test {
     pub async fn build_connection_test() {
         let connect_id = 1;
         let client_id = "client_id-***".to_string();
-        let cluster = MQTTClusterDynamicConfig::new();
+        let cluster = MqttClusterDynamicConfig::new();
         let connect = Connect {
             keep_alive: 10,
             client_id: client_id.clone(),

--- a/src/mqtt-broker/src/handler/keep_alive.rs
+++ b/src/mqtt-broker/src/handler/keep_alive.rs
@@ -20,8 +20,8 @@ use bytes::BytesMut;
 use clients::poll::ClientPool;
 use common_base::tools::now_second;
 use log::{error, info, warn};
-use metadata_struct::mqtt::cluster::MQTTClusterDynamicConfig;
-use protocol::mqtt::codec::{MQTTPacketWrapper, MqttCodec};
+use metadata_struct::mqtt::cluster::MqttClusterDynamicConfig;
+use protocol::mqtt::codec::{MqttPacketWrapper, MqttCodec};
 use protocol::mqtt::common::{DisconnectReasonCode, MQTTProtocol};
 use serde::{Deserialize, Serialize};
 use tokio::select;
@@ -92,7 +92,7 @@ impl ClientKeepAlive {
                         Some(DisconnectReasonCode::KeepAliveTimeout),
                     );
 
-                    let wrap = MQTTPacketWrapper {
+                    let wrap = MqttPacketWrapper {
                         protocol_version: protocol.clone().into(),
                         packet: resp,
                     };
@@ -219,7 +219,7 @@ pub fn keep_live_time(keep_alive: u16) -> u16 {
     return new_keep_alive as u16;
 }
 
-pub fn client_keep_live_time(cluster: &MQTTClusterDynamicConfig, mut keep_alive: u16) -> u16 {
+pub fn client_keep_live_time(cluster: &MqttClusterDynamicConfig, mut keep_alive: u16) -> u16 {
     if keep_alive <= 0 {
         keep_alive = cluster.protocol.default_server_keep_alive;
     }
@@ -244,7 +244,7 @@ mod test {
     use clients::poll::ClientPool;
     use common_base::config::broker_mqtt::BrokerMQTTConfig;
     use common_base::tools::{now_second, unique_id};
-    use metadata_struct::mqtt::session::MQTTSession;
+    use metadata_struct::mqtt::session::MqttSession;
     use tokio::sync::broadcast;
     use tokio::time::sleep;
 
@@ -294,7 +294,7 @@ mod test {
         let client_id = unique_id();
         let connect_id = 1;
 
-        let session = MQTTSession::new(&client_id, 60, false, None);
+        let session = MqttSession::new(&client_id, 60, false, None);
         cache_manager.add_session(client_id.clone(), session);
 
         let keep_alive = 2;

--- a/src/mqtt-broker/src/handler/lastwill.rs
+++ b/src/mqtt-broker/src/handler/lastwill.rs
@@ -18,7 +18,7 @@ use bytes::Bytes;
 use clients::poll::ClientPool;
 use common_base::error::common::CommonError;
 use metadata_struct::mqtt::lastwill::LastWillData;
-use metadata_struct::mqtt::message::MQTTMessage;
+use metadata_struct::mqtt::message::MqttMessage;
 use protocol::mqtt::common::{LastWill, LastWillProperties, Publish, PublishProperties};
 use storage_adapter::storage::StorageAdapter;
 
@@ -78,7 +78,7 @@ where
 
             let message_expire = build_message_expire(cache_manager, &publish_properties);
             if let Some(record) =
-                MQTTMessage::build_record(client_id, &publish, &publish_properties, message_expire)
+                MqttMessage::build_record(client_id, &publish, &publish_properties, message_expire)
             {
                 match message_storage
                     .append_topic_message(topic.topic_id.clone(), vec![record])

--- a/src/mqtt-broker/src/handler/message.rs
+++ b/src/mqtt-broker/src/handler/message.rs
@@ -15,12 +15,12 @@
 use std::sync::Arc;
 
 use common_base::tools::now_second;
-use metadata_struct::mqtt::message::MQTTMessage;
+use metadata_struct::mqtt::message::MqttMessage;
 use protocol::mqtt::common::PublishProperties;
 
 use super::cache::CacheManager;
 
-pub fn is_message_expire(message: &MQTTMessage) -> bool {
+pub fn is_message_expire(message: &MqttMessage) -> bool {
     return message.expiry_interval < now_second();
 }
 
@@ -46,7 +46,7 @@ mod tests {
 
     use clients::poll::ClientPool;
     use common_base::tools::now_second;
-    use metadata_struct::mqtt::cluster::MQTTClusterDynamicConfig;
+    use metadata_struct::mqtt::cluster::MqttClusterDynamicConfig;
     use protocol::mqtt::common::PublishProperties;
 
     use crate::handler::cache::CacheManager;
@@ -57,7 +57,7 @@ mod tests {
         let client_poll = Arc::new(ClientPool::new(1));
         let cluster_name = "test".to_string();
         let cache_manager = Arc::new(CacheManager::new(client_poll, cluster_name));
-        let mut cluster = MQTTClusterDynamicConfig::default();
+        let mut cluster = MqttClusterDynamicConfig::default();
         cluster.protocol.max_message_expiry_interval = 10;
         cache_manager.set_cluster_info(cluster);
 

--- a/src/mqtt-broker/src/handler/mqtt.rs
+++ b/src/mqtt-broker/src/handler/mqtt.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use clients::poll::ClientPool;
 use common_base::tools::now_second;
 use log::{error, warn};
-use metadata_struct::mqtt::message::MQTTMessage;
+use metadata_struct::mqtt::message::MqttMessage;
 use protocol::mqtt::common::{
     Connect, ConnectProperties, ConnectReturnCode, Disconnect, DisconnectProperties,
     DisconnectReasonCode, LastWill, LastWillProperties, Login, MQTTPacket, MQTTProtocol, PingReq,
@@ -108,7 +108,7 @@ where
         login: &Option<Login>,
         addr: SocketAddr,
     ) -> MQTTPacket {
-        let cluster: metadata_struct::mqtt::cluster::MQTTClusterDynamicConfig =
+        let cluster: metadata_struct::mqtt::cluster::MqttClusterDynamicConfig =
             self.cache_manager.get_cluster_info();
 
         if let Some(res) = connect_validator(
@@ -419,7 +419,7 @@ where
 
         let message_expire = build_message_expire(&self.cache_manager, &publish_properties);
         let offset = if let Some(record) =
-            MQTTMessage::build_record(&client_id, &publish, &publish_properties, message_expire)
+            MqttMessage::build_record(&client_id, &publish, &publish_properties, message_expire)
         {
             match message_storage
                 .append_topic_message(topic.topic_id.clone(), vec![record])

--- a/src/mqtt-broker/src/handler/response.rs
+++ b/src/mqtt-broker/src/handler/response.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use log::{error, warn};
-use metadata_struct::mqtt::cluster::MQTTClusterDynamicConfig;
+use metadata_struct::mqtt::cluster::MqttClusterDynamicConfig;
 use protocol::mqtt::common::{
     ConnAck, ConnAckProperties, ConnectProperties, ConnectReturnCode, Disconnect,
     DisconnectProperties, DisconnectReasonCode, MQTTPacket, MQTTProtocol, PingResp, PubAck,
@@ -28,7 +28,7 @@ use super::validator::is_request_problem_info;
 
 pub fn response_packet_mqtt_connect_success(
     protocol: &MQTTProtocol,
-    cluster: &MQTTClusterDynamicConfig,
+    cluster: &MqttClusterDynamicConfig,
     client_id: String,
     auto_client_id: bool,
     session_expiry_interval: u32,

--- a/src/mqtt-broker/src/handler/retain.rs
+++ b/src/mqtt-broker/src/handler/retain.rs
@@ -19,7 +19,7 @@ use clients::poll::ClientPool;
 use common_base::error::common::CommonError;
 use common_base::tools::now_second;
 use log::error;
-use metadata_struct::mqtt::message::MQTTMessage;
+use metadata_struct::mqtt::message::MqttMessage;
 use protocol::mqtt::common::{Publish, PublishProperties, QoS, RetainForwardRule};
 use tokio::sync::broadcast::{self};
 
@@ -64,7 +64,7 @@ pub async fn save_topic_retain_message(
         record_retain_recv_metrics(publish.qos);
         let message_expire = build_message_expire(cache_manager, publish_properties);
         let retain_message =
-            MQTTMessage::build_message(client_id, publish, publish_properties, message_expire);
+            MqttMessage::build_message(client_id, publish, publish_properties, message_expire);
         match topic_storage
             .set_retain_message(topic_name, &retain_message, message_expire)
             .await

--- a/src/mqtt-broker/src/handler/session.rs
+++ b/src/mqtt-broker/src/handler/session.rs
@@ -18,7 +18,7 @@ use clients::poll::ClientPool;
 use common_base::config::broker_mqtt::broker_mqtt_conf;
 use common_base::error::common::CommonError;
 use common_base::tools::now_second;
-use metadata_struct::mqtt::session::MQTTSession;
+use metadata_struct::mqtt::session::MqttSession;
 use protocol::mqtt::common::{Connect, ConnectProperties, LastWill, LastWillProperties};
 
 use super::cache::CacheManager;
@@ -34,7 +34,7 @@ pub async fn build_session(
     last_will_properties: &Option<LastWillProperties>,
     client_poll: &Arc<ClientPool>,
     cache_manager: &Arc<CacheManager>,
-) -> Result<(MQTTSession, bool), CommonError> {
+) -> Result<(MqttSession, bool), CommonError> {
     let session_expiry = session_expiry_interval(cache_manager, connect_properties);
     let is_contain_last_will = !last_will.is_none();
     let last_will_delay_interval = last_will_delay_interval(&last_will_properties);
@@ -44,7 +44,7 @@ pub async fn build_session(
         match session_storage.get_session(client_id.clone()).await {
             Ok(Some(session)) => (session, false),
             Ok(None) => (
-                MQTTSession::new(
+                MqttSession::new(
                     &client_id,
                     session_expiry,
                     is_contain_last_will,
@@ -58,7 +58,7 @@ pub async fn build_session(
         }
     } else {
         (
-            MQTTSession::new(
+            MqttSession::new(
                 &client_id,
                 session_expiry,
                 is_contain_last_will,
@@ -77,7 +77,7 @@ pub async fn build_session(
 
 pub async fn save_session(
     connect_id: u64,
-    session: MQTTSession,
+    session: MqttSession,
     new_session: bool,
     client_id: &String,
     client_poll: &Arc<ClientPool>,
@@ -136,7 +136,7 @@ mod test {
 
     use clients::poll::ClientPool;
     use common_base::config::broker_mqtt::BrokerMQTTConfig;
-    use metadata_struct::mqtt::session::MQTTSession;
+    use metadata_struct::mqtt::session::MqttSession;
     use protocol::mqtt::common::ConnectProperties;
 
     use super::session_expiry_interval;
@@ -145,7 +145,7 @@ mod test {
     #[tokio::test]
     pub async fn build_session_test() {
         let client_id = "client_id_test-**".to_string();
-        let session = MQTTSession::new(&client_id, 10, false, None);
+        let session = MqttSession::new(&client_id, 10, false, None);
         assert_eq!(client_id, session.client_id);
         assert_eq!(10, session.session_expiry);
         assert!(!session.is_contain_last_will);

--- a/src/mqtt-broker/src/handler/topic.rs
+++ b/src/mqtt-broker/src/handler/topic.rs
@@ -19,7 +19,7 @@ use clients::poll::ClientPool;
 use common_base::error::common::CommonError;
 use common_base::error::mqtt_broker::MQTTBrokerError;
 use common_base::tools::unique_id;
-use metadata_struct::mqtt::topic::MQTTTopic;
+use metadata_struct::mqtt::topic::MqttTopic;
 use protocol::mqtt::common::{Publish, PublishProperties};
 use regex::Regex;
 use storage_adapter::storage::{ShardConfig, StorageAdapter};
@@ -111,7 +111,7 @@ pub async fn try_init_topic<S>(
     metadata_cache: &Arc<CacheManager>,
     message_storage_adapter: &Arc<S>,
     client_poll: &Arc<ClientPool>,
-) -> Result<MQTTTopic, CommonError>
+) -> Result<MqttTopic, CommonError>
 where
     S: StorageAdapter + Sync + Send + 'static + Clone,
 {
@@ -120,7 +120,7 @@ where
     } else {
         let topic_storage = TopicStorage::new(client_poll.clone());
         let topic_id = unique_id();
-        let topic = MQTTTopic::new(topic_id, topic_name.clone());
+        let topic = MqttTopic::new(topic_id, topic_name.clone());
         topic_storage.save_topic(topic.clone()).await?;
         metadata_cache.add_topic(&topic_name, &topic);
 

--- a/src/mqtt-broker/src/handler/validator.rs
+++ b/src/mqtt-broker/src/handler/validator.rs
@@ -20,8 +20,8 @@ use clients::poll::ClientPool;
 use common_base::error::mqtt_broker::MQTTBrokerError;
 use futures::SinkExt;
 use log::error;
-use metadata_struct::mqtt::cluster::MQTTClusterDynamicConfig;
-use protocol::mqtt::codec::{MQTTPacketWrapper, MqttCodec};
+use metadata_struct::mqtt::cluster::MqttClusterDynamicConfig;
+use protocol::mqtt::codec::{MqttPacketWrapper, MqttCodec};
 use protocol::mqtt::common::{
     Connect, ConnectProperties, ConnectReturnCode, DisconnectReasonCode, LastWill,
     LastWillProperties, Login, MQTTPacket, MQTTProtocol, PubAckReason, PubRecReason, Publish,
@@ -52,7 +52,7 @@ pub async fn tcp_establish_connection_check(
     write_frame_stream: &mut FramedWrite<tokio::io::WriteHalf<tokio::net::TcpStream>, MqttCodec>,
 ) -> bool {
     if connection_manager.tcp_connect_num_check() {
-        let packet_wrapper = MQTTPacketWrapper {
+        let packet_wrapper = MqttPacketWrapper {
             protocol_version: MQTTProtocol::MQTT5.into(),
             packet: response_packet_mqtt_distinct_by_reason(
                 &MQTTProtocol::MQTT5,
@@ -77,7 +77,7 @@ pub async fn tcp_establish_connection_check(
     }
 
     if is_connection_rate_exceeded() {
-        let packet_wrapper = MQTTPacketWrapper {
+        let packet_wrapper = MqttPacketWrapper {
             protocol_version: MQTTProtocol::MQTT5.into(),
             packet: response_packet_mqtt_distinct_by_reason(
                 &MQTTProtocol::MQTT5,
@@ -112,7 +112,7 @@ pub async fn tcp_tls_establish_connection_check(
     >,
 ) -> bool {
     if connection_manager.tcp_connect_num_check() {
-        let packet_wrapper = MQTTPacketWrapper {
+        let packet_wrapper = MqttPacketWrapper {
             protocol_version: MQTTProtocol::MQTT5.into(),
             packet: response_packet_mqtt_distinct_by_reason(
                 &MQTTProtocol::MQTT5,
@@ -137,7 +137,7 @@ pub async fn tcp_tls_establish_connection_check(
     }
 
     if is_connection_rate_exceeded() {
-        let packet_wrapper = MQTTPacketWrapper {
+        let packet_wrapper = MqttPacketWrapper {
             protocol_version: MQTTProtocol::MQTT5.into(),
             packet: response_packet_mqtt_distinct_by_reason(
                 &MQTTProtocol::MQTT5,
@@ -165,7 +165,7 @@ pub async fn tcp_tls_establish_connection_check(
 
 pub fn connect_validator(
     protocol: &MQTTProtocol,
-    cluster: &MQTTClusterDynamicConfig,
+    cluster: &MqttClusterDynamicConfig,
     connect: &Connect,
     connect_properties: &Option<ConnectProperties>,
     last_will: &Option<LastWill>,
@@ -612,7 +612,7 @@ pub fn is_request_problem_info(connect_properties: &Option<ConnectProperties>) -
 
 pub fn connection_max_packet_size(
     connect_properties: &Option<ConnectProperties>,
-    cluster: &MQTTClusterDynamicConfig,
+    cluster: &MqttClusterDynamicConfig,
 ) -> u32 {
     if let Some(properties) = connect_properties {
         if let Some(size) = properties.max_packet_size {

--- a/src/mqtt-broker/src/observability/metrics/packets.rs
+++ b/src/mqtt-broker/src/observability/metrics/packets.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use lazy_static::lazy_static;
 use prometheus::{register_int_gauge_vec, IntGaugeVec};
-use protocol::mqtt::codec::{calc_mqtt_packet_size, MQTTPacketWrapper};
+use protocol::mqtt::codec::{calc_mqtt_packet_size, MqttPacketWrapper};
 use protocol::mqtt::common::{MQTTPacket, QoS};
 
 use crate::handler::constant::{METRICS_KEY_NETWORK_TYPE, METRICS_KEY_QOS};
@@ -95,7 +95,7 @@ pub fn record_received_metrics(
     network_type: &NetworkConnectionType,
 ) {
     let payload_size = if let Some(protocol) = connection.protocol.clone() {
-        let wrapper = MQTTPacketWrapper {
+        let wrapper = MqttPacketWrapper {
             protocol_version: protocol.into(),
             packet: pkg.clone(),
         };
@@ -124,7 +124,7 @@ pub fn record_sent_metrics(resp: &ResponsePackage, connection_manager: &Arc<Conn
     let (payload_size, network_type) =
         if let Some(connection) = connection_manager.get_connect(resp.connection_id) {
             if let Some(protocol) = connection.protocol.clone() {
-                let wrapper = MQTTPacketWrapper {
+                let wrapper = MqttPacketWrapper {
                     protocol_version: protocol.into(),
                     packet: resp.packet.clone(),
                 };
@@ -160,7 +160,7 @@ pub fn record_retain_sent_metrics(qos: QoS) {
 
 #[cfg(test)]
 mod tests {
-    use protocol::mqtt::codec::{calc_mqtt_packet_size, MQTTPacketWrapper};
+    use protocol::mqtt::codec::{calc_mqtt_packet_size, MqttPacketWrapper};
     use protocol::mqtt::common::{MQTTPacket, UnsubAck};
 
     #[test]
@@ -171,7 +171,7 @@ mod tests {
         };
 
         let packet = MQTTPacket::UnsubAck(unsub_ack, None);
-        let packet_wrapper = MQTTPacketWrapper {
+        let packet_wrapper = MqttPacketWrapper {
             protocol_version: 4,
             packet,
         };

--- a/src/mqtt-broker/src/observability/system_topic/broker.rs
+++ b/src/mqtt-broker/src/observability/system_topic/broker.rs
@@ -19,7 +19,7 @@ use clients::poll::ClientPool;
 use common_base::tools::now_second;
 use log::error;
 use metadata_struct::adapter::record::Record;
-use metadata_struct::mqtt::message::MQTTMessage;
+use metadata_struct::mqtt::message::MqttMessage;
 use storage_adapter::storage::StorageAdapter;
 
 use super::{
@@ -76,7 +76,7 @@ async fn report_broker_version<S>(
         Err(_) => "-".to_string(),
     };
 
-    if let Some(record) = MQTTMessage::build_system_topic_message(topic_name.clone(), version) {
+    if let Some(record) = MqttMessage::build_system_topic_message(topic_name.clone(), version) {
         write_topic_data(
             message_storage_adapter,
             metadata_cache,
@@ -98,7 +98,7 @@ async fn report_broker_time<S>(
     let topic_name = replace_topic_name(SYSTEM_TOPIC_BROKERS_UPTIME.to_string());
     let start_long_time: u64 = now_second() - BROKER_START_TIME.clone();
     if let Some(record) =
-        MQTTMessage::build_system_topic_message(topic_name.clone(), start_long_time.to_string())
+        MqttMessage::build_system_topic_message(topic_name.clone(), start_long_time.to_string())
     {
         write_topic_data(
             message_storage_adapter,
@@ -112,7 +112,7 @@ async fn report_broker_time<S>(
 
     let topic_name = replace_topic_name(SYSTEM_TOPIC_BROKERS_DATETIME.to_string());
     if let Some(record) =
-        MQTTMessage::build_system_topic_message(topic_name.clone(), now_second().to_string())
+        MqttMessage::build_system_topic_message(topic_name.clone(), now_second().to_string())
     {
         write_topic_data(
             message_storage_adapter,
@@ -134,7 +134,7 @@ async fn report_broker_sysdescr<S>(
 {
     let topic_name = replace_topic_name(SYSTEM_TOPIC_BROKERS_SYSDESCR.to_string());
     let info = format!("{}", os_info::get());
-    if let Some(record) = MQTTMessage::build_system_topic_message(topic_name.clone(), info) {
+    if let Some(record) = MqttMessage::build_system_topic_message(topic_name.clone(), info) {
         write_topic_data(
             &message_storage_adapter,
             &metadata_cache,
@@ -167,7 +167,7 @@ async fn build_node_cluster(topic_name: &String, client_poll: &Arc<ClientPool>) 
         }
     };
 
-    return MQTTMessage::build_system_topic_message(topic_name.to_string(), content);
+    return MqttMessage::build_system_topic_message(topic_name.to_string(), content);
 }
 
 #[cfg(test)]

--- a/src/mqtt-broker/src/observability/system_topic/event.rs
+++ b/src/mqtt-broker/src/observability/system_topic/event.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 use clients::poll::ClientPool;
 use common_base::tools::{get_local_ip, now_mills};
 use log::error;
-use metadata_struct::mqtt::message::MQTTMessage;
-use metadata_struct::mqtt::session::MQTTSession;
+use metadata_struct::mqtt::message::MqttMessage;
+use metadata_struct::mqtt::session::MqttSession;
 use protocol::mqtt::common::{DisconnectReasonCode, MQTTProtocol, Subscribe, Unsubscribe};
 use serde::{Deserialize, Serialize};
 use storage_adapter::storage::StorageAdapter;
@@ -94,7 +94,7 @@ pub async fn st_report_connected_event<S>(
     message_storage_adapter: &Arc<S>,
     metadata_cache: &Arc<CacheManager>,
     client_poll: &Arc<ClientPool>,
-    session: &MQTTSession,
+    session: &MqttSession,
     connection: &Connection,
     connect_id: u64,
     connnection_manager: &Arc<ConnectionManager>,
@@ -124,7 +124,7 @@ pub async fn st_report_connected_event<S>(
                 );
 
                 if let Some(record) =
-                    MQTTMessage::build_system_topic_message(topic_name.clone(), data)
+                    MqttMessage::build_system_topic_message(topic_name.clone(), data)
                 {
                     write_topic_data(
                         message_storage_adapter,
@@ -148,7 +148,7 @@ pub async fn st_report_disconnected_event<S>(
     message_storage_adapter: &Arc<S>,
     metadata_cache: &Arc<CacheManager>,
     client_poll: &Arc<ClientPool>,
-    session: &MQTTSession,
+    session: &MqttSession,
     connection: &Connection,
     connect_id: u64,
     connnection_manager: &Arc<ConnectionManager>,
@@ -177,7 +177,7 @@ pub async fn st_report_disconnected_event<S>(
                 );
 
                 if let Some(record) =
-                    MQTTMessage::build_system_topic_message(topic_name.clone(), data)
+                    MqttMessage::build_system_topic_message(topic_name.clone(), data)
                 {
                     write_topic_data(
                         message_storage_adapter,
@@ -234,7 +234,7 @@ pub async fn st_report_subscribed_event<S>(
                     );
 
                     if let Some(record) =
-                        MQTTMessage::build_system_topic_message(topic_name.clone(), data)
+                        MqttMessage::build_system_topic_message(topic_name.clone(), data)
                     {
                         write_topic_data(
                             message_storage_adapter,
@@ -283,7 +283,7 @@ pub async fn st_report_unsubscribed_event<S>(
                     );
 
                     if let Some(record) =
-                        MQTTMessage::build_system_topic_message(topic_name.clone(), data)
+                        MqttMessage::build_system_topic_message(topic_name.clone(), data)
                     {
                         write_topic_data(
                             message_storage_adapter,

--- a/src/mqtt-broker/src/security/acl/metadata.rs
+++ b/src/mqtt-broker/src/security/acl/metadata.rs
@@ -13,22 +13,22 @@
 // limitations under the License.
 
 use dashmap::DashMap;
-use metadata_struct::acl::mqtt_acl::{MQTTAcl, MQTTAclResourceType};
-use metadata_struct::acl::mqtt_blacklist::{MQTTAclBlackList, MQTTAclBlackListType};
+use metadata_struct::acl::mqtt_acl::{MqttAcl, MqttAclResourceType};
+use metadata_struct::acl::mqtt_blacklist::{MqttAclBlackList, MqttAclBlackListType};
 
 #[derive(Clone)]
 pub struct AclMetadata {
     // blacklist
-    pub blacklist_user: DashMap<String, MQTTAclBlackList>,
-    pub blacklist_client_id: DashMap<String, MQTTAclBlackList>,
-    pub blacklist_ip: DashMap<String, MQTTAclBlackList>,
-    pub blacklist_user_match: DashMap<String, Vec<MQTTAclBlackList>>,
-    pub blacklist_client_id_match: DashMap<String, Vec<MQTTAclBlackList>>,
-    pub blacklist_ip_match: DashMap<String, Vec<MQTTAclBlackList>>,
+    pub blacklist_user: DashMap<String, MqttAclBlackList>,
+    pub blacklist_client_id: DashMap<String, MqttAclBlackList>,
+    pub blacklist_ip: DashMap<String, MqttAclBlackList>,
+    pub blacklist_user_match: DashMap<String, Vec<MqttAclBlackList>>,
+    pub blacklist_client_id_match: DashMap<String, Vec<MqttAclBlackList>>,
+    pub blacklist_ip_match: DashMap<String, Vec<MqttAclBlackList>>,
 
     // acl
-    pub acl_user: DashMap<String, Vec<MQTTAcl>>,
-    pub acl_client_id: DashMap<String, Vec<MQTTAcl>>,
+    pub acl_user: DashMap<String, Vec<MqttAcl>>,
+    pub acl_client_id: DashMap<String, Vec<MqttAcl>>,
 }
 
 impl AclMetadata {
@@ -46,9 +46,9 @@ impl AclMetadata {
         };
     }
 
-    pub fn parse_mqtt_acl(&self, acl: MQTTAcl) {
+    pub fn parse_mqtt_acl(&self, acl: MqttAcl) {
         match acl.resource_type {
-            MQTTAclResourceType::ClientId => {
+            MqttAclResourceType::ClientId => {
                 if let Some(mut raw) = self.acl_client_id.get_mut(&acl.resource_name) {
                     raw.push(acl);
                 } else {
@@ -56,7 +56,7 @@ impl AclMetadata {
                         .insert(acl.resource_name.clone(), vec![acl]);
                 }
             }
-            MQTTAclResourceType::User => {
+            MqttAclResourceType::User => {
                 if let Some(mut raw) = self.acl_user.get_mut(&acl.resource_name) {
                     raw.push(acl);
                 } else {
@@ -66,21 +66,21 @@ impl AclMetadata {
         }
     }
 
-    pub fn parse_mqtt_blacklist(&self, blacklist: MQTTAclBlackList) {
+    pub fn parse_mqtt_blacklist(&self, blacklist: MqttAclBlackList) {
         match blacklist.blacklist_type {
-            MQTTAclBlackListType::ClientId => {
+            MqttAclBlackListType::ClientId => {
                 self.blacklist_client_id
                     .insert(blacklist.resource_name.clone(), blacklist);
             }
-            MQTTAclBlackListType::User => {
+            MqttAclBlackListType::User => {
                 self.blacklist_user
                     .insert(blacklist.resource_name.clone(), blacklist);
             }
-            MQTTAclBlackListType::Ip => {
+            MqttAclBlackListType::Ip => {
                 self.blacklist_ip
                     .insert(blacklist.resource_name.clone(), blacklist);
             }
-            MQTTAclBlackListType::ClientIdMatch => {
+            MqttAclBlackListType::ClientIdMatch => {
                 let key = self.get_client_id_match_key();
                 if let Some(mut data) = self.blacklist_client_id_match.get_mut(&key) {
                     data.push(blacklist)
@@ -88,7 +88,7 @@ impl AclMetadata {
                     self.blacklist_client_id_match.insert(key, vec![blacklist]);
                 }
             }
-            MQTTAclBlackListType::UserMatch => {
+            MqttAclBlackListType::UserMatch => {
                 let key = self.get_user_match_key();
                 if let Some(mut data) = self.blacklist_user_match.get_mut(&key) {
                     data.push(blacklist)
@@ -96,7 +96,7 @@ impl AclMetadata {
                     self.blacklist_user_match.insert(key, vec![blacklist]);
                 }
             }
-            MQTTAclBlackListType::IPCIDR => {
+            MqttAclBlackListType::IPCIDR => {
                 let key = self.get_ip_cidr_key();
                 if let Some(mut data) = self.blacklist_ip_match.get_mut(&key) {
                     data.push(blacklist)
@@ -107,7 +107,7 @@ impl AclMetadata {
         }
     }
 
-    pub fn get_blacklist_user_match(&self) -> Option<Vec<MQTTAclBlackList>> {
+    pub fn get_blacklist_user_match(&self) -> Option<Vec<MqttAclBlackList>> {
         let key = self.get_user_match_key();
         if let Some(data) = self.blacklist_user_match.get(&key) {
             return Some(data.clone());
@@ -115,7 +115,7 @@ impl AclMetadata {
         return None;
     }
 
-    pub fn get_blacklist_client_id_match(&self) -> Option<Vec<MQTTAclBlackList>> {
+    pub fn get_blacklist_client_id_match(&self) -> Option<Vec<MqttAclBlackList>> {
         let key = self.get_client_id_match_key();
         if let Some(data) = self.blacklist_client_id_match.get(&key) {
             return Some(data.clone());
@@ -123,7 +123,7 @@ impl AclMetadata {
         return None;
     }
 
-    pub fn get_blacklist_ip_match(&self) -> Option<Vec<MQTTAclBlackList>> {
+    pub fn get_blacklist_ip_match(&self) -> Option<Vec<MqttAclBlackList>> {
         let key = self.get_ip_cidr_key();
         if let Some(data) = self.blacklist_ip_match.get(&key) {
             return Some(data.clone());
@@ -148,9 +148,9 @@ impl AclMetadata {
 mod test {
     use common_base::tools::now_second;
     use metadata_struct::acl::mqtt_acl::{
-        MQTTAcl, MQTTAclAction, MQTTAclPermission, MQTTAclResourceType,
+        MqttAcl, MqttAclAction, MqttAclPermission, MqttAclResourceType,
     };
-    use metadata_struct::acl::mqtt_blacklist::{MQTTAclBlackList, MQTTAclBlackListType};
+    use metadata_struct::acl::mqtt_blacklist::{MqttAclBlackList, MqttAclBlackListType};
 
     use crate::security::acl::metadata::AclMetadata;
 
@@ -158,13 +158,13 @@ mod test {
     pub async fn parse_mqtt_acl_test() {
         let acl_metadata = AclMetadata::new();
         // Test ClientId ACL
-        let client_id_acl = MQTTAcl {
-            resource_type: MQTTAclResourceType::ClientId,
+        let client_id_acl = MqttAcl {
+            resource_type: MqttAclResourceType::ClientId,
             resource_name: "test_client".to_string(),
             topic: "".to_string(),
             ip: "".to_string(),
-            action: MQTTAclAction::All,
-            permission: MQTTAclPermission::Allow,
+            action: MqttAclAction::All,
+            permission: MqttAclPermission::Allow,
         };
         acl_metadata.parse_mqtt_acl(client_id_acl.clone());
 
@@ -179,13 +179,13 @@ mod test {
         );
 
         // Test User ACL
-        let user_acl = MQTTAcl {
-            resource_type: MQTTAclResourceType::User,
+        let user_acl = MqttAcl {
+            resource_type: MqttAclResourceType::User,
             resource_name: "test_user".to_string(),
             topic: "".to_string(),
             ip: "".to_string(),
-            action: MQTTAclAction::All,
-            permission: MQTTAclPermission::Allow,
+            action: MqttAclAction::All,
+            permission: MqttAclPermission::Allow,
         };
         acl_metadata.parse_mqtt_acl(user_acl.clone());
 
@@ -212,8 +212,8 @@ mod test {
         let acl_metadata = AclMetadata::new();
 
         // Test ClientId blacklist
-        let client_id_blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::ClientId,
+        let client_id_blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::ClientId,
             resource_name: "test_client".to_string(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -222,8 +222,8 @@ mod test {
         assert!(acl_metadata.blacklist_client_id.contains_key("test_client"));
 
         // Test User blacklist
-        let user_blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::User,
+        let user_blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::User,
             resource_name: "test_user".to_string(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -232,8 +232,8 @@ mod test {
         assert!(acl_metadata.blacklist_user.contains_key("test_user"));
 
         // Test IP blacklist
-        let ip_blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::Ip,
+        let ip_blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::Ip,
             resource_name: "192.168.1.1".to_string(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -242,8 +242,8 @@ mod test {
         assert!(acl_metadata.blacklist_ip.contains_key("192.168.1.1"));
 
         // Test ClientIdMatch blacklist
-        let client_id_match_blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::ClientIdMatch,
+        let client_id_match_blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::ClientIdMatch,
             resource_name: "test_client_*".to_string(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -263,8 +263,8 @@ mod test {
         );
 
         // Test UserMatch blacklist
-        let user_match_blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::UserMatch,
+        let user_match_blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::UserMatch,
             resource_name: "test_user_*".to_string(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -284,8 +284,8 @@ mod test {
         );
 
         // Test IPCIDR blacklist
-        let ip_cidr_blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::IPCIDR,
+        let ip_cidr_blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::IPCIDR,
             resource_name: "192.168.1.0/24".to_string(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -303,8 +303,8 @@ mod test {
         );
 
         // Test adding multiple entries for match types
-        let another_client_id_match_blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::ClientIdMatch,
+        let another_client_id_match_blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::ClientIdMatch,
             resource_name: "another_client_*".to_string(),
             end_time: now_second() + 100,
             desc: "".to_string(),

--- a/src/mqtt-broker/src/security/acl/mod.rs
+++ b/src/mqtt-broker/src/security/acl/mod.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use common_base::tools::now_second;
 use ipnet::IpNet;
-use metadata_struct::acl::mqtt_acl::{MQTTAclAction, MQTTAclPermission};
+use metadata_struct::acl::mqtt_acl::{MqttAclAction, MqttAclPermission};
 use protocol::mqtt::common::QoS;
 use regex::Regex;
 
@@ -32,7 +32,7 @@ pub fn is_allow_acl(
     cache_mamanger: &Arc<CacheManager>,
     connection: &Connection,
     topic_name: &String,
-    action: MQTTAclAction,
+    action: MqttAclAction,
     retain: bool,
     _: QoS,
 ) -> bool {
@@ -57,7 +57,7 @@ pub fn is_allow_acl(
             cache_mamanger,
             &connection,
             &topic_name,
-            MQTTAclAction::Retain,
+            MqttAclAction::Retain,
         ) {
             return false;
         }
@@ -149,7 +149,7 @@ fn is_acl_deny(
     cache_mamanger: &Arc<CacheManager>,
     connection: &Connection,
     topic_name: &String,
-    action: MQTTAclAction,
+    action: MqttAclAction,
 ) -> bool {
     // check user acl
     if let Some(acl_list) = cache_mamanger
@@ -161,7 +161,7 @@ fn is_acl_deny(
             if topic_match(topic_name.clone(), raw.topic.clone())
                 && ip_match(connection.source_ip_addr.clone(), raw.ip.clone())
                 && raw.action == action
-                && raw.permission == MQTTAclPermission::Deny
+                && raw.permission == MqttAclPermission::Deny
             {
                 return true;
             }
@@ -177,7 +177,7 @@ fn is_acl_deny(
             if topic_match(topic_name.clone(), raw.topic.clone())
                 && ip_match(connection.source_ip_addr.clone(), raw.ip.clone())
                 && raw.action == action
-                && raw.permission == MQTTAclPermission::Deny
+                && raw.permission == MqttAclPermission::Deny
             {
                 return true;
             }
@@ -219,10 +219,10 @@ mod test {
     use clients::poll::ClientPool;
     use common_base::tools::now_second;
     use metadata_struct::acl::mqtt_acl::{
-        MQTTAcl, MQTTAclAction, MQTTAclPermission, MQTTAclResourceType,
+        MqttAcl, MqttAclAction, MqttAclPermission, MqttAclResourceType,
     };
-    use metadata_struct::acl::mqtt_blacklist::{MQTTAclBlackList, MQTTAclBlackListType};
-    use metadata_struct::mqtt::user::MQTTUser;
+    use metadata_struct::acl::mqtt_blacklist::{MqttAclBlackList, MqttAclBlackListType};
+    use metadata_struct::mqtt::user::MqttUser;
 
     use super::{ip_match, is_acl_deny, is_blacklist, is_super_user, topic_match};
     use crate::handler::cache::CacheManager;
@@ -235,7 +235,7 @@ mod test {
         let cluster_name = "test".to_string();
 
         let cache_manager = Arc::new(CacheManager::new(client_poll, cluster_name));
-        let user = MQTTUser {
+        let user = MqttUser {
             username: "loboxu".to_string(),
             password: "lobo_123".to_string(),
             is_superuser: true,
@@ -250,7 +250,7 @@ mod test {
 
         assert!(is_super_user(&cache_manager, &user.username));
 
-        let user = MQTTUser {
+        let user = MqttUser {
             username: "loboxu".to_string(),
             password: "lobo_123".to_string(),
             is_superuser: false,
@@ -264,7 +264,7 @@ mod test {
         let client_poll = Arc::new(ClientPool::new(1));
         let cluster_name = "test".to_string();
         let cache_manager = Arc::new(CacheManager::new(client_poll, cluster_name));
-        let user = MQTTUser {
+        let user = MqttUser {
             username: "loboxu".to_string(),
             password: "lobo_123".to_string(),
             is_superuser: true,
@@ -287,8 +287,8 @@ mod test {
         assert!(!is_blacklist(&cache_manager, &connection));
 
         // user blacklist
-        let blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::User,
+        let blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::User,
             resource_name: user.username.clone(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -296,8 +296,8 @@ mod test {
         cache_manager.add_blacklist(blacklist);
         assert!(is_blacklist(&cache_manager, &connection));
 
-        let blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::UserMatch,
+        let blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::UserMatch,
             resource_name: user.username.clone(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -306,8 +306,8 @@ mod test {
         assert!(is_blacklist(&cache_manager, &connection));
 
         // client id blacklist
-        let blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::ClientId,
+        let blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::ClientId,
             resource_name: connection.client_id.clone(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -315,8 +315,8 @@ mod test {
         cache_manager.add_blacklist(blacklist);
         assert!(is_blacklist(&cache_manager, &connection));
 
-        let blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::ClientIdMatch,
+        let blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::ClientIdMatch,
             resource_name: connection.client_id.clone(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -325,8 +325,8 @@ mod test {
         assert!(is_blacklist(&cache_manager, &connection));
 
         // client ip blacklist
-        let blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::Ip,
+        let blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::Ip,
             resource_name: connection.source_ip_addr.clone(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -334,8 +334,8 @@ mod test {
         cache_manager.add_blacklist(blacklist);
         assert!(is_blacklist(&cache_manager, &connection));
 
-        let blacklist = MQTTAclBlackList {
-            blacklist_type: MQTTAclBlackListType::IPCIDR,
+        let blacklist = MqttAclBlackList {
+            blacklist_type: MqttAclBlackListType::IPCIDR,
             resource_name: "127.0.0.0/24".to_string(),
             end_time: now_second() + 100,
             desc: "".to_string(),
@@ -350,7 +350,7 @@ mod test {
         let cluster_name = "test".to_string();
         let topic_name = "tp-1".to_string();
         let cache_manager = Arc::new(CacheManager::new(client_poll, cluster_name));
-        let user = MQTTUser {
+        let user = MqttUser {
             username: "loboxu".to_string(),
             password: "lobo_123".to_string(),
             is_superuser: true,
@@ -373,14 +373,14 @@ mod test {
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Publish
+            MqttAclAction::Publish
         ));
 
         assert!(!is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Subscribe
+            MqttAclAction::Subscribe
         ));
     }
 
@@ -390,7 +390,7 @@ mod test {
         let cluster_name = "test".to_string();
         let topic_name = "tp-1".to_string();
         let cache_manager = Arc::new(CacheManager::new(client_poll, cluster_name));
-        let user = MQTTUser {
+        let user = MqttUser {
             username: "loboxu".to_string(),
             password: "lobo_123".to_string(),
             is_superuser: true,
@@ -409,43 +409,43 @@ mod test {
         );
         connection.login_success(user.username.clone());
 
-        let acl = MQTTAcl {
-            resource_type: MQTTAclResourceType::User,
+        let acl = MqttAcl {
+            resource_type: MqttAclResourceType::User,
             resource_name: user.username.clone(),
             topic: WILDCARD_RESOURCE.to_string(),
             ip: WILDCARD_RESOURCE.to_string(),
-            action: MQTTAclAction::Publish,
-            permission: MQTTAclPermission::Deny,
+            action: MqttAclAction::Publish,
+            permission: MqttAclPermission::Deny,
         };
         cache_manager.add_acl(acl);
         assert!(is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Publish
+            MqttAclAction::Publish
         ));
 
         assert!(!is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Subscribe
+            MqttAclAction::Subscribe
         ));
 
-        let acl = MQTTAcl {
-            resource_type: MQTTAclResourceType::User,
+        let acl = MqttAcl {
+            resource_type: MqttAclResourceType::User,
             resource_name: user.username.clone(),
             topic: WILDCARD_RESOURCE.to_string(),
             ip: WILDCARD_RESOURCE.to_string(),
-            action: MQTTAclAction::Subscribe,
-            permission: MQTTAclPermission::Deny,
+            action: MqttAclAction::Subscribe,
+            permission: MqttAclPermission::Deny,
         };
         cache_manager.add_acl(acl);
         assert!(is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Subscribe
+            MqttAclAction::Subscribe
         ));
     }
 
@@ -455,7 +455,7 @@ mod test {
         let cluster_name = "test".to_string();
         let topic_name = "tp-1".to_string();
         let cache_manager = Arc::new(CacheManager::new(client_poll, cluster_name));
-        let user = MQTTUser {
+        let user = MqttUser {
             username: "loboxu".to_string(),
             password: "lobo_123".to_string(),
             is_superuser: true,
@@ -474,43 +474,43 @@ mod test {
         );
         connection.login_success(user.username.clone());
 
-        let acl = MQTTAcl {
-            resource_type: MQTTAclResourceType::User,
+        let acl = MqttAcl {
+            resource_type: MqttAclResourceType::User,
             resource_name: user.username.clone(),
             topic: topic_name.clone(),
             ip: WILDCARD_RESOURCE.to_string(),
-            action: MQTTAclAction::Publish,
-            permission: MQTTAclPermission::Deny,
+            action: MqttAclAction::Publish,
+            permission: MqttAclPermission::Deny,
         };
         cache_manager.add_acl(acl);
         assert!(is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Publish
+            MqttAclAction::Publish
         ));
 
         assert!(!is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Subscribe
+            MqttAclAction::Subscribe
         ));
 
-        let acl = MQTTAcl {
-            resource_type: MQTTAclResourceType::User,
+        let acl = MqttAcl {
+            resource_type: MqttAclResourceType::User,
             resource_name: user.username.clone(),
             topic: topic_name.clone(),
             ip: WILDCARD_RESOURCE.to_string(),
-            action: MQTTAclAction::Subscribe,
-            permission: MQTTAclPermission::Deny,
+            action: MqttAclAction::Subscribe,
+            permission: MqttAclPermission::Deny,
         };
         cache_manager.add_acl(acl);
         assert!(is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Subscribe
+            MqttAclAction::Subscribe
         ));
     }
 
@@ -520,7 +520,7 @@ mod test {
         let cluster_name = "test".to_string();
         let topic_name = "tp-1".to_string();
         let cache_manager = Arc::new(CacheManager::new(client_poll, cluster_name));
-        let user = MQTTUser {
+        let user = MqttUser {
             username: "loboxu".to_string(),
             password: "lobo_123".to_string(),
             is_superuser: true,
@@ -539,43 +539,43 @@ mod test {
         );
         connection.login_success(user.username.clone());
 
-        let acl = MQTTAcl {
-            resource_type: MQTTAclResourceType::ClientId,
+        let acl = MqttAcl {
+            resource_type: MqttAclResourceType::ClientId,
             resource_name: connection.client_id.clone(),
             topic: WILDCARD_RESOURCE.to_string(),
             ip: WILDCARD_RESOURCE.to_string(),
-            action: MQTTAclAction::Publish,
-            permission: MQTTAclPermission::Deny,
+            action: MqttAclAction::Publish,
+            permission: MqttAclPermission::Deny,
         };
         cache_manager.add_acl(acl);
         assert!(is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Publish
+            MqttAclAction::Publish
         ));
 
         assert!(!is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Subscribe
+            MqttAclAction::Subscribe
         ));
 
-        let acl = MQTTAcl {
-            resource_type: MQTTAclResourceType::ClientId,
+        let acl = MqttAcl {
+            resource_type: MqttAclResourceType::ClientId,
             resource_name: connection.client_id.clone(),
             topic: WILDCARD_RESOURCE.to_string(),
             ip: WILDCARD_RESOURCE.to_string(),
-            action: MQTTAclAction::Subscribe,
-            permission: MQTTAclPermission::Deny,
+            action: MqttAclAction::Subscribe,
+            permission: MqttAclPermission::Deny,
         };
         cache_manager.add_acl(acl);
         assert!(is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Subscribe
+            MqttAclAction::Subscribe
         ));
     }
 
@@ -585,7 +585,7 @@ mod test {
         let cluster_name = "test".to_string();
         let topic_name = "tp-1".to_string();
         let cache_manager = Arc::new(CacheManager::new(client_poll, cluster_name));
-        let user = MQTTUser {
+        let user = MqttUser {
             username: "loboxu".to_string(),
             password: "lobo_123".to_string(),
             is_superuser: true,
@@ -604,43 +604,43 @@ mod test {
         );
         connection.login_success(user.username.clone());
 
-        let acl = MQTTAcl {
-            resource_type: MQTTAclResourceType::ClientId,
+        let acl = MqttAcl {
+            resource_type: MqttAclResourceType::ClientId,
             resource_name: connection.client_id.clone(),
             topic: topic_name.clone(),
             ip: WILDCARD_RESOURCE.to_string(),
-            action: MQTTAclAction::Publish,
-            permission: MQTTAclPermission::Deny,
+            action: MqttAclAction::Publish,
+            permission: MqttAclPermission::Deny,
         };
         cache_manager.add_acl(acl);
         assert!(is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Publish
+            MqttAclAction::Publish
         ));
 
         assert!(!is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Subscribe
+            MqttAclAction::Subscribe
         ));
 
-        let acl = MQTTAcl {
-            resource_type: MQTTAclResourceType::ClientId,
+        let acl = MqttAcl {
+            resource_type: MqttAclResourceType::ClientId,
             resource_name: connection.client_id.clone(),
             topic: topic_name.clone(),
             ip: WILDCARD_RESOURCE.to_string(),
-            action: MQTTAclAction::Subscribe,
-            permission: MQTTAclPermission::Deny,
+            action: MqttAclAction::Subscribe,
+            permission: MqttAclPermission::Deny,
         };
         cache_manager.add_acl(acl);
         assert!(is_acl_deny(
             &cache_manager,
             &connection,
             &topic_name,
-            MQTTAclAction::Subscribe
+            MqttAclAction::Subscribe
         ));
     }
 

--- a/src/mqtt-broker/src/security/login/plaintext.rs
+++ b/src/mqtt-broker/src/security/login/plaintext.rs
@@ -52,7 +52,7 @@ mod test {
 
     use clients::poll::ClientPool;
     use common_base::config::broker_mqtt::BrokerMQTTConfig;
-    use metadata_struct::mqtt::user::MQTTUser;
+    use metadata_struct::mqtt::user::MqttUser;
     use protocol::mqtt::common::Login;
 
     use super::Plaintext;
@@ -70,7 +70,7 @@ mod test {
         ));
         let username = "lobo".to_string();
         let password = "pwd123".to_string();
-        let user = MQTTUser {
+        let user = MqttUser {
             username: username.clone(),
             password: password.clone(),
             is_superuser: true,

--- a/src/mqtt-broker/src/security/mod.rs
+++ b/src/mqtt-broker/src/security/mod.rs
@@ -25,9 +25,9 @@ use common_base::error::mqtt_broker::MQTTBrokerError;
 use dashmap::DashMap;
 use login::plaintext::Plaintext;
 use login::Authentication;
-use metadata_struct::acl::mqtt_acl::{MQTTAcl, MQTTAclAction};
-use metadata_struct::acl::mqtt_blacklist::MQTTAclBlackList;
-use metadata_struct::mqtt::user::MQTTUser;
+use metadata_struct::acl::mqtt_acl::{MqttAcl, MqttAclAction};
+use metadata_struct::acl::mqtt_blacklist::MqttAclBlackList;
+use metadata_struct::mqtt::user::MqttUser;
 use mysql::MySQLAuthStorageAdapter;
 use placement::PlacementAuthStorageAdapter;
 use protocol::mqtt::common::{ConnectProperties, Login, QoS, Subscribe};
@@ -45,13 +45,13 @@ pub mod redis;
 
 #[async_trait]
 pub trait AuthStorageAdapter {
-    async fn read_all_user(&self) -> Result<DashMap<String, MQTTUser>, CommonError>;
+    async fn read_all_user(&self) -> Result<DashMap<String, MqttUser>, CommonError>;
 
-    async fn read_all_acl(&self) -> Result<Vec<MQTTAcl>, CommonError>;
+    async fn read_all_acl(&self) -> Result<Vec<MqttAcl>, CommonError>;
 
-    async fn read_all_blacklist(&self) -> Result<Vec<MQTTAclBlackList>, CommonError>;
+    async fn read_all_blacklist(&self) -> Result<Vec<MqttAclBlackList>, CommonError>;
 
-    async fn get_user(&self, username: String) -> Result<Option<MQTTUser>, CommonError>;
+    async fn get_user(&self, username: String) -> Result<Option<MqttUser>, CommonError>;
 }
 
 pub struct AuthDriver {
@@ -87,15 +87,15 @@ impl AuthDriver {
         return Ok(());
     }
 
-    pub async fn read_all_user(&self) -> Result<DashMap<String, MQTTUser>, CommonError> {
+    pub async fn read_all_user(&self) -> Result<DashMap<String, MqttUser>, CommonError> {
         return self.driver.read_all_user().await;
     }
 
-    pub async fn read_all_acl(&self) -> Result<Vec<MQTTAcl>, CommonError> {
+    pub async fn read_all_acl(&self) -> Result<Vec<MqttAcl>, CommonError> {
         return self.driver.read_all_acl().await;
     }
 
-    pub async fn read_all_blacklist(&self) -> Result<Vec<MQTTAclBlackList>, CommonError> {
+    pub async fn read_all_blacklist(&self) -> Result<Vec<MqttAclBlackList>, CommonError> {
         return self.driver.read_all_blacklist().await;
     }
 
@@ -131,7 +131,7 @@ impl AuthDriver {
             &self.cache_manager,
             connection,
             topic_name,
-            MQTTAclAction::Publish,
+            MqttAclAction::Publish,
             retain,
             qos,
         );
@@ -145,7 +145,7 @@ impl AuthDriver {
                     &self.cache_manager,
                     connection,
                     &topic,
-                    MQTTAclAction::Publish,
+                    MqttAclAction::Publish,
                     false,
                     filter.qos,
                 ) {

--- a/src/mqtt-broker/src/security/mysql/mod.rs
+++ b/src/mqtt-broker/src/security/mysql/mod.rs
@@ -15,9 +15,9 @@
 use axum::async_trait;
 use common_base::error::common::CommonError;
 use dashmap::DashMap;
-use metadata_struct::acl::mqtt_acl::MQTTAcl;
-use metadata_struct::acl::mqtt_blacklist::MQTTAclBlackList;
-use metadata_struct::mqtt::user::MQTTUser;
+use metadata_struct::acl::mqtt_acl::MqttAcl;
+use metadata_struct::acl::mqtt_blacklist::MqttAclBlackList;
+use metadata_struct::mqtt::user::MqttUser;
 use mysql::prelude::Queryable;
 use mysql::Pool;
 use third_driver::mysql::build_mysql_conn_pool;
@@ -47,7 +47,7 @@ impl MySQLAuthStorageAdapter {
 
 #[async_trait]
 impl AuthStorageAdapter for MySQLAuthStorageAdapter {
-    async fn read_all_user(&self) -> Result<DashMap<String, MQTTUser>, CommonError> {
+    async fn read_all_user(&self) -> Result<DashMap<String, MqttUser>, CommonError> {
         match self.pool.get_conn() {
             Ok(mut conn) => {
                 let sql = format!(
@@ -58,7 +58,7 @@ impl AuthStorageAdapter for MySQLAuthStorageAdapter {
                     conn.query(sql).unwrap();
                 let results = DashMap::with_capacity(2);
                 for raw in data {
-                    let user = MQTTUser {
+                    let user = MqttUser {
                         username: raw.0.clone(),
                         password: raw.1.clone(),
                         is_superuser: raw.3 == 1,
@@ -73,7 +73,7 @@ impl AuthStorageAdapter for MySQLAuthStorageAdapter {
         }
     }
 
-    async fn get_user(&self, username: String) -> Result<Option<MQTTUser>, CommonError> {
+    async fn get_user(&self, username: String) -> Result<Option<MqttUser>, CommonError> {
         match self.pool.get_conn() {
             Ok(mut conn) => {
                 let sql = format!(
@@ -84,7 +84,7 @@ impl AuthStorageAdapter for MySQLAuthStorageAdapter {
                 let data: Vec<(String, String, Option<String>, u8, Option<String>)> =
                     conn.query(sql).unwrap();
                 if let Some(value) = data.first() {
-                    return Ok(Some(MQTTUser {
+                    return Ok(Some(MqttUser {
                         username: value.0.clone(),
                         password: value.1.clone(),
                         is_superuser: value.3 == 1,
@@ -98,11 +98,11 @@ impl AuthStorageAdapter for MySQLAuthStorageAdapter {
         }
     }
 
-    async fn read_all_acl(&self) -> Result<Vec<MQTTAcl>, CommonError> {
+    async fn read_all_acl(&self) -> Result<Vec<MqttAcl>, CommonError> {
         return Ok(Vec::new());
     }
 
-    async fn read_all_blacklist(&self) -> Result<Vec<MQTTAclBlackList>, CommonError> {
+    async fn read_all_blacklist(&self) -> Result<Vec<MqttAclBlackList>, CommonError> {
         return Ok(Vec::new());
     }
 }

--- a/src/mqtt-broker/src/security/placement/mod.rs
+++ b/src/mqtt-broker/src/security/placement/mod.rs
@@ -18,9 +18,9 @@ use axum::async_trait;
 use clients::poll::ClientPool;
 use common_base::error::common::CommonError;
 use dashmap::DashMap;
-use metadata_struct::acl::mqtt_acl::MQTTAcl;
-use metadata_struct::acl::mqtt_blacklist::MQTTAclBlackList;
-use metadata_struct::mqtt::user::MQTTUser;
+use metadata_struct::acl::mqtt_acl::MqttAcl;
+use metadata_struct::acl::mqtt_blacklist::MqttAclBlackList;
+use metadata_struct::mqtt::user::MqttUser;
 
 use super::AuthStorageAdapter;
 use crate::storage::acl::AclStorage;
@@ -39,22 +39,22 @@ impl PlacementAuthStorageAdapter {
 
 #[async_trait]
 impl AuthStorageAdapter for PlacementAuthStorageAdapter {
-    async fn read_all_user(&self) -> Result<DashMap<String, MQTTUser>, CommonError> {
+    async fn read_all_user(&self) -> Result<DashMap<String, MqttUser>, CommonError> {
         let user_storage = UserStorage::new(self.client_poll.clone());
         return user_storage.user_list().await;
     }
 
-    async fn get_user(&self, username: String) -> Result<Option<MQTTUser>, CommonError> {
+    async fn get_user(&self, username: String) -> Result<Option<MqttUser>, CommonError> {
         let user_storage = UserStorage::new(self.client_poll.clone());
         return user_storage.get_user(username).await;
     }
 
-    async fn read_all_acl(&self) -> Result<Vec<MQTTAcl>, CommonError> {
+    async fn read_all_acl(&self) -> Result<Vec<MqttAcl>, CommonError> {
         let acl_storage = AclStorage::new(self.client_poll.clone());
         return acl_storage.list_acl().await;
     }
 
-    async fn read_all_blacklist(&self) -> Result<Vec<MQTTAclBlackList>, CommonError> {
+    async fn read_all_blacklist(&self) -> Result<Vec<MqttAclBlackList>, CommonError> {
         let blacklist_storage = BlackListStorage::new(self.client_poll.clone());
         return blacklist_storage.list_blacklist().await;
     }

--- a/src/mqtt-broker/src/server/connection_manager.rs
+++ b/src/mqtt-broker/src/server/connection_manager.rs
@@ -21,7 +21,7 @@ use dashmap::DashMap;
 use futures::stream::SplitSink;
 use futures::SinkExt;
 use log::{debug, error, info};
-use protocol::mqtt::codec::{MQTTPacketWrapper, MqttCodec};
+use protocol::mqtt::codec::{MqttPacketWrapper, MqttCodec};
 use protocol::mqtt::common::MQTTProtocol;
 use tokio::time::sleep;
 use tokio_util::codec::FramedWrite;
@@ -190,7 +190,7 @@ impl ConnectionManager {
     pub async fn write_tcp_frame(
         &self,
         connection_id: u64,
-        resp: MQTTPacketWrapper,
+        resp: MqttPacketWrapper,
     ) -> Result<(), CommonError> {
         debug!("response packet:{resp:?},connection_id:{connection_id}");
 
@@ -252,7 +252,7 @@ impl ConnectionManager {
     async fn write_tcp_tls_frame(
         &self,
         connection_id: u64,
-        resp: MQTTPacketWrapper,
+        resp: MqttPacketWrapper,
     ) -> Result<(), CommonError> {
         let mut times = 0;
         let cluster = self.cache_manager.get_cluster_info();

--- a/src/mqtt-broker/src/server/tcp/response.rs
+++ b/src/mqtt-broker/src/server/tcp/response.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use clients::poll::ClientPool;
 use log::{debug, error};
-use protocol::mqtt::codec::MQTTPacketWrapper;
+use protocol::mqtt::codec::MqttPacketWrapper;
 use protocol::mqtt::common::MQTTPacket;
 use tokio::select;
 use tokio::sync::broadcast;
@@ -141,7 +141,7 @@ pub(crate) fn response_child_process(
                             if let Some(protocol) =
                             raw_connect_manager.get_connect_protocol(response_package.connection_id)
                             {
-                                let packet_wrapper = MQTTPacketWrapper {
+                                let packet_wrapper = MqttPacketWrapper {
                                     protocol_version: protocol.into(),
                                     packet: response_package.packet.clone(),
                                 };

--- a/src/mqtt-broker/src/server/websocket/server.rs
+++ b/src/mqtt-broker/src/server/websocket/server.rs
@@ -29,7 +29,7 @@ use clients::poll::ClientPool;
 use common_base::config::broker_mqtt::broker_mqtt_conf;
 use futures_util::stream::StreamExt;
 use log::{debug, error, info};
-use protocol::mqtt::codec::{MQTTPacketWrapper, MqttCodec};
+use protocol::mqtt::codec::{MqttPacketWrapper, MqttCodec};
 use protocol::mqtt::common::{MQTTPacket, MQTTProtocol};
 use storage_adapter::storage::StorageAdapter;
 use tokio::select;
@@ -244,7 +244,7 @@ async fn handle_socket<S>(
                                         }
 
                                         let mut response_buff = BytesMut::new();
-                                        let packet_wrapper = MQTTPacketWrapper {
+                                        let packet_wrapper = MqttPacketWrapper {
                                             protocol_version: protocol_version.clone().into(),
                                             packet: resp_pkg,
                                         };

--- a/src/mqtt-broker/src/storage/acl.rs
+++ b/src/mqtt-broker/src/storage/acl.rs
@@ -18,7 +18,7 @@ use clients::placement::mqtt::call::list_acl;
 use clients::poll::ClientPool;
 use common_base::config::broker_mqtt::broker_mqtt_conf;
 use common_base::error::common::CommonError;
-use metadata_struct::acl::mqtt_acl::MQTTAcl;
+use metadata_struct::acl::mqtt_acl::MqttAcl;
 use protocol::placement_center::generate::mqtt::ListAclRequest;
 
 pub struct AclStorage {
@@ -30,7 +30,7 @@ impl AclStorage {
         return AclStorage { client_poll };
     }
 
-    pub async fn list_acl(&self) -> Result<Vec<MQTTAcl>, CommonError> {
+    pub async fn list_acl(&self) -> Result<Vec<MqttAcl>, CommonError> {
         let config = broker_mqtt_conf();
         let request = ListAclRequest {
             cluster_name: config.cluster_name.clone(),
@@ -45,7 +45,7 @@ impl AclStorage {
             Ok(reply) => {
                 let mut list = Vec::new();
                 for raw in reply.acls {
-                    list.push(serde_json::from_slice::<MQTTAcl>(raw.as_slice())?);
+                    list.push(serde_json::from_slice::<MqttAcl>(raw.as_slice())?);
                 }
                 return Ok(list);
             }

--- a/src/mqtt-broker/src/storage/blacklist.rs
+++ b/src/mqtt-broker/src/storage/blacklist.rs
@@ -18,7 +18,7 @@ use clients::placement::mqtt::call::list_blacklist;
 use clients::poll::ClientPool;
 use common_base::config::broker_mqtt::broker_mqtt_conf;
 use common_base::error::common::CommonError;
-use metadata_struct::acl::mqtt_blacklist::MQTTAclBlackList;
+use metadata_struct::acl::mqtt_blacklist::MqttAclBlackList;
 use protocol::placement_center::generate::mqtt::ListBlacklistRequest;
 
 pub struct BlackListStorage {
@@ -30,7 +30,7 @@ impl BlackListStorage {
         return BlackListStorage { client_poll };
     }
 
-    pub async fn list_blacklist(&self) -> Result<Vec<MQTTAclBlackList>, CommonError> {
+    pub async fn list_blacklist(&self) -> Result<Vec<MqttAclBlackList>, CommonError> {
         let config = broker_mqtt_conf();
         let request = ListBlacklistRequest {
             cluster_name: config.cluster_name.clone(),
@@ -45,7 +45,7 @@ impl BlackListStorage {
             Ok(reply) => {
                 let mut list = Vec::new();
                 for raw in reply.blacklists {
-                    list.push(serde_json::from_slice::<MQTTAclBlackList>(raw.as_slice())?);
+                    list.push(serde_json::from_slice::<MqttAclBlackList>(raw.as_slice())?);
                 }
                 return Ok(list);
             }

--- a/src/mqtt-broker/src/storage/cluster.rs
+++ b/src/mqtt-broker/src/storage/cluster.rs
@@ -22,8 +22,8 @@ use clients::poll::ClientPool;
 use common_base::config::broker_mqtt::broker_mqtt_conf;
 use common_base::error::common::CommonError;
 use common_base::tools::get_local_ip;
-use metadata_struct::mqtt::cluster::MQTTClusterDynamicConfig;
-use metadata_struct::mqtt::node_extend::MQTTNodeExtend;
+use metadata_struct::mqtt::cluster::MqttClusterDynamicConfig;
+use metadata_struct::mqtt::node_extend::MqttNodeExtend;
 use metadata_struct::placement::broker_node::BrokerNode;
 use protocol::placement_center::generate::common::ClusterType;
 use protocol::placement_center::generate::placement::{
@@ -75,7 +75,7 @@ impl ClusterStorage {
         req.node_ip = local_ip.clone();
         req.node_inner_addr = format!("{}:{}", local_ip, config.grpc_port);
 
-        let node = MQTTNodeExtend {
+        let node = MqttNodeExtend {
             grpc_addr: format!("{}:{}", local_ip, config.grpc_port),
             http_addr: format!("{}:{}", local_ip, config.http_port),
             mqtt_addr: format!("{}:{}", local_ip, config.network.tcp_port),
@@ -132,7 +132,7 @@ impl ClusterStorage {
     pub async fn set_cluster_config(
         &self,
         cluster_name: String,
-        cluster: MQTTClusterDynamicConfig,
+        cluster: MqttClusterDynamicConfig,
     ) -> Result<(), CommonError> {
         let config = broker_mqtt_conf();
         let resources = self.cluster_config_resources(cluster_name.clone());
@@ -172,7 +172,7 @@ impl ClusterStorage {
     pub async fn get_cluster_config(
         &self,
         cluster_name: String,
-    ) -> Result<Option<MQTTClusterDynamicConfig>, CommonError> {
+    ) -> Result<Option<MqttClusterDynamicConfig>, CommonError> {
         let config = broker_mqtt_conf();
         let resources = self.cluster_config_resources(cluster_name.clone());
         let request = GetResourceConfigRequest {
@@ -191,7 +191,7 @@ impl ClusterStorage {
                 if data.config.is_empty() {
                     return Ok(None);
                 } else {
-                    match serde_json::from_slice::<MQTTClusterDynamicConfig>(&data.config) {
+                    match serde_json::from_slice::<MqttClusterDynamicConfig>(&data.config) {
                         Ok(data) => {
                             return Ok(Some(data));
                         }
@@ -216,7 +216,7 @@ mod tests {
 
     use clients::poll::ClientPool;
     use common_base::config::broker_mqtt::init_broker_mqtt_conf_by_path;
-    use metadata_struct::mqtt::cluster::MQTTClusterDynamicConfig;
+    use metadata_struct::mqtt::cluster::MqttClusterDynamicConfig;
 
     use crate::storage::cluster::ClusterStorage;
 
@@ -235,7 +235,7 @@ mod tests {
         let cluster_storage = ClusterStorage::new(client_poll);
 
         let cluster_name = "robust_test".to_string();
-        let mut cluster = MQTTClusterDynamicConfig::default();
+        let mut cluster = MqttClusterDynamicConfig::default();
         cluster.protocol.topic_alias_max = 999;
         cluster_storage
             .set_cluster_config(cluster_name.clone(), cluster)

--- a/src/mqtt-broker/src/storage/session.rs
+++ b/src/mqtt-broker/src/storage/session.rs
@@ -22,7 +22,7 @@ use clients::poll::ClientPool;
 use common_base::config::broker_mqtt::broker_mqtt_conf;
 use common_base::error::common::CommonError;
 use dashmap::DashMap;
-use metadata_struct::mqtt::session::MQTTSession;
+use metadata_struct::mqtt::session::MqttSession;
 use protocol::placement_center::generate::mqtt::{
     CreateSessionRequest, DeleteSessionRequest, ListSessionRequest, SaveLastWillMessageRequest,
     UpdateSessionRequest,
@@ -40,7 +40,7 @@ impl SessionStorage {
     pub async fn set_session(
         &self,
         client_id: &String,
-        session: &MQTTSession,
+        session: &MqttSession,
     ) -> Result<(), CommonError> {
         let config = broker_mqtt_conf();
         let request = CreateSessionRequest {
@@ -113,7 +113,7 @@ impl SessionStorage {
         }
     }
 
-    pub async fn get_session(&self, client_id: String) -> Result<Option<MQTTSession>, CommonError> {
+    pub async fn get_session(&self, client_id: String) -> Result<Option<MqttSession>, CommonError> {
         let config = broker_mqtt_conf();
         let request = ListSessionRequest {
             cluster_name: config.cluster_name.clone(),
@@ -131,7 +131,7 @@ impl SessionStorage {
                     return Ok(None);
                 }
                 let raw = reply.sessions.get(0).unwrap();
-                match serde_json::from_slice::<MQTTSession>(&raw) {
+                match serde_json::from_slice::<MqttSession>(&raw) {
                     Ok(data) => return Ok(Some(data)),
                     Err(e) => {
                         return Err(CommonError::CommmonError(e.to_string()));
@@ -144,7 +144,7 @@ impl SessionStorage {
         }
     }
 
-    pub async fn list_session(&self) -> Result<DashMap<String, MQTTSession>, CommonError> {
+    pub async fn list_session(&self) -> Result<DashMap<String, MqttSession>, CommonError> {
         let config = broker_mqtt_conf();
         let request = ListSessionRequest {
             cluster_name: config.cluster_name.clone(),
@@ -160,7 +160,7 @@ impl SessionStorage {
             Ok(reply) => {
                 let results = DashMap::with_capacity(2);
                 for raw in reply.sessions {
-                    match serde_json::from_slice::<MQTTSession>(&raw) {
+                    match serde_json::from_slice::<MqttSession>(&raw) {
                         Ok(data) => {
                             results.insert(data.client_id.clone(), data);
                         }
@@ -210,7 +210,7 @@ mod tests {
     use clients::poll::ClientPool;
     use common_base::config::broker_mqtt::init_broker_mqtt_conf_by_path;
     use common_base::tools::now_second;
-    use metadata_struct::mqtt::session::MQTTSession;
+    use metadata_struct::mqtt::session::MqttSession;
 
     use crate::storage::session::SessionStorage;
 
@@ -225,7 +225,7 @@ mod tests {
         let client_poll: Arc<ClientPool> = Arc::new(ClientPool::new(10));
         let session_storage = SessionStorage::new(client_poll);
         let client_id: String = "client_id_11111".to_string();
-        let mut session = MQTTSession::default();
+        let mut session = MqttSession::default();
         session.client_id = client_id.clone();
         session.session_expiry = 1000;
         session.broker_id = Some(1);

--- a/src/mqtt-broker/src/storage/user.rs
+++ b/src/mqtt-broker/src/storage/user.rs
@@ -21,7 +21,7 @@ use clients::poll::ClientPool;
 use common_base::config::broker_mqtt::broker_mqtt_conf;
 use common_base::error::common::CommonError;
 use dashmap::DashMap;
-use metadata_struct::mqtt::user::MQTTUser;
+use metadata_struct::mqtt::user::MqttUser;
 use protocol::placement_center::generate::mqtt::{
     CreateUserRequest, DeleteUserRequest, ListUserRequest,
 };
@@ -34,7 +34,7 @@ impl UserStorage {
         return UserStorage { client_poll };
     }
 
-    pub async fn save_user(&self, user_info: MQTTUser) -> Result<(), CommonError> {
+    pub async fn save_user(&self, user_info: MqttUser) -> Result<(), CommonError> {
         let config = broker_mqtt_conf();
         let request = CreateUserRequest {
             cluster_name: config.cluster_name.clone(),
@@ -75,7 +75,7 @@ impl UserStorage {
         }
     }
 
-    pub async fn get_user(&self, username: String) -> Result<Option<MQTTUser>, CommonError> {
+    pub async fn get_user(&self, username: String) -> Result<Option<MqttUser>, CommonError> {
         let config = broker_mqtt_conf();
         let request = ListUserRequest {
             cluster_name: config.cluster_name.clone(),
@@ -93,7 +93,7 @@ impl UserStorage {
                     return Ok(None);
                 }
                 let raw = reply.users.get(0).unwrap();
-                match serde_json::from_slice::<MQTTUser>(raw) {
+                match serde_json::from_slice::<MqttUser>(raw) {
                     Ok(data) => {
                         return Ok(Some(data));
                     }
@@ -108,7 +108,7 @@ impl UserStorage {
         }
     }
 
-    pub async fn user_list(&self) -> Result<DashMap<String, MQTTUser>, CommonError> {
+    pub async fn user_list(&self) -> Result<DashMap<String, MqttUser>, CommonError> {
         let config = broker_mqtt_conf();
         let request = ListUserRequest {
             cluster_name: config.cluster_name.clone(),
@@ -124,7 +124,7 @@ impl UserStorage {
             Ok(reply) => {
                 let results = DashMap::with_capacity(2);
                 for raw in reply.users {
-                    match serde_json::from_slice::<MQTTUser>(&raw) {
+                    match serde_json::from_slice::<MqttUser>(&raw) {
                         Ok(data) => {
                             results.insert(data.username.clone(), data);
                         }
@@ -164,7 +164,7 @@ mod tests {
         let username = "test".to_string();
         let password = "test_password".to_string();
         let is_superuser = true;
-        let user_info = metadata_struct::mqtt::user::MQTTUser {
+        let user_info = metadata_struct::mqtt::user::MqttUser {
             username: username.clone(),
             password: password.clone(),
             is_superuser,

--- a/src/mqtt-broker/src/subscribe/sub_common.rs
+++ b/src/mqtt-broker/src/subscribe/sub_common.rs
@@ -23,7 +23,7 @@ use common_base::config::broker_mqtt::broker_mqtt_conf;
 use common_base::error::common::CommonError;
 use common_base::error::mqtt_broker::MQTTBrokerError;
 use log::error;
-use protocol::mqtt::codec::{MQTTPacketWrapper, MqttCodec};
+use protocol::mqtt::codec::{MqttPacketWrapper, MqttCodec};
 use protocol::mqtt::common::{MQTTPacket, MQTTProtocol, PubRel, Publish, PublishProperties, QoS};
 use protocol::placement_center::generate::mqtt::{
     GetShareSubLeaderReply, GetShareSubLeaderRequest,
@@ -174,7 +174,7 @@ pub async fn publish_message_to_client(
     if let Some(protocol) = connection_manager.get_connect_protocol(resp.connection_id) {
         record_sent_metrics(&resp, connection_manager);
 
-        let response: MQTTPacketWrapper = MQTTPacketWrapper {
+        let response: MqttPacketWrapper = MqttPacketWrapper {
             protocol_version: protocol.clone().into(),
             packet: resp.packet,
         };
@@ -435,7 +435,7 @@ mod tests {
 
     use clients::poll::ClientPool;
     use common_base::tools::unique_id;
-    use metadata_struct::mqtt::topic::MQTTTopic;
+    use metadata_struct::mqtt::topic::MqttTopic;
     use protocol::mqtt::common::QoS;
 
     use crate::handler::cache::CacheManager;
@@ -557,7 +557,7 @@ mod tests {
         let client_poll: Arc<ClientPool> = Arc::new(ClientPool::new(100));
         let metadata_cache = Arc::new(CacheManager::new(client_poll, "test-cluster".to_string()));
         let topic_name = "/test/topic".to_string();
-        let topic = MQTTTopic::new(unique_id(), topic_name.clone());
+        let topic = MqttTopic::new(unique_id(), topic_name.clone());
         metadata_cache.add_topic(&topic_name, &topic);
 
         let sub_path = "/test/topic".to_string();

--- a/src/mqtt-broker/src/subscribe/sub_exclusive.rs
+++ b/src/mqtt-broker/src/subscribe/sub_exclusive.rs
@@ -20,7 +20,7 @@ use clients::poll::ClientPool;
 use common_base::error::common::CommonError;
 use common_base::tools::now_second;
 use log::{debug, error, info};
-use metadata_struct::mqtt::message::MQTTMessage;
+use metadata_struct::mqtt::message::MqttMessage;
 use protocol::mqtt::common::{MQTTPacket, MQTTProtocol, Publish, PublishProperties, QoS};
 use storage_adapter::storage::StorageAdapter;
 use tokio::sync::broadcast::{self};
@@ -182,7 +182,7 @@ where
                             }
 
                             for record in result.clone() {
-                                let msg = match MQTTMessage::decode_record(record.clone()) {
+                                let msg = match MqttMessage::decode_record(record.clone()) {
                                     Ok(msg) => msg,
                                     Err(e) => {
                                         error!("Storage layer message Decord failed with error message :{}",e);

--- a/src/mqtt-broker/src/subscribe/sub_share_follower.rs
+++ b/src/mqtt-broker/src/subscribe/sub_share_follower.rs
@@ -22,7 +22,7 @@ use common_base::tools::{now_second, unique_id};
 use dashmap::DashMap;
 use futures::{SinkExt, StreamExt};
 use log::{error, info};
-use metadata_struct::mqtt::node_extend::MQTTNodeExtend;
+use metadata_struct::mqtt::node_extend::MqttNodeExtend;
 use protocol::mqtt::common::{
     Connect, ConnectProperties, ConnectReturnCode, Login, MQTTPacket, MQTTProtocol, PingReq,
     PubAck, PubAckProperties, PubAckReason, PubComp, PubCompProperties, PubCompReason, PubRec,
@@ -131,8 +131,8 @@ impl SubscribeShareFollower {
                                     "MQTT 4 does not currently support shared subscriptions"
                                 );
                             } else if share_sub.protocol == MQTTProtocol::MQTT5 {
-                                let extend_info: MQTTNodeExtend = match serde_json::from_str::<
-                                    MQTTNodeExtend,
+                                let extend_info: MqttNodeExtend = match serde_json::from_str::<
+                                    MqttNodeExtend,
                                 >(
                                     &reply.extend_info
                                 ) {

--- a/src/mqtt-broker/src/subscribe/sub_share_leader.rs
+++ b/src/mqtt-broker/src/subscribe/sub_share_leader.rs
@@ -21,7 +21,7 @@ use common_base::error::common::CommonError;
 use common_base::error::mqtt_broker::MQTTBrokerError;
 use common_base::tools::now_second;
 use log::{debug, error, info};
-use metadata_struct::mqtt::message::MQTTMessage;
+use metadata_struct::mqtt::message::MqttMessage;
 use protocol::mqtt::common::{MQTTPacket, MQTTProtocol, Publish, PublishProperties, QoS};
 use storage_adapter::storage::StorageAdapter;
 use tokio::select;
@@ -257,7 +257,7 @@ where
             }
 
             for record in results {
-                let msg: MQTTMessage = match MQTTMessage::decode_record(record.clone()) {
+                let msg: MqttMessage = match MqttMessage::decode_record(record.clone()) {
                     Ok(msg) => msg,
                     Err(e) => {
                         error!(
@@ -459,7 +459,7 @@ fn build_publish(
     metadata_cache: &Arc<CacheManager>,
     subscribe: &Subscriber,
     topic_name: &String,
-    msg: &MQTTMessage,
+    msg: &MqttMessage,
 ) -> Option<(Publish, PublishProperties)> {
     let cluster_qos = metadata_cache.get_cluster_info().protocol.max_qos;
     let qos = min_qos(cluster_qos, subscribe.qos);

--- a/src/placement-center/src/cache/mqtt.rs
+++ b/src/placement-center/src/cache/mqtt.rs
@@ -15,19 +15,19 @@
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use metadata_struct::mqtt::topic::MQTTTopic;
-use metadata_struct::mqtt::user::MQTTUser;
+use metadata_struct::mqtt::topic::MqttTopic;
+use metadata_struct::mqtt::user::MqttUser;
 use protocol::placement_center::generate::common::ClusterType;
 
 use super::placement::PlacementCacheManager;
 use crate::controller::mqtt::session_expire::ExpireLastWill;
-use crate::storage::mqtt::topic::MQTTTopicStorage;
-use crate::storage::mqtt::user::MQTTUserStorage;
+use crate::storage::mqtt::topic::MqttTopicStorage;
+use crate::storage::mqtt::user::MqttUserStorage;
 use crate::storage::rocksdb::RocksDBEngine;
 
 pub struct MqttCacheManager {
-    pub topic_list: DashMap<String, DashMap<String, MQTTTopic>>,
-    pub user_list: DashMap<String, DashMap<String, MQTTUser>>,
+    pub topic_list: DashMap<String, DashMap<String, MqttTopic>>,
+    pub user_list: DashMap<String, DashMap<String, MqttUser>>,
     pub expire_last_wills: DashMap<String, DashMap<String, ExpireLastWill>>,
 }
 
@@ -45,7 +45,7 @@ impl MqttCacheManager {
         cache
     }
 
-    pub fn add_topic(&self, cluster_name: &String, topic: MQTTTopic) {
+    pub fn add_topic(&self, cluster_name: &String, topic: MqttTopic) {
         if let Some(data) = self.topic_list.get_mut(cluster_name) {
             data.insert(topic.topic_name.clone(), topic);
         } else {
@@ -62,7 +62,7 @@ impl MqttCacheManager {
         }
     }
 
-    pub fn add_user(&self, cluster_name: &String, user: MQTTUser) {
+    pub fn add_user(&self, cluster_name: &String, user: MqttUser) {
         if let Some(data) = self.user_list.get_mut(cluster_name) {
             data.insert(user.username.clone(), user);
         } else {
@@ -99,7 +99,7 @@ impl MqttCacheManager {
     ) {
         for (_, cluster) in placement_cache.cluster_list.clone() {
             if cluster.cluster_type == *ClusterType::MqttBrokerServer.as_str_name() {
-                let topic = MQTTTopicStorage::new(rocksdb_engine_handler.clone());
+                let topic = MqttTopicStorage::new(rocksdb_engine_handler.clone());
                 match topic.list(&cluster.cluster_name) {
                     Ok(data) => {
                         for topic in data {
@@ -111,7 +111,7 @@ impl MqttCacheManager {
                     }
                 }
 
-                let user = MQTTUserStorage::new(rocksdb_engine_handler.clone());
+                let user = MqttUserStorage::new(rocksdb_engine_handler.clone());
                 match user.list(&cluster.cluster_name) {
                     Ok(data) => {
                         for user in data {

--- a/src/placement-center/src/controller/mqtt/call_broker.rs
+++ b/src/placement-center/src/controller/mqtt/call_broker.rs
@@ -19,7 +19,7 @@ use clients::poll::ClientPool;
 use common_base::tools::now_second;
 use log::{debug, error, warn};
 use metadata_struct::mqtt::lastwill::LastWillData;
-use metadata_struct::mqtt::session::MQTTSession;
+use metadata_struct::mqtt::session::MqttSession;
 use protocol::broker_server::generate::placement::{
     DeleteSessionRequest, SendLastWillMessageRequest,
 };
@@ -27,10 +27,10 @@ use protocol::broker_server::generate::placement::{
 use super::session_expire::ExpireLastWill;
 use crate::cache::mqtt::MqttCacheManager;
 use crate::cache::placement::PlacementCacheManager;
-use crate::storage::mqtt::session::MQTTSessionStorage;
+use crate::storage::mqtt::session::MqttSessionStorage;
 use crate::storage::rocksdb::RocksDBEngine;
 
-pub struct MQTTBrokerCall {
+pub struct MqttBrokerCall {
     cluster_name: String,
     placement_cache_manager: Arc<PlacementCacheManager>,
     rocksdb_engine_handler: Arc<RocksDBEngine>,
@@ -38,7 +38,7 @@ pub struct MQTTBrokerCall {
     mqtt_cache_manager: Arc<MqttCacheManager>,
 }
 
-impl MQTTBrokerCall {
+impl MqttBrokerCall {
     pub fn new(
         cluster_name: String,
         placement_cache_manager: Arc<PlacementCacheManager>,
@@ -46,7 +46,7 @@ impl MQTTBrokerCall {
         client_poll: Arc<ClientPool>,
         mqtt_cache_manager: Arc<MqttCacheManager>,
     ) -> Self {
-        MQTTBrokerCall {
+        MqttBrokerCall {
             cluster_name,
             placement_cache_manager,
             rocksdb_engine_handler,
@@ -55,8 +55,8 @@ impl MQTTBrokerCall {
         }
     }
 
-    pub async fn delete_sessions(&self, sessions: Vec<MQTTSession>) {
-        let chunks: Vec<Vec<MQTTSession>> = sessions
+    pub async fn delete_sessions(&self, sessions: Vec<MqttSession>) {
+        let chunks: Vec<Vec<MqttSession>> = sessions
             .chunks(100)
             .map(|chunk| chunk.to_vec()) // 将切片转换为Vec
             .collect();
@@ -89,7 +89,7 @@ impl MQTTBrokerCall {
             }
             debug!("Session expired call Broker status: {}", success);
             if success {
-                let session_storage = MQTTSessionStorage::new(self.rocksdb_engine_handler.clone());
+                let session_storage = MqttSessionStorage::new(self.rocksdb_engine_handler.clone());
                 for ms in raw {
                     match session_storage.delete(&self.cluster_name, &ms.client_id) {
                         Ok(()) => {

--- a/src/placement-center/src/controller/mqtt/message_expire.rs
+++ b/src/placement-center/src/controller/mqtt/message_expire.rs
@@ -19,14 +19,14 @@ use common_base::error::common::CommonError;
 use common_base::tools::now_second;
 use log::error;
 use metadata_struct::mqtt::lastwill::LastWillData;
-use metadata_struct::mqtt::topic::MQTTTopic;
+use metadata_struct::mqtt::topic::MqttTopic;
 use tokio::time::sleep;
 
 use crate::storage::keys::{
     storage_key_mqtt_last_will_prefix, storage_key_mqtt_topic_cluster_prefix,
 };
-use crate::storage::mqtt::lastwill::MQTTLastWillStorage;
-use crate::storage::mqtt::topic::MQTTTopicStorage;
+use crate::storage::mqtt::lastwill::MqttLastWillStorage;
+use crate::storage::mqtt::topic::MqttTopicStorage;
 use crate::storage::rocksdb::{RocksDBEngine, DB_COLUMN_FAMILY_CLUSTER};
 use crate::storage::StorageDataWrap;
 
@@ -45,7 +45,7 @@ impl MessageExpire {
 
     pub async fn retain_message_expire(&self) {
         let search_key = storage_key_mqtt_topic_cluster_prefix(&self.cluster_name);
-        let topic_storage = MQTTTopicStorage::new(self.rocksdb_engine_handler.clone());
+        let topic_storage = MqttTopicStorage::new(self.rocksdb_engine_handler.clone());
 
         let cf = if let Some(cf) = self
             .rocksdb_engine_handler
@@ -84,7 +84,7 @@ impl MessageExpire {
 
             let result_value = value.unwrap().to_vec();
             let data = serde_json::from_slice::<StorageDataWrap>(&result_value).unwrap();
-            let mut value = serde_json::from_slice::<MQTTTopic>(data.data.as_slice()).unwrap();
+            let mut value = serde_json::from_slice::<MqttTopic>(data.data.as_slice()).unwrap();
 
             if value.retain_message.is_some() {
                 let delete = if let Some(expired_at) = value.retain_message_expired_at {
@@ -110,7 +110,7 @@ impl MessageExpire {
 
     pub async fn last_will_message_expire(&self) {
         let search_key = storage_key_mqtt_last_will_prefix(&self.cluster_name);
-        let lastwill_storage = MQTTLastWillStorage::new(self.rocksdb_engine_handler.clone());
+        let lastwill_storage = MqttLastWillStorage::new(self.rocksdb_engine_handler.clone());
 
         let cf = if let Some(cf) = self
             .rocksdb_engine_handler
@@ -182,16 +182,16 @@ mod tests {
     use common_base::config::placement_center::placement_center_test_conf;
     use common_base::tools::{now_second, unique_id};
     use metadata_struct::mqtt::lastwill::LastWillData;
-    use metadata_struct::mqtt::message::MQTTMessage;
-    use metadata_struct::mqtt::session::MQTTSession;
-    use metadata_struct::mqtt::topic::MQTTTopic;
+    use metadata_struct::mqtt::message::MqttMessage;
+    use metadata_struct::mqtt::session::MqttSession;
+    use metadata_struct::mqtt::topic::MqttTopic;
     use protocol::mqtt::common::{LastWillProperties, Publish};
     use tokio::time::sleep;
 
     use super::MessageExpire;
-    use crate::storage::mqtt::lastwill::MQTTLastWillStorage;
-    use crate::storage::mqtt::session::MQTTSessionStorage;
-    use crate::storage::mqtt::topic::MQTTTopicStorage;
+    use crate::storage::mqtt::lastwill::MqttLastWillStorage;
+    use crate::storage::mqtt::session::MqttSessionStorage;
+    use crate::storage::mqtt::topic::MqttTopicStorage;
     use crate::storage::rocksdb::{column_family_list, RocksDBEngine};
 
     #[tokio::test]
@@ -207,14 +207,14 @@ mod tests {
         let message_expire =
             MessageExpire::new(cluster_name.clone(), rocksdb_engine_handler.clone());
 
-        let topic_storage = MQTTTopicStorage::new(rocksdb_engine_handler.clone());
-        let topic = MQTTTopic::new(unique_id(), "tp1".to_string());
+        let topic_storage = MqttTopicStorage::new(rocksdb_engine_handler.clone());
+        let topic = MqttTopic::new(unique_id(), "tp1".to_string());
         topic_storage
             .save(&cluster_name, &topic.topic_name.clone(), topic.clone())
             .unwrap();
 
         let retain_msg =
-            MQTTMessage::build_message(&"c1".to_string(), &Publish::default(), &None, 600);
+            MqttMessage::build_message(&"c1".to_string(), &Publish::default(), &None, 600);
         topic_storage
             .set_topic_retain_message(
                 &cluster_name,
@@ -255,8 +255,8 @@ mod tests {
             config.rocksdb.max_open_files.unwrap(),
             column_family_list(),
         ));
-        let lastwill_storage = MQTTLastWillStorage::new(rocksdb_engine_handler.clone());
-        let session_storage = MQTTSessionStorage::new(rocksdb_engine_handler.clone());
+        let lastwill_storage = MqttLastWillStorage::new(rocksdb_engine_handler.clone());
+        let session_storage = MqttSessionStorage::new(rocksdb_engine_handler.clone());
 
         let client_id = unique_id();
         let mut last_will_properties = LastWillProperties::default();
@@ -274,7 +274,7 @@ mod tests {
             }
         });
 
-        let mut session = MQTTSession::default();
+        let mut session = MqttSession::default();
         session.client_id = client_id.clone();
         session_storage
             .save(&cluster_name, &client_id, session)

--- a/src/placement-center/src/controller/mqtt/mod.rs
+++ b/src/placement-center/src/controller/mqtt/mod.rs
@@ -31,7 +31,7 @@ pub mod call_broker;
 pub mod message_expire;
 pub mod session_expire;
 
-pub struct MQTTController {
+pub struct MqttController {
     rocksdb_engine_handler: Arc<RocksDBEngine>,
     placement_center_cache: Arc<PlacementCacheManager>,
     mqtt_cache_manager: Arc<MqttCacheManager>,
@@ -40,15 +40,15 @@ pub struct MQTTController {
     stop_send: broadcast::Sender<bool>,
 }
 
-impl MQTTController {
+impl MqttController {
     pub fn new(
         rocksdb_engine_handler: Arc<RocksDBEngine>,
         placement_center_cache: Arc<PlacementCacheManager>,
         mqtt_cache_manager: Arc<MqttCacheManager>,
         client_poll: Arc<ClientPool>,
         stop_send: broadcast::Sender<bool>,
-    ) -> MQTTController {
-        MQTTController {
+    ) -> MqttController {
+        MqttController {
             rocksdb_engine_handler,
             placement_center_cache,
             mqtt_cache_manager,

--- a/src/placement-center/src/lib.rs
+++ b/src/placement-center/src/lib.rs
@@ -21,7 +21,7 @@ use cache::placement::PlacementCacheManager;
 use clients::poll::ClientPool;
 use common_base::config::placement_center::placement_center_conf;
 use controller::journal::controller::StorageEngineController;
-use controller::mqtt::MQTTController;
+use controller::mqtt::MqttController;
 use controller::placement::controller::ClusterController;
 use log::info;
 use openraft::Raft;
@@ -217,7 +217,7 @@ impl PlacementCenter {
             ctrl.start_node_heartbeat_check().await;
         });
 
-        let mqtt_controller = MQTTController::new(
+        let mqtt_controller = MqttController::new(
             self.rocksdb_engine_handler.clone(),
             self.cluster_cache.clone(),
             self.mqtt_cache.clone(),

--- a/src/placement-center/src/server/grpc/service_mqtt.rs
+++ b/src/placement-center/src/server/grpc/service_mqtt.rs
@@ -30,10 +30,10 @@ use tonic::{Request, Response, Status};
 use crate::cache::placement::PlacementCacheManager;
 use crate::core::share_sub::ShareSubLeader;
 use crate::storage::mqtt::acl::AclStorage;
-use crate::storage::mqtt::blacklist::MQTTBlackListStorage;
-use crate::storage::mqtt::session::MQTTSessionStorage;
-use crate::storage::mqtt::topic::MQTTTopicStorage;
-use crate::storage::mqtt::user::MQTTUserStorage;
+use crate::storage::mqtt::blacklist::MqttBlackListStorage;
+use crate::storage::mqtt::session::MqttSessionStorage;
+use crate::storage::mqtt::topic::MqttTopicStorage;
+use crate::storage::mqtt::user::MqttUserStorage;
 use crate::storage::rocksdb::RocksDBEngine;
 use crate::storage::route::apply::RaftMachineApply;
 use crate::storage::route::data::{StorageData, StorageDataType};
@@ -97,7 +97,7 @@ impl MqttService for GrpcMqttService {
         request: Request<ListUserRequest>,
     ) -> Result<Response<ListUserReply>, Status> {
         let req = request.into_inner();
-        let storage = MQTTUserStorage::new(self.rocksdb_engine_handler.clone());
+        let storage = MqttUserStorage::new(self.rocksdb_engine_handler.clone());
 
         if !req.user_name.is_empty() {
             match storage.get(&req.cluster_name, &req.user_name) {
@@ -208,7 +208,7 @@ impl MqttService for GrpcMqttService {
         request: Request<ListTopicRequest>,
     ) -> Result<Response<ListTopicReply>, Status> {
         let req = request.into_inner();
-        let storage = MQTTTopicStorage::new(self.rocksdb_engine_handler.clone());
+        let storage = MqttTopicStorage::new(self.rocksdb_engine_handler.clone());
         if !req.topic_name.is_empty() {
             match storage.get(&req.cluster_name, &req.topic_name) {
                 Ok(Some(data)) => {
@@ -244,7 +244,7 @@ impl MqttService for GrpcMqttService {
         request: Request<ListSessionRequest>,
     ) -> Result<Response<ListSessionReply>, Status> {
         let req = request.into_inner();
-        let storage = MQTTSessionStorage::new(self.rocksdb_engine_handler.clone());
+        let storage = MqttSessionStorage::new(self.rocksdb_engine_handler.clone());
 
         if !req.client_id.is_empty() {
             match storage.get(&req.cluster_name, &req.client_id) {
@@ -435,7 +435,7 @@ impl MqttService for GrpcMqttService {
         request: Request<ListBlacklistRequest>,
     ) -> Result<Response<ListBlacklistReply>, Status> {
         let req = request.into_inner();
-        let blacklist_storage = MQTTBlackListStorage::new(self.rocksdb_engine_handler.clone());
+        let blacklist_storage = MqttBlackListStorage::new(self.rocksdb_engine_handler.clone());
         match blacklist_storage.list(&req.cluster_name) {
             Ok(list) => {
                 let mut blacklists = Vec::new();

--- a/src/placement-center/src/storage/mqtt/acl.rs
+++ b/src/placement-center/src/storage/mqtt/acl.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use common_base::error::common::CommonError;
-use metadata_struct::acl::mqtt_acl::MQTTAcl;
+use metadata_struct::acl::mqtt_acl::MqttAcl;
 
 use crate::storage::engine::{
     engine_get_by_cluster, engine_prefix_list_by_cluster, engine_save_by_cluster,
@@ -34,7 +34,7 @@ impl AclStorage {
         }
     }
 
-    pub fn save(&self, cluster_name: &String, acl: MQTTAcl) -> Result<(), CommonError> {
+    pub fn save(&self, cluster_name: &String, acl: MqttAcl) -> Result<(), CommonError> {
         let mut acl_list = self.get(
             cluster_name,
             &acl.resource_type.to_string(),
@@ -55,13 +55,13 @@ impl AclStorage {
         engine_save_by_cluster(self.rocksdb_engine_handler.clone(), key, acl_list)
     }
 
-    pub fn list(&self, cluster_name: &String) -> Result<Vec<MQTTAcl>, CommonError> {
+    pub fn list(&self, cluster_name: &String) -> Result<Vec<MqttAcl>, CommonError> {
         let prefix_key = storage_key_mqtt_acl_prefix(cluster_name);
         match engine_prefix_list_by_cluster(self.rocksdb_engine_handler.clone(), prefix_key) {
             Ok(data) => {
                 let mut results = Vec::new();
                 for raw in data {
-                    match serde_json::from_slice::<Vec<MQTTAcl>>(&raw.data) {
+                    match serde_json::from_slice::<Vec<MqttAcl>>(&raw.data) {
                         Ok(acl_list) => {
                             results.extend(acl_list);
                         }
@@ -76,7 +76,7 @@ impl AclStorage {
         }
     }
 
-    pub fn delete(&self, cluster_name: &String, delete_acl: &MQTTAcl) -> Result<(), CommonError> {
+    pub fn delete(&self, cluster_name: &String, delete_acl: &MqttAcl) -> Result<(), CommonError> {
         let acl_list = self.get(
             cluster_name,
             &delete_acl.resource_type.to_string(),
@@ -110,10 +110,10 @@ impl AclStorage {
         cluster_name: &String,
         resource_type: &String,
         resource_name: &String,
-    ) -> Result<Vec<MQTTAcl>, CommonError> {
+    ) -> Result<Vec<MqttAcl>, CommonError> {
         let key = storage_key_mqtt_acl(cluster_name, resource_type, resource_name);
         match engine_get_by_cluster(self.rocksdb_engine_handler.clone(), key) {
-            Ok(Some(data)) => match serde_json::from_slice::<Vec<MQTTAcl>>(&data.data) {
+            Ok(Some(data)) => match serde_json::from_slice::<Vec<MqttAcl>>(&data.data) {
                 Ok(session) => Ok(session),
                 Err(e) => Err(e.into()),
             },
@@ -122,7 +122,7 @@ impl AclStorage {
         }
     }
 
-    fn acl_exists(&self, acl_list: &Vec<MQTTAcl>, acl: &MQTTAcl) -> bool {
+    fn acl_exists(&self, acl_list: &Vec<MqttAcl>, acl: &MqttAcl) -> bool {
         for raw in acl_list {
             if !(raw.permission == acl.permission
                 && raw.action == acl.action

--- a/src/placement-center/src/storage/mqtt/blacklist.rs
+++ b/src/placement-center/src/storage/mqtt/blacklist.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use common_base::error::common::CommonError;
-use metadata_struct::acl::mqtt_blacklist::MQTTAclBlackList;
+use metadata_struct::acl::mqtt_blacklist::MqttAclBlackList;
 
 use crate::storage::engine::{
     engine_delete_by_cluster, engine_prefix_list_by_cluster, engine_save_by_cluster,
@@ -23,13 +23,13 @@ use crate::storage::engine::{
 use crate::storage::keys::{storage_key_mqtt_blacklist, storage_key_mqtt_blacklist_prefix};
 use crate::storage::rocksdb::RocksDBEngine;
 
-pub struct MQTTBlackListStorage {
+pub struct MqttBlackListStorage {
     rocksdb_engine_handler: Arc<RocksDBEngine>,
 }
 
-impl MQTTBlackListStorage {
+impl MqttBlackListStorage {
     pub fn new(rocksdb_engine_handler: Arc<RocksDBEngine>) -> Self {
-        MQTTBlackListStorage {
+        MqttBlackListStorage {
             rocksdb_engine_handler,
         }
     }
@@ -37,7 +37,7 @@ impl MQTTBlackListStorage {
     pub fn save(
         &self,
         cluster_name: &String,
-        blacklist: MQTTAclBlackList,
+        blacklist: MqttAclBlackList,
     ) -> Result<(), CommonError> {
         let key = storage_key_mqtt_blacklist(
             cluster_name,
@@ -47,13 +47,13 @@ impl MQTTBlackListStorage {
         engine_save_by_cluster(self.rocksdb_engine_handler.clone(), key, blacklist)
     }
 
-    pub fn list(&self, cluster_name: &String) -> Result<Vec<MQTTAclBlackList>, CommonError> {
+    pub fn list(&self, cluster_name: &String) -> Result<Vec<MqttAclBlackList>, CommonError> {
         let prefix_key = storage_key_mqtt_blacklist_prefix(cluster_name);
         match engine_prefix_list_by_cluster(self.rocksdb_engine_handler.clone(), prefix_key) {
             Ok(data) => {
                 let mut results = Vec::new();
                 for raw in data {
-                    match serde_json::from_slice::<MQTTAclBlackList>(&raw.data) {
+                    match serde_json::from_slice::<MqttAclBlackList>(&raw.data) {
                         Ok(blacklist) => {
                             results.push(blacklist);
                         }

--- a/src/placement-center/src/storage/mqtt/lastwill.rs
+++ b/src/placement-center/src/storage/mqtt/lastwill.rs
@@ -30,20 +30,20 @@ use common_base::error::common::CommonError;
 use common_base::error::mqtt_broker::MQTTBrokerError;
 use metadata_struct::mqtt::lastwill::LastWillData;
 
-use super::session::MQTTSessionStorage;
+use super::session::MqttSessionStorage;
 use crate::storage::engine::{
     engine_delete_by_cluster, engine_get_by_cluster, engine_save_by_cluster,
 };
 use crate::storage::keys::storage_key_mqtt_last_will;
 use crate::storage::rocksdb::RocksDBEngine;
 
-pub struct MQTTLastWillStorage {
+pub struct MqttLastWillStorage {
     rocksdb_engine_handler: Arc<RocksDBEngine>,
 }
 
-impl MQTTLastWillStorage {
+impl MqttLastWillStorage {
     pub fn new(rocksdb_engine_handler: Arc<RocksDBEngine>) -> Self {
-        MQTTLastWillStorage {
+        MqttLastWillStorage {
             rocksdb_engine_handler,
         }
     }
@@ -54,7 +54,7 @@ impl MQTTLastWillStorage {
         client_id: &String,
         last_will_message: LastWillData,
     ) -> Result<(), CommonError> {
-        let session_storage = MQTTSessionStorage::new(self.rocksdb_engine_handler.clone());
+        let session_storage = MqttSessionStorage::new(self.rocksdb_engine_handler.clone());
         let results = session_storage.get(cluster_name, client_id)?;
         if results.is_none() {
             return Err(MQTTBrokerError::SessionDoesNotExist.into());
@@ -93,10 +93,10 @@ mod tests {
 
     use common_base::config::placement_center::placement_center_test_conf;
     use metadata_struct::mqtt::lastwill::LastWillData;
-    use metadata_struct::mqtt::session::MQTTSession;
+    use metadata_struct::mqtt::session::MqttSession;
 
-    use super::MQTTLastWillStorage;
-    use crate::storage::mqtt::session::MQTTSessionStorage;
+    use super::MqttLastWillStorage;
+    use crate::storage::mqtt::session::MqttSessionStorage;
     use crate::storage::rocksdb::{column_family_list, RocksDBEngine};
 
     #[tokio::test]
@@ -108,17 +108,17 @@ mod tests {
             config.rocksdb.max_open_files.unwrap(),
             column_family_list(),
         ));
-        let session_storage = MQTTSessionStorage::new(rs.clone());
+        let session_storage = MqttSessionStorage::new(rs.clone());
 
         let cluster_name = "test_cluster".to_string();
         let client_id = "loboxu".to_string();
-        let session = MQTTSession::default();
+        let session = MqttSession::default();
 
         session_storage
             .save(&cluster_name, &client_id, session)
             .unwrap();
 
-        let lastwill_storage = MQTTLastWillStorage::new(rs.clone());
+        let lastwill_storage = MqttLastWillStorage::new(rs.clone());
         let last_will_message = LastWillData {
             client_id: client_id.clone(),
             last_will: None,

--- a/src/placement-center/src/storage/mqtt/session.rs
+++ b/src/placement-center/src/storage/mqtt/session.rs
@@ -27,7 +27,7 @@
 use std::sync::Arc;
 
 use common_base::error::common::CommonError;
-use metadata_struct::mqtt::session::MQTTSession;
+use metadata_struct::mqtt::session::MqttSession;
 
 use crate::storage::engine::{
     engine_delete_by_cluster, engine_get_by_cluster, engine_prefix_list_by_cluster,
@@ -37,13 +37,13 @@ use crate::storage::keys::{storage_key_mqtt_session, storage_key_mqtt_session_cl
 use crate::storage::rocksdb::RocksDBEngine;
 use crate::storage::StorageDataWrap;
 
-pub struct MQTTSessionStorage {
+pub struct MqttSessionStorage {
     rocksdb_engine_handler: Arc<RocksDBEngine>,
 }
 
-impl MQTTSessionStorage {
+impl MqttSessionStorage {
     pub fn new(rocksdb_engine_handler: Arc<RocksDBEngine>) -> Self {
-        MQTTSessionStorage {
+        MqttSessionStorage {
             rocksdb_engine_handler,
         }
     }
@@ -51,7 +51,7 @@ impl MQTTSessionStorage {
         &self,
         cluster_name: &String,
         client_id: &String,
-        session: MQTTSession,
+        session: MqttSession,
     ) -> Result<(), CommonError> {
         let key = storage_key_mqtt_session(cluster_name, client_id);
         engine_save_by_cluster(self.rocksdb_engine_handler.clone(), key, session)
@@ -66,10 +66,10 @@ impl MQTTSessionStorage {
         &self,
         cluster_name: &String,
         client_id: &String,
-    ) -> Result<Option<MQTTSession>, CommonError> {
+    ) -> Result<Option<MqttSession>, CommonError> {
         let key: String = storage_key_mqtt_session(cluster_name, client_id);
         match engine_get_by_cluster(self.rocksdb_engine_handler.clone(), key) {
-            Ok(Some(data)) => match serde_json::from_slice::<MQTTSession>(&data.data) {
+            Ok(Some(data)) => match serde_json::from_slice::<MqttSession>(&data.data) {
                 Ok(session) => Ok(Some(session)),
                 Err(e) => Err(e.into()),
             },
@@ -90,9 +90,9 @@ mod tests {
     use std::sync::Arc;
 
     use common_base::config::placement_center::placement_center_test_conf;
-    use metadata_struct::mqtt::session::MQTTSession;
+    use metadata_struct::mqtt::session::MqttSession;
 
-    use crate::storage::mqtt::session::MQTTSessionStorage;
+    use crate::storage::mqtt::session::MqttSessionStorage;
     use crate::storage::rocksdb::{column_family_list, RocksDBEngine};
 
     #[tokio::test]
@@ -103,16 +103,16 @@ mod tests {
             config.rocksdb.max_open_files.unwrap(),
             column_family_list(),
         ));
-        let session_storage = MQTTSessionStorage::new(rs);
+        let session_storage = MqttSessionStorage::new(rs);
         let cluster_name = "test_cluster".to_string();
         let client_id = "loboxu".to_string();
-        let session = MQTTSession::default();
+        let session = MqttSession::default();
         session_storage
             .save(&cluster_name, &client_id, session)
             .unwrap();
 
         let client_id = "lobo1".to_string();
-        let session = MQTTSession::default();
+        let session = MqttSession::default();
         session_storage
             .save(&cluster_name, &client_id, session)
             .unwrap();

--- a/src/placement-center/src/storage/mqtt/topic.rs
+++ b/src/placement-center/src/storage/mqtt/topic.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use common_base::error::common::CommonError;
 use common_base::error::mqtt_broker::MQTTBrokerError;
-use metadata_struct::mqtt::topic::MQTTTopic;
+use metadata_struct::mqtt::topic::MqttTopic;
 
 use crate::storage::engine::{
     engine_delete_by_cluster, engine_get_by_cluster, engine_prefix_list_by_cluster,
@@ -25,13 +25,13 @@ use crate::storage::engine::{
 use crate::storage::keys::{storage_key_mqtt_topic, storage_key_mqtt_topic_cluster_prefix};
 use crate::storage::rocksdb::RocksDBEngine;
 
-pub struct MQTTTopicStorage {
+pub struct MqttTopicStorage {
     rocksdb_engine_handler: Arc<RocksDBEngine>,
 }
 
-impl MQTTTopicStorage {
+impl MqttTopicStorage {
     pub fn new(rocksdb_engine_handler: Arc<RocksDBEngine>) -> Self {
-        MQTTTopicStorage {
+        MqttTopicStorage {
             rocksdb_engine_handler,
         }
     }
@@ -40,19 +40,19 @@ impl MQTTTopicStorage {
         &self,
         cluster_name: &String,
         topic_name: &String,
-        topic: MQTTTopic,
+        topic: MqttTopic,
     ) -> Result<(), CommonError> {
         let key = storage_key_mqtt_topic(cluster_name, topic_name);
         engine_save_by_cluster(self.rocksdb_engine_handler.clone(), key, topic)
     }
 
-    pub fn list(&self, cluster_name: &String) -> Result<Vec<MQTTTopic>, CommonError> {
+    pub fn list(&self, cluster_name: &String) -> Result<Vec<MqttTopic>, CommonError> {
         let prefix_key = storage_key_mqtt_topic_cluster_prefix(cluster_name);
         match engine_prefix_list_by_cluster(self.rocksdb_engine_handler.clone(), prefix_key) {
             Ok(data) => {
                 let mut results = Vec::new();
                 for raw in data {
-                    match serde_json::from_slice::<MQTTTopic>(&raw.data) {
+                    match serde_json::from_slice::<MqttTopic>(&raw.data) {
                         Ok(topic) => {
                             results.push(topic);
                         }
@@ -71,10 +71,10 @@ impl MQTTTopicStorage {
         &self,
         cluster_name: &String,
         topicname: &String,
-    ) -> Result<Option<MQTTTopic>, CommonError> {
+    ) -> Result<Option<MqttTopic>, CommonError> {
         let key: String = storage_key_mqtt_topic(cluster_name, topicname);
         match engine_get_by_cluster(self.rocksdb_engine_handler.clone(), key) {
-            Ok(Some(data)) => match serde_json::from_slice::<MQTTTopic>(&data.data) {
+            Ok(Some(data)) => match serde_json::from_slice::<MqttTopic>(&data.data) {
                 Ok(lastwill) => Ok(Some(lastwill)),
                 Err(e) => Err(e.into()),
             },
@@ -121,10 +121,10 @@ mod tests {
     use std::sync::Arc;
 
     use common_base::config::placement_center::placement_center_test_conf;
-    use metadata_struct::mqtt::topic::MQTTTopic;
+    use metadata_struct::mqtt::topic::MqttTopic;
     use tokio::fs::remove_dir_all;
 
-    use crate::storage::mqtt::topic::MQTTTopicStorage;
+    use crate::storage::mqtt::topic::MqttTopicStorage;
     use crate::storage::rocksdb::{column_family_list, RocksDBEngine};
 
     #[tokio::test]
@@ -136,10 +136,10 @@ mod tests {
             config.rocksdb.max_open_files.unwrap(),
             column_family_list(),
         ));
-        let topic_storage = MQTTTopicStorage::new(rs);
+        let topic_storage = MqttTopicStorage::new(rs);
         let cluster_name = "test_cluster".to_string();
         let topic_name = "loboxu".to_string();
-        let topic = MQTTTopic {
+        let topic = MqttTopic {
             topic_id: "xxx".to_string(),
             topic_name: topic_name.clone(),
             retain_message: None,
@@ -150,7 +150,7 @@ mod tests {
             .unwrap();
 
         let topic_name = "lobo1".to_string();
-        let topic = MQTTTopic {
+        let topic = MqttTopic {
             topic_id: "xxx".to_string(),
             topic_name: topic_name.clone(),
             retain_message: None,

--- a/src/placement-center/src/storage/mqtt/user.rs
+++ b/src/placement-center/src/storage/mqtt/user.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use common_base::error::common::CommonError;
-use metadata_struct::mqtt::user::MQTTUser;
+use metadata_struct::mqtt::user::MqttUser;
 
 use crate::storage::engine::{
     engine_delete_by_cluster, engine_get_by_cluster, engine_prefix_list_by_cluster,
@@ -24,13 +24,13 @@ use crate::storage::engine::{
 use crate::storage::keys::{storage_key_mqtt_user, storage_key_mqtt_user_cluster_prefix};
 use crate::storage::rocksdb::RocksDBEngine;
 
-pub struct MQTTUserStorage {
+pub struct MqttUserStorage {
     rocksdb_engine_handler: Arc<RocksDBEngine>,
 }
 
-impl MQTTUserStorage {
+impl MqttUserStorage {
     pub fn new(rocksdb_engine_handler: Arc<RocksDBEngine>) -> Self {
-        MQTTUserStorage {
+        MqttUserStorage {
             rocksdb_engine_handler,
         }
     }
@@ -39,19 +39,19 @@ impl MQTTUserStorage {
         &self,
         cluster_name: &String,
         user_name: &String,
-        user: MQTTUser,
+        user: MqttUser,
     ) -> Result<(), CommonError> {
         let key = storage_key_mqtt_user(cluster_name, user_name);
         engine_save_by_cluster(self.rocksdb_engine_handler.clone(), key, user)
     }
 
-    pub fn list(&self, cluster_name: &String) -> Result<Vec<MQTTUser>, CommonError> {
+    pub fn list(&self, cluster_name: &String) -> Result<Vec<MqttUser>, CommonError> {
         let prefix_key = storage_key_mqtt_user_cluster_prefix(cluster_name);
         match engine_prefix_list_by_cluster(self.rocksdb_engine_handler.clone(), prefix_key) {
             Ok(data) => {
                 let mut results = Vec::new();
                 for raw in data {
-                    match serde_json::from_slice::<MQTTUser>(&raw.data) {
+                    match serde_json::from_slice::<MqttUser>(&raw.data) {
                         Ok(topic) => {
                             results.push(topic);
                         }
@@ -70,10 +70,10 @@ impl MQTTUserStorage {
         &self,
         cluster_name: &String,
         username: &String,
-    ) -> Result<Option<MQTTUser>, CommonError> {
+    ) -> Result<Option<MqttUser>, CommonError> {
         let key: String = storage_key_mqtt_user(cluster_name, username);
         match engine_get_by_cluster(self.rocksdb_engine_handler.clone(), key) {
-            Ok(Some(data)) => match serde_json::from_slice::<MQTTUser>(&data.data) {
+            Ok(Some(data)) => match serde_json::from_slice::<MqttUser>(&data.data) {
                 Ok(user) => Ok(Some(user)),
                 Err(e) => Err(e.into()),
             },
@@ -94,9 +94,9 @@ mod tests {
     use std::sync::Arc;
 
     use common_base::config::placement_center::placement_center_test_conf;
-    use metadata_struct::mqtt::user::MQTTUser;
+    use metadata_struct::mqtt::user::MqttUser;
 
-    use crate::storage::mqtt::user::MQTTUserStorage;
+    use crate::storage::mqtt::user::MqttUserStorage;
     use crate::storage::rocksdb::{column_family_list, RocksDBEngine};
 
     #[tokio::test]
@@ -108,10 +108,10 @@ mod tests {
             config.rocksdb.max_open_files.unwrap(),
             column_family_list(),
         ));
-        let user_storage = MQTTUserStorage::new(rs);
+        let user_storage = MqttUserStorage::new(rs);
         let cluster_name = "test_cluster".to_string();
         let username = "loboxu".to_string();
-        let user = MQTTUser {
+        let user = MqttUser {
             username: username.clone(),
             password: "pwd123".to_string(),
             is_superuser: true,
@@ -119,7 +119,7 @@ mod tests {
         user_storage.save(&cluster_name, &username, user).unwrap();
 
         let username = "lobo1".to_string();
-        let user = MQTTUser {
+        let user = MqttUser {
             username: username.clone(),
             password: "pwd1231".to_string(),
             is_superuser: true,

--- a/src/placement-center/src/storage/route/cluster.rs
+++ b/src/placement-center/src/storage/route/cluster.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 
 use common_base::error::common::CommonError;
 use common_base::tools::{now_mills, unique_id};
-use metadata_struct::acl::mqtt_acl::MQTTAcl;
-use metadata_struct::acl::mqtt_blacklist::MQTTAclBlackList;
+use metadata_struct::acl::mqtt_acl::MqttAcl;
+use metadata_struct::acl::mqtt_blacklist::MqttAclBlackList;
 use metadata_struct::placement::broker_node::BrokerNode;
 use metadata_struct::placement::cluster::ClusterInfo;
 use prost::Message as _;
@@ -31,7 +31,7 @@ use protocol::placement_center::generate::placement::{
 
 use crate::cache::placement::PlacementCacheManager;
 use crate::storage::mqtt::acl::AclStorage;
-use crate::storage::mqtt::blacklist::MQTTBlackListStorage;
+use crate::storage::mqtt::blacklist::MqttBlackListStorage;
 use crate::storage::placement::cluster::ClusterStorage;
 use crate::storage::placement::config::ResourceConfigStorage;
 use crate::storage::placement::idempotent::IdempotentStorage;
@@ -127,27 +127,27 @@ impl DataRouteCluster {
     pub fn create_acl(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = CreateAclRequest::decode(value.as_ref())?;
         let acl_storage = AclStorage::new(self.rocksdb_engine_handler.clone());
-        let acl = serde_json::from_slice::<MQTTAcl>(&req.acl)?;
+        let acl = serde_json::from_slice::<MqttAcl>(&req.acl)?;
         acl_storage.save(&req.cluster_name, acl)
     }
 
     pub fn delete_acl(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = DeleteAclRequest::decode(value.as_ref())?;
         let acl_storage = AclStorage::new(self.rocksdb_engine_handler.clone());
-        let acl = serde_json::from_slice::<MQTTAcl>(&req.acl)?;
+        let acl = serde_json::from_slice::<MqttAcl>(&req.acl)?;
         acl_storage.delete(&req.cluster_name, &acl)
     }
 
     pub fn create_blacklist(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = CreateBlacklistRequest::decode(value.as_ref())?;
-        let blacklist_storage = MQTTBlackListStorage::new(self.rocksdb_engine_handler.clone());
-        let blacklist = serde_json::from_slice::<MQTTAclBlackList>(&req.blacklist)?;
+        let blacklist_storage = MqttBlackListStorage::new(self.rocksdb_engine_handler.clone());
+        let blacklist = serde_json::from_slice::<MqttAclBlackList>(&req.blacklist)?;
         blacklist_storage.save(&req.cluster_name, blacklist)
     }
 
     pub fn delete_blacklist(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = DeleteBlacklistRequest::decode(value.as_ref())?;
-        let blacklist_storage = MQTTBlackListStorage::new(self.rocksdb_engine_handler.clone());
+        let blacklist_storage = MqttBlackListStorage::new(self.rocksdb_engine_handler.clone());
         blacklist_storage.delete(&req.cluster_name, &req.blacklist_type, &req.resource_name)
     }
 }

--- a/src/placement-center/src/storage/route/mqtt.rs
+++ b/src/placement-center/src/storage/route/mqtt.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use common_base::error::common::CommonError;
 use common_base::error::mqtt_broker::MQTTBrokerError;
-use metadata_struct::mqtt::session::MQTTSession;
+use metadata_struct::mqtt::session::MqttSession;
 use prost::Message as _;
 use protocol::placement_center::generate::mqtt::{
     CreateSessionRequest, CreateTopicRequest, CreateUserRequest, DeleteSessionRequest,
@@ -24,10 +24,10 @@ use protocol::placement_center::generate::mqtt::{
     SetTopicRetainMessageRequest, UpdateSessionRequest,
 };
 
-use crate::storage::mqtt::lastwill::MQTTLastWillStorage;
-use crate::storage::mqtt::session::MQTTSessionStorage;
-use crate::storage::mqtt::topic::MQTTTopicStorage;
-use crate::storage::mqtt::user::MQTTUserStorage;
+use crate::storage::mqtt::lastwill::MqttLastWillStorage;
+use crate::storage::mqtt::session::MqttSessionStorage;
+use crate::storage::mqtt::topic::MqttTopicStorage;
+use crate::storage::mqtt::user::MqttUserStorage;
 use crate::storage::rocksdb::RocksDBEngine;
 
 #[derive(Debug, Clone)]
@@ -43,34 +43,34 @@ impl DataRouteMQTT {
 
     pub fn create_user(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = CreateUserRequest::decode(value.as_ref())?;
-        let storage = MQTTUserStorage::new(self.rocksdb_engine_handler.clone());
+        let storage = MqttUserStorage::new(self.rocksdb_engine_handler.clone());
         let user = serde_json::from_slice(&req.content)?;
         storage.save(&req.cluster_name, &req.user_name, user)
     }
 
     pub fn delete_user(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = DeleteUserRequest::decode(value.as_ref())?;
-        let storage = MQTTUserStorage::new(self.rocksdb_engine_handler.clone());
+        let storage = MqttUserStorage::new(self.rocksdb_engine_handler.clone());
         storage.delete(&req.cluster_name, &req.user_name)
     }
 
     pub fn create_topic(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = CreateTopicRequest::decode(value.as_ref())?;
-        let storage = MQTTTopicStorage::new(self.rocksdb_engine_handler.clone());
+        let storage = MqttTopicStorage::new(self.rocksdb_engine_handler.clone());
         let topic = serde_json::from_slice(&req.content)?;
         storage.save(&req.cluster_name, &req.topic_name, topic)
     }
 
     pub fn delete_topic(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = DeleteTopicRequest::decode(value.as_ref())?;
-        let storage = MQTTTopicStorage::new(self.rocksdb_engine_handler.clone());
+        let storage = MqttTopicStorage::new(self.rocksdb_engine_handler.clone());
         storage.delete(&req.cluster_name, &req.topic_name)
     }
 
     pub fn set_topic_retain_message(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req: SetTopicRetainMessageRequest =
             SetTopicRetainMessageRequest::decode(value.as_ref())?;
-        let storage = MQTTTopicStorage::new(self.rocksdb_engine_handler.clone());
+        let storage = MqttTopicStorage::new(self.rocksdb_engine_handler.clone());
         storage.set_topic_retain_message(
             &req.cluster_name,
             &req.topic_name,
@@ -81,21 +81,21 @@ impl DataRouteMQTT {
 
     pub fn save_last_will_message(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = SaveLastWillMessageRequest::decode(value.as_ref())?;
-        let storage = MQTTLastWillStorage::new(self.rocksdb_engine_handler.clone());
+        let storage = MqttLastWillStorage::new(self.rocksdb_engine_handler.clone());
         let last_will_message = serde_json::from_slice(&req.last_will_message)?;
         storage.save(&req.cluster_name, &req.client_id, last_will_message)
     }
 
     pub fn create_session(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = CreateSessionRequest::decode(value.as_ref())?;
-        let storage = MQTTSessionStorage::new(self.rocksdb_engine_handler.clone());
-        let session = serde_json::from_slice::<MQTTSession>(&req.session)?;
+        let storage = MqttSessionStorage::new(self.rocksdb_engine_handler.clone());
+        let session = serde_json::from_slice::<MqttSession>(&req.session)?;
         storage.save(&req.cluster_name, &req.client_id, session)
     }
 
     pub fn update_session(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = UpdateSessionRequest::decode(value.as_ref())?;
-        let storage = MQTTSessionStorage::new(self.rocksdb_engine_handler.clone());
+        let storage = MqttSessionStorage::new(self.rocksdb_engine_handler.clone());
         let result = storage.get(&req.cluster_name, &req.client_id)?;
         if result.is_none() {
             return Err(MQTTBrokerError::SessionDoesNotExist.into());
@@ -130,7 +130,7 @@ impl DataRouteMQTT {
 
     pub fn delete_session(&self, value: Vec<u8>) -> Result<(), CommonError> {
         let req = DeleteSessionRequest::decode(value.as_ref())?;
-        let storage = MQTTSessionStorage::new(self.rocksdb_engine_handler.clone());
+        let storage = MqttSessionStorage::new(self.rocksdb_engine_handler.clone());
         storage.delete(&req.cluster_name, &req.client_id)
     }
 }

--- a/src/protocol/src/mqtt/codec.rs
+++ b/src/protocol/src/mqtt/codec.rs
@@ -18,7 +18,7 @@ use tokio_util::codec;
 use crate::mqtt::common::{check, connect_read, Error, LastWillProperties, MQTTPacket, PacketType};
 
 #[derive(Debug, Clone)]
-pub struct MQTTPacketWrapper {
+pub struct MqttPacketWrapper {
     pub protocol_version: u8,
     pub packet: MQTTPacket,
 }
@@ -221,7 +221,7 @@ impl MqttCodec {
 
     pub fn encode_data(
         &mut self,
-        packet_wrapper: MQTTPacketWrapper,
+        packet_wrapper: MqttPacketWrapper,
         buffer: &mut BytesMut,
     ) -> Result<(), crate::mqtt::common::Error> {
         let packet = packet_wrapper.packet;
@@ -280,11 +280,11 @@ impl MqttCodec {
     }
 }
 
-impl codec::Encoder<MQTTPacketWrapper> for MqttCodec {
+impl codec::Encoder<MqttPacketWrapper> for MqttCodec {
     type Error = crate::mqtt::common::Error;
     fn encode(
         &mut self,
-        packet_wrapper: MQTTPacketWrapper,
+        packet_wrapper: MqttPacketWrapper,
         buffer: &mut BytesMut,
     ) -> Result<(), Self::Error> {
         self.encode_data(packet_wrapper, buffer)
@@ -299,12 +299,12 @@ impl codec::Decoder for MqttCodec {
     }
 }
 
-pub fn calc_mqtt_packet_size(packet_wrapper: MQTTPacketWrapper) -> usize {
+pub fn calc_mqtt_packet_size(packet_wrapper: MqttPacketWrapper) -> usize {
     calc_mqtt_packet_len(packet_wrapper).unwrap_or_default()
 }
 
 fn calc_mqtt_packet_len(
-    packet_wrapper: MQTTPacketWrapper,
+    packet_wrapper: MqttPacketWrapper,
 ) -> Result<usize, crate::mqtt::common::Error> {
     let packet = packet_wrapper.packet;
     let protocol_version = packet_wrapper.protocol_version;

--- a/src/protocol/src/placement_center/generate/mqtt.rs
+++ b/src/protocol/src/placement_center/generate/mqtt.rs
@@ -48,7 +48,7 @@ pub struct ListUserRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListUserReply {
-    /// The parameter contains a list of users, encoded from a `Vec<MQTTTopic>` into a binary format.
+    /// The parameter contains a list of users, encoded from a `Vec<MqttTopic>` into a binary format.
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub users: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
@@ -61,7 +61,7 @@ pub struct CreateUserRequest {
     /// The name of the user.
     #[prost(string, tag = "2")]
     pub user_name: ::prost::alloc::string::String,
-    /// The parameter contains user information, encoded from a `MQTTUser` object into a binary format.
+    /// The parameter contains user information, encoded from a `MqttUser` object into a binary format.
     #[prost(bytes = "vec", tag = "3")]
     pub content: ::prost::alloc::vec::Vec<u8>,
 }
@@ -88,7 +88,7 @@ pub struct ListTopicRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListTopicReply {
-    /// The parameter contains a list of topics, encoded from a `Vec<MQTTTopic>` into a binary format.
+    /// The parameter contains a list of topics, encoded from a `Vec<MqttTopic>` into a binary format.
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub topics: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
@@ -101,7 +101,7 @@ pub struct CreateTopicRequest {
     /// The name of the topic.
     #[prost(string, tag = "2")]
     pub topic_name: ::prost::alloc::string::String,
-    /// The parameter contains topic information, encoded from a `MQTTTopic` object into a binary format.
+    /// The parameter contains topic information, encoded from a `MqttTopic` object into a binary format.
     #[prost(bytes = "vec", tag = "3")]
     pub content: ::prost::alloc::vec::Vec<u8>,
 }
@@ -124,7 +124,7 @@ pub struct SetTopicRetainMessageRequest {
     /// The name of the topic.
     #[prost(string, tag = "2")]
     pub topic_name: ::prost::alloc::string::String,
-    /// The parameter contains retain message, encoded from a `MQTTMessage` object into a binary format.
+    /// The parameter contains retain message, encoded from a `MqttMessage` object into a binary format.
     #[prost(bytes = "vec", tag = "3")]
     pub retain_message: ::prost::alloc::vec::Vec<u8>,
     /// The parameter is the expiration time of the retain message. The unit is seconds.
@@ -144,7 +144,7 @@ pub struct ListSessionRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListSessionReply {
-    /// The parameter contains a list of sessions, encoded from a `Vec<MQTTSession>` into a binary format.
+    /// The parameter contains a list of sessions, encoded from a `Vec<MqttSession>` into a binary format.
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub sessions: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
@@ -157,7 +157,7 @@ pub struct CreateSessionRequest {
     /// The id of the client.
     #[prost(string, tag = "2")]
     pub client_id: ::prost::alloc::string::String,
-    /// The parameter contains session information, encoded from a `MQTTSession` object into a binary format.
+    /// The parameter contains session information, encoded from a `MqttSession` object into a binary format.
     #[prost(bytes = "vec", tag = "3")]
     pub session: ::prost::alloc::vec::Vec<u8>,
 }
@@ -216,7 +216,7 @@ pub struct ListAclRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListAclReply {
-    /// The parameter contains a list of acls, encoded from a `Vec<MQTTAcl>` into a binary format.
+    /// The parameter contains a list of acls, encoded from a `Vec<MqttAcl>` into a binary format.
     #[prost(bytes = "vec", repeated, tag = "2")]
     pub acls: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
@@ -226,7 +226,7 @@ pub struct DeleteAclRequest {
     /// The name of the cluster.
     #[prost(string, tag = "1")]
     pub cluster_name: ::prost::alloc::string::String,
-    /// The parameter contains acl information, encoded from a `MQTTAcl` object into a binary format.
+    /// The parameter contains acl information, encoded from a `MqttAcl` object into a binary format.
     #[prost(bytes = "vec", tag = "2")]
     pub acl: ::prost::alloc::vec::Vec<u8>,
 }
@@ -236,7 +236,7 @@ pub struct CreateAclRequest {
     /// The name of the cluster.
     #[prost(string, tag = "1")]
     pub cluster_name: ::prost::alloc::string::String,
-    /// The parameter contains acl information, encoded from a `MQTTAcl` object into a binary format.
+    /// The parameter contains acl information, encoded from a `MqttAcl` object into a binary format.
     #[prost(bytes = "vec", tag = "2")]
     pub acl: ::prost::alloc::vec::Vec<u8>,
 }
@@ -250,7 +250,7 @@ pub struct ListBlacklistRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListBlacklistReply {
-    /// The parameter contains a list of blacklist, encoded from a `Vec<MQTTAclBlackList>` into a binary format.
+    /// The parameter contains a list of blacklist, encoded from a `Vec<MqttAclBlackList>` into a binary format.
     #[prost(bytes = "vec", repeated, tag = "2")]
     pub blacklists: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
@@ -260,7 +260,7 @@ pub struct CreateBlacklistRequest {
     /// The name of the cluster.
     #[prost(string, tag = "1")]
     pub cluster_name: ::prost::alloc::string::String,
-    /// The parameter contains blacklist information, encoded from a `MQTTAclBlackList` object into a binary format.
+    /// The parameter contains blacklist information, encoded from a `MqttAclBlackList` object into a binary format.
     #[prost(bytes = "vec", tag = "2")]
     pub blacklist: ::prost::alloc::vec::Vec<u8>,
 }
@@ -270,7 +270,7 @@ pub struct DeleteBlacklistRequest {
     /// The name of the cluster.
     #[prost(string, tag = "1")]
     pub cluster_name: ::prost::alloc::string::String,
-    /// The type of blacklist. Refer to the `MQTTAclBlackListType` enum for specific values.
+    /// The type of blacklist. Refer to the `MqttAclBlackListType` enum for specific values.
     #[prost(string, tag = "2")]
     pub blacklist_type: ::prost::alloc::string::String,
     /// The name of the resource.
@@ -368,7 +368,7 @@ pub mod mqtt_service_client {
         /// - `user_name: String` (Option): The name of the user.
         ///
         /// Returns:
-        /// - `users: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MQTTUser>` into a binary format.
+        /// - `users: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MqttUser>` into a binary format.
         pub async fn list_user(
             &mut self,
             request: impl tonic::IntoRequest<super::ListUserRequest>,
@@ -391,7 +391,7 @@ pub mod mqtt_service_client {
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
         /// - `user_name: String`: The name of the user.
-        /// - `content: Vec<u8>`: The parameter contains user information, encoded from a `MQTTUser` object into a binary format.
+        /// - `content: Vec<u8>`: The parameter contains user information, encoded from a `MqttUser` object into a binary format.
         ///
         /// Returns: An empty struct.
         pub async fn create_user(
@@ -444,7 +444,7 @@ pub mod mqtt_service_client {
         /// - `client_id: String` (Option): The id of the client.
         ///
         /// Returns:
-        /// - `sessions: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MQTTSession>` into a binary format.
+        /// - `sessions: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MqttSession>` into a binary format.
         pub async fn list_session(
             &mut self,
             request: impl tonic::IntoRequest<super::ListSessionRequest>,
@@ -467,7 +467,7 @@ pub mod mqtt_service_client {
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
         /// - `client_id: String`: The id of the client.
-        /// - `session: Vec<u8>`: The parameter contains session information, encoded from a `MQTTSession` object into a binary format.
+        /// - `session: Vec<u8>`: The parameter contains session information, encoded from a `MqttSession` object into a binary format.
         ///
         /// Returns: An empty struct.
         pub async fn create_session(
@@ -549,7 +549,7 @@ pub mod mqtt_service_client {
         /// - `topic_name: String`: The name of the topic.
         ///
         /// Returns:
-        /// - `topics: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MQTTTopic>` into a binary format.
+        /// - `topics: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MqttTopic>` into a binary format.
         pub async fn list_topic(
             &mut self,
             request: impl tonic::IntoRequest<super::ListTopicRequest>,
@@ -572,7 +572,7 @@ pub mod mqtt_service_client {
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
         /// - `topic_name: String`: The name of the topic.
-        /// - `content: Vec<u8>`: The parameter contains topic information, encoded from a `MQTTTopic` object into a binary format.
+        /// - `content: Vec<u8>`: The parameter contains topic information, encoded from a `MqttTopic` object into a binary format.
         ///
         /// Returns: An empty struct.
         pub async fn create_topic(
@@ -623,7 +623,7 @@ pub mod mqtt_service_client {
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
         /// - `topic_name: String`: The name of the topic.
-        /// - `retain_message: Vec<u8>`: The parameter contains retain message, encoded from a `MQTTMessage` object into a binary format.
+        /// - `retain_message: Vec<u8>`: The parameter contains retain message, encoded from a `MqttMessage` object into a binary format.
         /// - `retain_message_expired_at: u64`: The parameter is the expiration time of the retain message. The unit is seconds.
         ///
         /// Returns: An empty struct.
@@ -707,7 +707,7 @@ pub mod mqtt_service_client {
         /// - `cluster_name: String`: The name of the cluster.
         ///
         /// Returns:
-        /// - `acls: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MQTTAcl>` into a binary format.
+        /// - `acls: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MqttAcl>` into a binary format.
         pub async fn list_acl(
             &mut self,
             request: impl tonic::IntoRequest<super::ListAclRequest>,
@@ -729,7 +729,7 @@ pub mod mqtt_service_client {
         ///
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
-        /// - `acl: Vec<u8>`: The parameter contains acl information, encoded from a `MQTTAcl` object into a binary format.
+        /// - `acl: Vec<u8>`: The parameter contains acl information, encoded from a `MqttAcl` object into a binary format.
         ///
         /// Returns: An empty struct.
         pub async fn delete_acl(
@@ -754,7 +754,7 @@ pub mod mqtt_service_client {
         ///
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
-        /// - `acl: Vec<u8>`: The parameter contains acl information, encoded from a `MQTTAcl` object into a binary format.
+        /// - `acl: Vec<u8>`: The parameter contains acl information, encoded from a `MqttAcl` object into a binary format.
         ///
         /// Returns: An empty struct.
         pub async fn create_acl(
@@ -781,7 +781,7 @@ pub mod mqtt_service_client {
         /// - `cluster_name: String`: The name of the cluster.
         ///
         /// Returns:
-        /// - `blacklists: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MQTTAclBlackList>` into a binary format.
+        /// - `blacklists: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MqttAclBlackList>` into a binary format.
         pub async fn list_blacklist(
             &mut self,
             request: impl tonic::IntoRequest<super::ListBlacklistRequest>,
@@ -804,7 +804,7 @@ pub mod mqtt_service_client {
         ///
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
-        /// - `blacklist_type: String`: The type of blacklist. Refer to the `MQTTAclBlackListType` enum for specific values.
+        /// - `blacklist_type: String`: The type of blacklist. Refer to the `MqttAclBlackListType` enum for specific values.
         /// - `resource_name: String`: The name of the resource.
         ///
         /// Returns: An empty struct.
@@ -830,7 +830,7 @@ pub mod mqtt_service_client {
         ///
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
-        /// - `blacklist: Vec<u8>`: The parameter contains blacklist information, encoded from a `MQTTAclBlackList` object into a binary format.
+        /// - `blacklist: Vec<u8>`: The parameter contains blacklist information, encoded from a `MqttAclBlackList` object into a binary format.
         ///
         /// Returns: An empty struct.
         pub async fn create_blacklist(
@@ -867,7 +867,7 @@ pub mod mqtt_service_server {
         /// - `user_name: String` (Option): The name of the user.
         ///
         /// Returns:
-        /// - `users: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MQTTUser>` into a binary format.
+        /// - `users: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MqttUser>` into a binary format.
         async fn list_user(
             &self,
             request: tonic::Request<super::ListUserRequest>,
@@ -877,7 +877,7 @@ pub mod mqtt_service_server {
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
         /// - `user_name: String`: The name of the user.
-        /// - `content: Vec<u8>`: The parameter contains user information, encoded from a `MQTTUser` object into a binary format.
+        /// - `content: Vec<u8>`: The parameter contains user information, encoded from a `MqttUser` object into a binary format.
         ///
         /// Returns: An empty struct.
         async fn create_user(
@@ -902,7 +902,7 @@ pub mod mqtt_service_server {
         /// - `client_id: String` (Option): The id of the client.
         ///
         /// Returns:
-        /// - `sessions: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MQTTSession>` into a binary format.
+        /// - `sessions: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MqttSession>` into a binary format.
         async fn list_session(
             &self,
             request: tonic::Request<super::ListSessionRequest>,
@@ -912,7 +912,7 @@ pub mod mqtt_service_server {
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
         /// - `client_id: String`: The id of the client.
-        /// - `session: Vec<u8>`: The parameter contains session information, encoded from a `MQTTSession` object into a binary format.
+        /// - `session: Vec<u8>`: The parameter contains session information, encoded from a `MqttSession` object into a binary format.
         ///
         /// Returns: An empty struct.
         async fn create_session(
@@ -952,7 +952,7 @@ pub mod mqtt_service_server {
         /// - `topic_name: String`: The name of the topic.
         ///
         /// Returns:
-        /// - `topics: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MQTTTopic>` into a binary format.
+        /// - `topics: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MqttTopic>` into a binary format.
         async fn list_topic(
             &self,
             request: tonic::Request<super::ListTopicRequest>,
@@ -962,7 +962,7 @@ pub mod mqtt_service_server {
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
         /// - `topic_name: String`: The name of the topic.
-        /// - `content: Vec<u8>`: The parameter contains topic information, encoded from a `MQTTTopic` object into a binary format.
+        /// - `content: Vec<u8>`: The parameter contains topic information, encoded from a `MqttTopic` object into a binary format.
         ///
         /// Returns: An empty struct.
         async fn create_topic(
@@ -985,7 +985,7 @@ pub mod mqtt_service_server {
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
         /// - `topic_name: String`: The name of the topic.
-        /// - `retain_message: Vec<u8>`: The parameter contains retain message, encoded from a `MQTTMessage` object into a binary format.
+        /// - `retain_message: Vec<u8>`: The parameter contains retain message, encoded from a `MqttMessage` object into a binary format.
         /// - `retain_message_expired_at: u64`: The parameter is the expiration time of the retain message. The unit is seconds.
         ///
         /// Returns: An empty struct.
@@ -1025,7 +1025,7 @@ pub mod mqtt_service_server {
         /// - `cluster_name: String`: The name of the cluster.
         ///
         /// Returns:
-        /// - `acls: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MQTTAcl>` into a binary format.
+        /// - `acls: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MqttAcl>` into a binary format.
         async fn list_acl(
             &self,
             request: tonic::Request<super::ListAclRequest>,
@@ -1034,7 +1034,7 @@ pub mod mqtt_service_server {
         ///
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
-        /// - `acl: Vec<u8>`: The parameter contains acl information, encoded from a `MQTTAcl` object into a binary format.
+        /// - `acl: Vec<u8>`: The parameter contains acl information, encoded from a `MqttAcl` object into a binary format.
         ///
         /// Returns: An empty struct.
         async fn delete_acl(
@@ -1045,7 +1045,7 @@ pub mod mqtt_service_server {
         ///
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
-        /// - `acl: Vec<u8>`: The parameter contains acl information, encoded from a `MQTTAcl` object into a binary format.
+        /// - `acl: Vec<u8>`: The parameter contains acl information, encoded from a `MqttAcl` object into a binary format.
         ///
         /// Returns: An empty struct.
         async fn create_acl(
@@ -1058,7 +1058,7 @@ pub mod mqtt_service_server {
         /// - `cluster_name: String`: The name of the cluster.
         ///
         /// Returns:
-        /// - `blacklists: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MQTTAclBlackList>` into a binary format.
+        /// - `blacklists: Vec<Vec<u8>>`: It's the result of encoding a `Vec<MqttAclBlackList>` into a binary format.
         async fn list_blacklist(
             &self,
             request: tonic::Request<super::ListBlacklistRequest>,
@@ -1067,7 +1067,7 @@ pub mod mqtt_service_server {
         ///
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
-        /// - `blacklist_type: String`: The type of blacklist. Refer to the `MQTTAclBlackListType` enum for specific values.
+        /// - `blacklist_type: String`: The type of blacklist. Refer to the `MqttAclBlackListType` enum for specific values.
         /// - `resource_name: String`: The name of the resource.
         ///
         /// Returns: An empty struct.
@@ -1079,7 +1079,7 @@ pub mod mqtt_service_server {
         ///
         /// Parameters:
         /// - `cluster_name: String`: The name of the cluster.
-        /// - `blacklist: Vec<u8>`: The parameter contains blacklist information, encoded from a `MQTTAclBlackList` object into a binary format.
+        /// - `blacklist: Vec<u8>`: The parameter contains blacklist information, encoded from a `MqttAclBlackList` object into a binary format.
         ///
         /// Returns: An empty struct.
         async fn create_blacklist(

--- a/src/protocol/tests/mqtt_frame.rs
+++ b/src/protocol/tests/mqtt_frame.rs
@@ -16,7 +16,7 @@
 mod tests {
     use bytes::Bytes;
     use futures::{SinkExt, StreamExt};
-    use protocol::mqtt::codec::{MQTTPacketWrapper, MqttCodec};
+    use protocol::mqtt::codec::{MqttPacketWrapper, MqttCodec};
     use protocol::mqtt::common::{
         ConnAck, ConnAckProperties, Connect, ConnectProperties, ConnectReturnCode, LastWill, Login,
         MQTTPacket,
@@ -120,12 +120,12 @@ mod tests {
 
     /// Build the connect content package for the mqtt4 protocol
     #[allow(dead_code)]
-    fn build_mqtt4_pg_connect_ack() -> MQTTPacketWrapper {
+    fn build_mqtt4_pg_connect_ack() -> MqttPacketWrapper {
         let ack: ConnAck = ConnAck {
             session_present: false,
             code: ConnectReturnCode::Success,
         };
-        MQTTPacketWrapper {
+        MqttPacketWrapper {
             protocol_version: 4,
             packet: MQTTPacket::ConnAck(ack, None),
         }
@@ -192,14 +192,14 @@ mod tests {
     }
 
     /// Build the connect content package for the mqtt5 protocol
-    fn build_mqtt5_pg_connect_ack() -> MQTTPacketWrapper {
+    fn build_mqtt5_pg_connect_ack() -> MqttPacketWrapper {
         let ack: ConnAck = ConnAck {
             session_present: true,
             code: ConnectReturnCode::Success,
         };
         let mut properties = ConnAckProperties::default();
         properties.max_qos = Some(10u8);
-        MQTTPacketWrapper {
+        MqttPacketWrapper {
             protocol_version: 5,
             packet: MQTTPacket::ConnAck(ack, Some(properties)),
         }


### PR DESCRIPTION
## What's changed and what's your intention?

This PR renames types that starts with `MQTT` to `Mqtt` to conform to the rust naming convention.

Please explain IN DETAIL what the changes are in this PR and why they are needed:

All structs in the form of `struct MQTT* { }` are renamed to `struct Mqtt* { }`.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)

#505 