### PR TITLE
chore: renamed Tcps to Tls

### DIFF
--- a/src/journal-server/src/server/connection.rs
+++ b/src/journal-server/src/server/connection.rs
@@ -23,7 +23,7 @@ static CONNECTION_ID_BUILD: AtomicU64 = AtomicU64::new(1);
 #[derive(Clone, PartialEq, PartialOrd)]
 pub enum NetworkConnectionType {
     Tcp,
-    Tcps,
+    Tls,
 }
 
 impl fmt::Display for NetworkConnectionType {
@@ -33,7 +33,7 @@ impl fmt::Display for NetworkConnectionType {
             "{}",
             match self {
                 NetworkConnectionType::Tcp => "tcp",
-                NetworkConnectionType::Tcps => "tcps",
+                NetworkConnectionType::Tls => "tls",
             }
         )
     }

--- a/src/journal-server/src/server/connection_manager.rs
+++ b/src/journal-server/src/server/connection_manager.rs
@@ -122,7 +122,7 @@ impl ConnectionManager {
 
         // write tls stream
         if let Some(connection) = self.get_connect(connection_id) {
-            if connection.connection_type == NetworkConnectionType::Tcps {
+            if connection.connection_type == NetworkConnectionType::Tls {
                 return self.write_tcp_tls_frame(connection_id, resp).await;
             }
         }

--- a/src/journal-server/src/server/tcp/server.rs
+++ b/src/journal-server/src/server/tcp/server.rs
@@ -195,7 +195,7 @@ impl TcpServer {
             self.stop_sx.clone(),
         )
         .await;
-        self.network_connection_type = NetworkConnectionType::Tcps;
+        self.network_connection_type = NetworkConnectionType::Tls;
         info!("MQTT TCP TLS Server started successfully, listening port: {port}");
     }
 }

--- a/src/journal-server/src/server/tcp/tls_server.rs
+++ b/src/journal-server/src/server/tcp/tls_server.rs
@@ -125,7 +125,7 @@ pub(crate) async fn acceptor_tls_process(
 
                                 let (connection_stop_sx, connection_stop_rx) = mpsc::channel::<bool>(1);
                                 let connection = NetworkConnection::new(
-                                    crate::server::connection::NetworkConnectionType::Tcps,
+                                    crate::server::connection::NetworkConnectionType::Tls,
                                     addr,
                                     Some(connection_stop_sx.clone())
                                 );

--- a/src/mqtt-broker/src/server/connection.rs
+++ b/src/mqtt-broker/src/server/connection.rs
@@ -24,7 +24,7 @@ static CONNECTION_ID_BUILD: AtomicU64 = AtomicU64::new(1);
 #[derive(Clone, PartialEq, PartialOrd)]
 pub enum NetworkConnectionType {
     Tcp,
-    Tcps,
+    Tls,
     WebSocket,
     WebSockets,
 }
@@ -36,7 +36,7 @@ impl fmt::Display for NetworkConnectionType {
             "{}",
             match self {
                 NetworkConnectionType::Tcp => "tcp",
-                NetworkConnectionType::Tcps => "tcps",
+                NetworkConnectionType::Tls => "tls",
                 NetworkConnectionType::WebSocket => "websocket",
                 NetworkConnectionType::WebSockets => "websockets",
             }
@@ -100,7 +100,7 @@ impl NetworkConnection {
 
     pub fn is_tcp(&self) -> bool {
         self.connection_type == NetworkConnectionType::Tcp
-            || self.connection_type == NetworkConnectionType::Tcps
+            || self.connection_type == NetworkConnectionType::Tls
     }
 
     pub async fn stop_connection(&self) {

--- a/src/mqtt-broker/src/server/connection_manager.rs
+++ b/src/mqtt-broker/src/server/connection_manager.rs
@@ -196,7 +196,7 @@ impl ConnectionManager {
 
         // write tls stream
         if let Some(connection) = self.get_connect(connection_id) {
-            if connection.connection_type == NetworkConnectionType::Tcps {
+            if connection.connection_type == NetworkConnectionType::Tls {
                 return self.write_tcp_tls_frame(connection_id, resp).await;
             }
         }

--- a/src/mqtt-broker/src/server/tcp/server.rs
+++ b/src/mqtt-broker/src/server/tcp/server.rs
@@ -222,7 +222,7 @@ where
             self.stop_sx.clone(),
         )
         .await;
-        self.network_connection_type = NetworkConnectionType::Tcps;
+        self.network_connection_type = NetworkConnectionType::Tls;
         info!("MQTT TCP TLS Server started successfully, listening port: {port}");
     }
 }

--- a/src/mqtt-broker/src/server/tcp/tls_server.rs
+++ b/src/mqtt-broker/src/server/tcp/tls_server.rs
@@ -130,7 +130,7 @@ pub(crate) async fn acceptor_tls_process(
 
                                 let (connection_stop_sx, connection_stop_rx) = mpsc::channel::<bool>(1);
                                 let connection = NetworkConnection::new(
-                                    crate::server::connection::NetworkConnectionType::Tcps,
+                                    crate::server::connection::NetworkConnectionType::Tls,
                                     addr,
                                     Some(connection_stop_sx.clone())
                                 );

--- a/src/protocol/src/mqtt/mqttv4/connect.rs
+++ b/src/protocol/src/mqtt/mqttv4/connect.rs
@@ -298,7 +298,7 @@ mod tests {
         assert_eq!(fixheader.fixed_header_len, 2);
         assert!(fixheader.remaining_len == 26);
         // test read function, x gets connect, y gets login and z gets will
-        let (l, x, _, _) = read(fixheader, buff_write.copy_to_bytes(buff_write.len())).unwrap();
+        let (_, x, _, _) = read(fixheader, buff_write.copy_to_bytes(buff_write.len())).unwrap();
         // only check connect value in this case as login and will being none
         assert_eq!(x.client_id, "test_client_id");
         assert_eq!(x.keep_alive, 30);

--- a/src/protocol/tests/mqtt_frame.rs
+++ b/src/protocol/tests/mqtt_frame.rs
@@ -71,10 +71,9 @@ mod tests {
                 Ok(da) => {
                     // assert_eq!(da, resp_packet.packet)
                     println!("{:?}", da);
-                    assert!(true);
                 }
                 Err(e) => {
-                    assert!(false);
+                    panic!("error: {:?}", e);
                 }
             }
         }
@@ -91,10 +90,9 @@ mod tests {
                 Ok(da) => {
                     // assert_eq!(da, resp_packet.packet)
                     println!("{:?}", da);
-                    assert!(true);
                 }
                 Err(e) => {
-                    assert!(false);
+                    panic!("error: {:?}", e);
                 }
             }
         }


### PR DESCRIPTION
## What's changed and what's your intention?

Renamed `NetworkConnectionType::Tcps` to `NetworkConnectionType::Tls`. Tls is much more accepted in the rust community, and it's very rare to see anyone using Tcps to described a secured TCP connection.

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Renamed `NetworkConnectionType::Tcps` to `NetworkConnectionType::Tls`.
- Remove `assert!(true)` and replace `assert!(false)` with `panic!(...)`

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
