### PR TITLE
refactor: add validation to the un_register_node method in GrpcPlacementService and fill in the test case

### DIFF
--- a/src/grpc-clients/tests/placement_test.rs
+++ b/src/grpc-clients/tests/placement_test.rs
@@ -18,7 +18,9 @@ mod common;
 mod tests {
     use std::sync::Arc;
 
-    use grpc_clients::placement::placement::call::{cluster_status, register_node, unregister_node};
+    use grpc_clients::placement::placement::call::{
+        cluster_status, register_node, unregister_node,
+    };
     use grpc_clients::poll::ClientPool;
     use protocol::placement_center::placement_center_inner::{
         ClusterStatusRequest, ClusterType, RegisterNodeRequest, UnRegisterNodeRequest,
@@ -105,7 +107,9 @@ mod tests {
         let addrs = vec![get_placement_addr()];
 
         let request = ClusterStatusRequest::default();
-        assert!(cluster_status(client_poll.clone(), addrs.clone(), request).await.is_ok());
+        assert!(cluster_status(client_poll.clone(), addrs.clone(), request)
+            .await
+            .is_ok());
 
         let cluster_type = ClusterType::PlacementCenter as i32;
         let cluster_name = "test-cluster-name".to_string();
@@ -116,13 +120,21 @@ mod tests {
             cluster_name: cluster_name.clone(),
             node_id,
         };
-        assert!(unregister_node(client_poll.clone(), addrs.clone(), request).await.is_ok());
+        assert!(unregister_node(client_poll.clone(), addrs.clone(), request)
+            .await
+            .is_ok());
 
-        let request_cluster_name_empty =  UnRegisterNodeRequest {
+        let request_cluster_name_empty = UnRegisterNodeRequest {
             cluster_type,
             cluster_name: "".to_string(),
             node_id,
         };
-        assert!(unregister_node(client_poll.clone(), addrs.clone(), request_cluster_name_empty).await.is_err());
+        assert!(unregister_node(
+            client_poll.clone(),
+            addrs.clone(),
+            request_cluster_name_empty
+        )
+        .await
+        .is_err());
     }
 }

--- a/src/grpc-clients/tests/placement_test.rs
+++ b/src/grpc-clients/tests/placement_test.rs
@@ -18,16 +18,16 @@ mod common;
 mod tests {
     use std::sync::Arc;
 
-    use grpc_clients::placement::placement::call::{cluster_status, register_node};
+    use grpc_clients::placement::placement::call::{cluster_status, register_node, unregister_node};
     use grpc_clients::poll::ClientPool;
     use protocol::placement_center::placement_center_inner::{
-        ClusterStatusRequest, ClusterType, RegisterNodeRequest,
+        ClusterStatusRequest, ClusterType, RegisterNodeRequest, UnRegisterNodeRequest,
     };
 
     use crate::common::get_placement_addr;
 
     #[tokio::test]
-    async fn placement_test() {
+    async fn register_node_test() {
         let client_poll: Arc<ClientPool> = Arc::new(ClientPool::new(1));
         let addrs = vec![get_placement_addr()];
 
@@ -97,5 +97,32 @@ mod tests {
             }
             Err(_e) => {}
         }
+    }
+
+    #[tokio::test]
+    async fn un_register_nodet_test() {
+        let client_poll: Arc<ClientPool> = Arc::new(ClientPool::new(1));
+        let addrs = vec![get_placement_addr()];
+
+        let request = ClusterStatusRequest::default();
+        assert!(cluster_status(client_poll.clone(), addrs.clone(), request).await.is_ok());
+
+        let cluster_type = ClusterType::PlacementCenter as i32;
+        let cluster_name = "test-cluster-name".to_string();
+        let node_id = 1235u64;
+
+        let request = UnRegisterNodeRequest {
+            cluster_type,
+            cluster_name: cluster_name.clone(),
+            node_id,
+        };
+        assert!(unregister_node(client_poll.clone(), addrs.clone(), request).await.is_ok());
+
+        let request_cluster_name_empty =  UnRegisterNodeRequest {
+            cluster_type,
+            cluster_name: "".to_string(),
+            node_id,
+        };
+        assert!(unregister_node(client_poll.clone(), addrs.clone(), request_cluster_name_empty).await.is_err());
     }
 }

--- a/src/placement-center/src/server/grpc/service_placement.rs
+++ b/src/placement-center/src/server/grpc/service_placement.rs
@@ -139,7 +139,7 @@ impl PlacementCenterService for GrpcPlacementService {
     ) -> Result<Response<UnRegisterNodeReply>, Status> {
         let req = request.into_inner();
         let _ = req.validate_ext()?;
-        
+
         let data = StorageData::new(
             StorageDataType::ClusterUngisterNode,
             UnRegisterNodeRequest::encode_to_vec(&req),

--- a/src/placement-center/src/server/grpc/service_placement.rs
+++ b/src/placement-center/src/server/grpc/service_placement.rs
@@ -138,7 +138,8 @@ impl PlacementCenterService for GrpcPlacementService {
         request: Request<UnRegisterNodeRequest>,
     ) -> Result<Response<UnRegisterNodeReply>, Status> {
         let req = request.into_inner();
-
+        let _ = req.validate_ext()?;
+        
         let data = StorageData::new(
             StorageDataType::ClusterUngisterNode,
             UnRegisterNodeRequest::encode_to_vec(&req),

--- a/src/placement-center/src/server/grpc/validate.rs
+++ b/src/placement-center/src/server/grpc/validate.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use common_base::error::common::CommonError;
-use protocol::placement_center::placement_center_inner::{RegisterNodeRequest, UnRegisterNodeRequest};
+use protocol::placement_center::placement_center_inner::{
+    RegisterNodeRequest, UnRegisterNodeRequest,
+};
 use tonic::Status;
 
 pub trait ValidateExt {

--- a/src/placement-center/src/server/grpc/validate.rs
+++ b/src/placement-center/src/server/grpc/validate.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_base::error::common::CommonError;
-use protocol::placement_center::placement_center_inner::RegisterNodeRequest;
+use protocol::placement_center::placement_center_inner::{RegisterNodeRequest, UnRegisterNodeRequest};
 use tonic::Status;
 
 pub trait ValidateExt {
@@ -31,6 +31,17 @@ impl ValidateExt for RegisterNodeRequest {
         if self.node_ip.is_empty() {
             return Err(Status::cancelled(
                 CommonError::ParameterCannotBeNull("node ip".to_string()).to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl ValidateExt for UnRegisterNodeRequest {
+    fn validate_ext(&self) -> Result<(), Status> {
+        if self.cluster_name.is_empty() {
+            return Err(Status::cancelled(
+                CommonError::ParameterCannotBeNull("cluster name".to_string()).to_string(),
             ));
         }
         Ok(())


### PR DESCRIPTION
## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- add validation to the un_register_node method in GrpcPlacementService 
- add un_register_node test case to src/grpc-clients/tests/placement_test.rs

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
relate https://github.com/robustmq/robustmq/issues/539
