### PR TITLE
feat: Add TLS support for gRPC servers

### DIFF
--- a/src/common/base/src/config/broker_mqtt.rs
+++ b/src/common/base/src/config/broker_mqtt.rs
@@ -70,7 +70,7 @@ pub struct Network {
     #[serde(default = "default_network_tcp_port")]
     pub tcp_port: u32,
     #[serde(default = "default_network_tcps_port")]
-    pub tcps_port: u32,
+    pub tls_port: u32,
     #[serde(default = "default_network_websocket_port")]
     pub websocket_port: u32,
     #[serde(default = "default_network_websockets_port")]
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(config.http_port, 9982);
 
         assert_eq!(config.network.tcp_port, 1883);
-        assert_eq!(config.network.tcps_port, 8883);
+        assert_eq!(config.network.tls_port, 8883);
         assert_eq!(config.network.websocket_port, 8093);
         assert_eq!(config.network.websockets_port, 8043);
         assert_eq!(config.network.quic_port, 9083);
@@ -234,7 +234,7 @@ mod tests {
         assert_eq!(config.http_port, 9982);
 
         assert_eq!(config.network.tcp_port, 1883);
-        assert_eq!(config.network.tcps_port, 8883);
+        assert_eq!(config.network.tls_port, 8883);
         assert_eq!(config.network.websocket_port, 8093);
         assert_eq!(config.network.websockets_port, 8043);
         assert_eq!(config.network.quic_port, 9083);

--- a/src/common/base/src/config/default_mqtt.rs
+++ b/src/common/base/src/config/default_mqtt.rs
@@ -26,7 +26,7 @@ pub fn default_http_port() -> usize {
 pub fn default_network() -> Network {
     Network {
         tcp_port: default_network_tcp_port(),
-        tcps_port: default_network_tcps_port(),
+        tls_port: default_network_tcps_port(),
         websocket_port: default_network_websocket_port(),
         websockets_port: default_network_websockets_port(),
         quic_port: default_network_quic_port(),

--- a/src/common/base/src/config/journal_server.rs
+++ b/src/common/base/src/config/journal_server.rs
@@ -68,6 +68,11 @@ pub struct Network {
     pub tcp_port: u32,
     #[serde(default = "default_network_tcps_port")]
     pub tls_port: u32,
+
+    /// Whether to enable using TLS for gRPC.
+    #[serde(default)]
+    pub grpc_tls_enable: bool,
+
     #[serde(default)]
     pub tls_cert: String,
     #[serde(default)]

--- a/src/common/base/src/config/journal_server.rs
+++ b/src/common/base/src/config/journal_server.rs
@@ -67,7 +67,7 @@ pub struct Network {
     #[serde(default = "default_network_tcp_port")]
     pub tcp_port: u32,
     #[serde(default = "default_network_tcps_port")]
-    pub tcps_port: u32,
+    pub tls_port: u32,
     #[serde(default)]
     pub tls_cert: String,
     #[serde(default)]
@@ -187,7 +187,7 @@ mod tests {
         assert_eq!(conf.placement_center, vec![String::from("127.0.0.1:1228")]);
         assert_eq!(conf.network.grpc_port, 2228);
         assert_eq!(conf.network.tcp_port, 3110);
-        assert_eq!(conf.network.tcps_port, 3111);
+        assert_eq!(conf.network.tls_port, 3111);
 
         assert_eq!(conf.system.runtime_work_threads, 100);
 

--- a/src/journal-server/src/server/tcp/server.rs
+++ b/src/journal-server/src/server/tcp/server.rs
@@ -65,7 +65,7 @@ pub async fn start_tcp_server(
         cache_manager,
         client_poll,
     );
-    server.start_tls(conf.network.tcps_port).await;
+    server.start_tls(conf.network.tls_port).await;
 }
 
 struct TcpServer {

--- a/src/mqtt-broker/src/server/tcp/server.rs
+++ b/src/mqtt-broker/src/server/tcp/server.rs
@@ -80,7 +80,7 @@ pub async fn start_tcp_server<S>(
         cache_manager,
         client_poll,
     );
-    server.start_tls(conf.network.tcps_port).await;
+    server.start_tls(conf.network.tls_port).await;
 }
 
 // U: codec: encoder + decoder

--- a/src/mqtt-broker/src/storage/cluster.rs
+++ b/src/mqtt-broker/src/storage/cluster.rs
@@ -71,7 +71,7 @@ impl ClusterStorage {
             grpc_addr: format!("{}:{}", local_ip, config.grpc_port),
             http_addr: format!("{}:{}", local_ip, config.http_port),
             mqtt_addr: format!("{}:{}", local_ip, config.network.tcp_port),
-            mqtts_addr: format!("{}:{}", local_ip, config.network.tcps_port),
+            mqtts_addr: format!("{}:{}", local_ip, config.network.tls_port),
             websocket_addr: format!("{}:{}", local_ip, config.network.websocket_port),
             websockets_addr: format!("{}:{}", local_ip, config.network.websockets_port),
             quic_addr: format!("{}:{}", local_ip, config.network.quic_port),


### PR DESCRIPTION
## What's changed and what's your intention?

This PR adds TLS support for gRPC servers in mqtt-broker, journal server and placement center

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Adds `grpc_tls_enable: bool` option to network config of `JournalServerConfig`
- The gRPC server serves with TLS enabled if `grpc_tls_enable` is found to be `true`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)

#521 