### PR TITLE
fix: Revert "feat: Add TLS support for gRPC servers"

### DIFF
--- a/src/common/base/src/config/broker_mqtt.rs
+++ b/src/common/base/src/config/broker_mqtt.rs
@@ -70,7 +70,7 @@ pub struct Network {
     #[serde(default = "default_network_tcp_port")]
     pub tcp_port: u32,
     #[serde(default = "default_network_tcps_port")]
-    pub tls_port: u32,
+    pub tcps_port: u32,
     #[serde(default = "default_network_websocket_port")]
     pub websocket_port: u32,
     #[serde(default = "default_network_websockets_port")]
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(config.http_port, 9982);
 
         assert_eq!(config.network.tcp_port, 1883);
-        assert_eq!(config.network.tls_port, 8883);
+        assert_eq!(config.network.tcps_port, 8883);
         assert_eq!(config.network.websocket_port, 8093);
         assert_eq!(config.network.websockets_port, 8043);
         assert_eq!(config.network.quic_port, 9083);
@@ -234,7 +234,7 @@ mod tests {
         assert_eq!(config.http_port, 9982);
 
         assert_eq!(config.network.tcp_port, 1883);
-        assert_eq!(config.network.tls_port, 8883);
+        assert_eq!(config.network.tcps_port, 8883);
         assert_eq!(config.network.websocket_port, 8093);
         assert_eq!(config.network.websockets_port, 8043);
         assert_eq!(config.network.quic_port, 9083);

--- a/src/common/base/src/config/default_mqtt.rs
+++ b/src/common/base/src/config/default_mqtt.rs
@@ -26,7 +26,7 @@ pub fn default_http_port() -> usize {
 pub fn default_network() -> Network {
     Network {
         tcp_port: default_network_tcp_port(),
-        tls_port: default_network_tcps_port(),
+        tcps_port: default_network_tcps_port(),
         websocket_port: default_network_websocket_port(),
         websockets_port: default_network_websockets_port(),
         quic_port: default_network_quic_port(),

--- a/src/common/base/src/config/journal_server.rs
+++ b/src/common/base/src/config/journal_server.rs
@@ -67,12 +67,7 @@ pub struct Network {
     #[serde(default = "default_network_tcp_port")]
     pub tcp_port: u32,
     #[serde(default = "default_network_tcps_port")]
-    pub tls_port: u32,
-
-    /// Whether to enable using TLS for gRPC.
-    #[serde(default)]
-    pub grpc_tls_enable: bool,
-
+    pub tcps_port: u32,
     #[serde(default)]
     pub tls_cert: String,
     #[serde(default)]
@@ -192,7 +187,7 @@ mod tests {
         assert_eq!(conf.placement_center, vec![String::from("127.0.0.1:1228")]);
         assert_eq!(conf.network.grpc_port, 2228);
         assert_eq!(conf.network.tcp_port, 3110);
-        assert_eq!(conf.network.tls_port, 3111);
+        assert_eq!(conf.network.tcps_port, 3111);
 
         assert_eq!(conf.system.runtime_work_threads, 100);
 

--- a/src/journal-server/src/lib.rs
+++ b/src/journal-server/src/lib.rs
@@ -89,30 +89,11 @@ impl JournalServer {
     }
 
     fn start_grpc_server(&self) {
-        let server = match self.config.network.grpc_tls_enable {
-            true => {
-                let cert = std::fs::read_to_string(&self.config.network.tls_cert)
-                    .expect("failed to read tls_cert");
-                let key = std::fs::read_to_string(&self.config.network.tls_key)
-                    .expect("failed to read tls_key");
-                let identity = tonic::transport::Identity::from_pem(cert, key);
-                let tls_config = tonic::transport::ServerTlsConfig::new().identity(identity);
-                GrpcServer::new_with_tls(
-                    self.config.network.grpc_port,
-                    self.client_poll.clone(),
-                    self.cache_manager.clone(),
-                    tls_config,
-                )
-            },
-            false => {
-                GrpcServer::new(
-                    self.config.network.grpc_port,
-                    self.client_poll.clone(),
-                    self.cache_manager.clone(),
-                )
-            },
-        };
-
+        let server = GrpcServer::new(
+            self.config.network.grpc_port,
+            self.client_poll.clone(),
+            self.cache_manager.clone(),
+        );
         self.server_runtime.spawn(async move {
             match server.start().await {
                 Ok(()) => {}

--- a/src/journal-server/src/server/grpc/server.rs
+++ b/src/journal-server/src/server/grpc/server.rs
@@ -29,7 +29,6 @@ pub struct GrpcServer {
     port: u32,
     client_poll: Arc<ClientPool>,
     cache_manager: Arc<CacheManager>,
-    tls_config: Option<tonic::transport::ServerTlsConfig>,
 }
 
 impl GrpcServer {
@@ -38,26 +37,10 @@ impl GrpcServer {
             port,
             client_poll,
             cache_manager,
-            tls_config: None,
         }
     }
-
-    pub fn new_with_tls(
-        port: u32,
-        client_pool: Arc<ClientPool>,
-        cache_manager: Arc<CacheManager>,
-        tls_config: tonic::transport::ServerTlsConfig,
-    ) -> Self {
-        Self {
-            port,
-            client_poll: client_pool,
-            cache_manager,
-            tls_config: Some(tls_config),
-        }
-    }
-
     pub async fn start(&self) -> Result<(), CommonError> {
-        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), self.port);
+        let addr = format!("0.0.0.0:{}", self.port).parse()?;
         info!(
             "Journal Engine Grpc Server start success. port:{}",
             self.port
@@ -65,13 +48,7 @@ impl GrpcServer {
         let admin_handler = GrpcJournalServerAdminService::new();
         let inner_handler = GrpcJournalServerInnerService::new(self.cache_manager.clone());
 
-        let mut server_builder = Server::builder();
-
-        if let Some(tls_config) = &self.tls_config {
-            server_builder = server_builder.tls_config(tls_config.clone())?;
-        }
-
-        server_builder
+        Server::builder()
             .add_service(JournalServerAdminServiceServer::new(admin_handler))
             .add_service(JournalServerInnerServiceServer::new(inner_handler))
             .serve(addr)

--- a/src/journal-server/src/server/tcp/server.rs
+++ b/src/journal-server/src/server/tcp/server.rs
@@ -65,7 +65,7 @@ pub async fn start_tcp_server(
         cache_manager,
         client_poll,
     );
-    server.start_tls(conf.network.tls_port).await;
+    server.start_tls(conf.network.tcps_port).await;
 }
 
 struct TcpServer {

--- a/src/mqtt-broker/src/server/tcp/server.rs
+++ b/src/mqtt-broker/src/server/tcp/server.rs
@@ -80,7 +80,7 @@ pub async fn start_tcp_server<S>(
         cache_manager,
         client_poll,
     );
-    server.start_tls(conf.network.tls_port).await;
+    server.start_tls(conf.network.tcps_port).await;
 }
 
 // U: codec: encoder + decoder

--- a/src/mqtt-broker/src/storage/cluster.rs
+++ b/src/mqtt-broker/src/storage/cluster.rs
@@ -71,7 +71,7 @@ impl ClusterStorage {
             grpc_addr: format!("{}:{}", local_ip, config.grpc_port),
             http_addr: format!("{}:{}", local_ip, config.http_port),
             mqtt_addr: format!("{}:{}", local_ip, config.network.tcp_port),
-            mqtts_addr: format!("{}:{}", local_ip, config.network.tls_port),
+            mqtts_addr: format!("{}:{}", local_ip, config.network.tcps_port),
             websocket_addr: format!("{}:{}", local_ip, config.network.websocket_port),
             websockets_addr: format!("{}:{}", local_ip, config.network.websockets_port),
             quic_addr: format!("{}:{}", local_ip, config.network.quic_port),


### PR DESCRIPTION
Reverts robustmq/robustmq#579

#579 was not complete when it was merged