### PR TITLE
refactor: Add validation to the set_idempotent_data method in GrpcPlacementService and fill in the test case

### DIFF
--- a/src/placement-center/src/server/grpc/service_placement.rs
+++ b/src/placement-center/src/server/grpc/service_placement.rs
@@ -262,6 +262,7 @@ impl PlacementCenterService for GrpcPlacementService {
         request: Request<SetIdempotentDataRequest>,
     ) -> Result<Response<SetIdempotentDataReply>, Status> {
         let req = request.into_inner();
+        let _ = req.validate_ext()?;
         let data = StorageData::new(
             StorageDataType::ClusterSetIdempotentData,
             SetIdempotentDataRequest::encode_to_vec(&req),

--- a/src/placement-center/src/server/grpc/validate.rs
+++ b/src/placement-center/src/server/grpc/validate.rs
@@ -14,8 +14,8 @@
 
 use common_base::error::common::CommonError;
 use protocol::placement_center::placement_center_inner::{
-    DeleteIdempotentDataRequest, RegisterNodeRequest, SetResourceConfigRequest,
-    UnRegisterNodeRequest,
+    DeleteIdempotentDataRequest, RegisterNodeRequest, SetIdempotentDataRequest,
+    SetResourceConfigRequest, UnRegisterNodeRequest,
 };
 use tonic::Status;
 
@@ -69,6 +69,24 @@ impl ValidateExt for SetResourceConfigRequest {
                 CommonError::ParameterCannotBeNull("cluster name".to_string()).to_string(),
             ));
         }
+        Ok(())
+    }
+}
+
+impl ValidateExt for SetIdempotentDataRequest {
+    fn validate_ext(&self) -> Result<(), Status> {
+        if self.cluster_name.is_empty() {
+            return Err(Status::cancelled(
+                CommonError::ParameterCannotBeNull("cluster name".to_string()).to_string(),
+            ));
+        }
+
+        if self.producer_id.is_empty() {
+            return Err(Status::cancelled(
+                CommonError::ParameterCannotBeNull("producer id".to_string()).to_string(),
+            ));
+        }
+
         Ok(())
     }
 }

--- a/src/placement-center/tests/common.rs
+++ b/src/placement-center/tests/common.rs
@@ -59,3 +59,13 @@ pub fn node_ip() -> String {
 pub fn extend_info() -> String {
     "extend info".to_string()
 }
+
+#[allow(dead_code)]
+pub fn producer_id() -> String {
+    "producer id".to_string()
+}
+
+#[allow(dead_code)]
+pub fn seq_num() -> u64 {
+    4
+}

--- a/src/placement-center/tests/grpc_clients_test.rs
+++ b/src/placement-center/tests/grpc_clients_test.rs
@@ -17,7 +17,7 @@ mod common;
 mod tests {
     use protocol::placement_center::placement_center_inner::placement_center_service_client::PlacementCenterServiceClient;
     use protocol::placement_center::placement_center_inner::{
-        HeartbeatRequest, RegisterNodeRequest, UnRegisterNodeRequest,
+        HeartbeatRequest, RegisterNodeRequest, SetIdempotentDataRequest, UnRegisterNodeRequest,
     };
     use protocol::placement_center::placement_center_journal::engine_service_client::EngineServiceClient;
     use protocol::placement_center::placement_center_journal::{
@@ -25,8 +25,8 @@ mod tests {
     };
 
     use crate::common::{
-        cluster_name, cluster_type, extend_info, namespace, node_id, node_ip, pc_addr, shard_name,
-        shard_replica,
+        cluster_name, cluster_type, extend_info, namespace, node_id, node_ip, pc_addr, producer_id,
+        seq_num, shard_name, shard_replica,
     };
 
     #[tokio::test]
@@ -79,6 +79,24 @@ mod tests {
         };
         client
             .un_register_node(tonic::Request::new(request))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_set_idempotent_data() {
+        let mut client = PlacementCenterServiceClient::connect(pc_addr())
+            .await
+            .unwrap();
+
+        let request = SetIdempotentDataRequest {
+            cluster_name: cluster_name(),
+            producer_id: producer_id(),
+            seq_num: seq_num(),
+        };
+
+        client
+            .set_idempotent_data(tonic::Request::new(request))
             .await
             .unwrap();
     }


### PR DESCRIPTION
## What's changed and what's your intention?

Add validation to the set_idempotent_data method in GrpcPlacementService and fill in the test case

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)

close #545 
