### PR TITLE
ci: Implement caching for CI/CD builds using sccache.

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -31,6 +31,7 @@ runs:
         apt-get update
         apt-get install -y protobuf-compiler
         apt-get install -y llvm libclang-dev
+        apt-get install -y cmake
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly

--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -30,6 +30,7 @@ runs:
       run: |
         apt-get update
         apt-get install -y protobuf-compiler
+        apt-get install llvm libclang-dev
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly

--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Prepare Rust Builder
+description: 'Prepare Rust Build Environment'
+inputs:
+  rust-version:
+    description: 'version of rust to install (e.g. stable)'
+    required: true
+    default: 'stable'
+runs:
+  using: "composite"
+  steps:
+    - name: Install Build Dependencies
+      shell: bash
+      run: |
+        apt-get update
+        apt-get install -y protobuf-compiler
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+    - name: Configure rust runtime env
+      uses: ./.github/actions/setup-rust-runtime

--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -1,19 +1,17 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# Copyright 2023 RobustMQ Team
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 name: Prepare Rust Builder
 description: 'Prepare Rust Build Environment'

--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -30,7 +30,7 @@ runs:
       run: |
         apt-get update
         apt-get install -y protobuf-compiler
-        apt-get install llvm libclang-dev
+        apt-get install -y llvm libclang-dev
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly

--- a/.github/actions/setup-rust-runtime/action.yml
+++ b/.github/actions/setup-rust-runtime/action.yml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Setup Rust Runtime
+description: 'Setup Rust Runtime Environment'
+runs:
+  using: "composite"
+  steps:
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.4
+    - name: Configure runtime env
+      shell: bash
+      # do not produce debug symbols to keep memory usage down
+      # hardcoding other profile params to avoid profile override values
+      # More on Cargo profiles https://doc.rust-lang.org/cargo/reference/profiles.html?profile-settings#profile-settings
+      #
+      # Set debuginfo=line-tables-only as debuginfo=0 causes immensely slow build
+      # See for more details: https://github.com/rust-lang/rust/issues/119560
+      run: |
+        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+        echo "RUST_BACKTRACE=1" >> $GITHUB_ENV
+        echo "RUSTFLAGS=-C debuginfo=line-tables-only -C incremental=false" >> $GITHUB_ENV

--- a/.github/actions/setup-rust-runtime/action.yml
+++ b/.github/actions/setup-rust-runtime/action.yml
@@ -1,19 +1,18 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# Copyright 2023 RobustMQ Team
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 
 name: Setup Rust Runtime
 description: 'Setup Rust Runtime Environment'

--- a/.github/workflows/rust-testing.yml
+++ b/.github/workflows/rust-testing.yml
@@ -16,14 +16,14 @@ name: Integration Testing
 
 on:
   push:
-    branches: [ "cache" ]
+    branches: [ "main" ]
     paths-ignore:
       - "docs/**"
       - "**.md"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/pull_request_template.md"
   pull_request:
-    branches: [ "cache" ]
+    branches: [ "main" ]
     paths-ignore:
       - "docs/**"
       - "**.md"

--- a/.github/workflows/rust-testing.yml
+++ b/.github/workflows/rust-testing.yml
@@ -64,6 +64,10 @@ jobs:
       image: amd64/rust
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
       - name: Install cargo-nextest
         uses: baptiste0928/cargo-install@v1
         with:

--- a/.github/workflows/rust-testing.yml
+++ b/.github/workflows/rust-testing.yml
@@ -63,9 +63,6 @@ jobs:
       image: amd64/rust
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies (ubuntu-latest)
-        run: |
-          sudo apt-get install protobuf-compiler
       - name: Install cargo-nextest
         uses: baptiste0928/cargo-install@v1
         with:

--- a/.github/workflows/rust-testing.yml
+++ b/.github/workflows/rust-testing.yml
@@ -16,17 +16,53 @@ name: Integration Testing
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "cache" ]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
   pull_request:
-    branches: [ "main" ]
+    branches: [ "cache" ]
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/pull_request_template.md"
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  tests:
+  # Check crate compiles
+  linux-build-lib:
+    name: cargo check
     runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
     steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./target/
+          key: cargo-cache-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}  # Run tests
+
+  linux-tests:
+    needs: [ linux-build-lib ]
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
       - name: Install dependencies (ubuntu-latest)
         run: |
           sudo apt-get install protobuf-compiler

--- a/.github/workflows/rust-testing.yml
+++ b/.github/workflows/rust-testing.yml
@@ -57,6 +57,7 @@ jobs:
           key: cargo-cache-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}  # Run tests
 
   linux-tests:
+    name: cargo test
     needs: [ linux-build-lib ]
     runs-on: ubuntu-latest
     container:

--- a/scripts/integration-testing.sh
+++ b/scripts/integration-testing.sh
@@ -18,8 +18,8 @@ sh example/mqtt-cluster/start.sh
 sleep 10
 
 # Run Cargo Test
-cargo nextest run
-# cargo test
+# cargo nextest run
+cargo test
 
 if [ $? -ne 0 ]; then
     echo "Test case failed to run"

--- a/scripts/integration-testing.sh
+++ b/scripts/integration-testing.sh
@@ -18,8 +18,8 @@ sh example/mqtt-cluster/start.sh
 sleep 10
 
 # Run Cargo Test
-# cargo nextest run
-cargo test
+cargo nextest run
+# cargo test
 
 if [ $? -ne 0 ]; then
     echo "Test case failed to run"


### PR DESCRIPTION
## What's changed and what's your intention?

By referring to [Apache Datafusion](https://github.com/apache/datafusion), we have modified our CI/CD pipeline to implement caching of compilation files through sccache, which has reduced the compilation time in CI/CD.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
There is not a related PR.