### PR TITLE
fix: Remove code that initializes the cache repeatedly

### DIFF
--- a/src/placement-center/src/lib.rs
+++ b/src/placement-center/src/lib.rs
@@ -117,8 +117,6 @@ impl PlacementCenter {
             self.engine_cache.clone(),
         ));
 
-        self.init_cache();
-
         self.start_call_thread();
 
         let openraft_node = create_raft_node(self.client_pool.clone(), data_route).await;

--- a/src/placement-center/src/raft/raft_node.rs
+++ b/src/placement-center/src/raft/raft_node.rs
@@ -127,7 +127,7 @@ pub async fn create_raft_node(
 
     let network = Network::new(client_pool);
 
-    match openraft::Raft::new(
+    match Raft::new(
         conf.node.node_id,
         config.clone(),
         network,


### PR DESCRIPTION
- Delete invalid prefixes in lib.rs
