### PR TITLE
refactor: remove unused code and simplify cluster metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,30 +208,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "autotools"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8da1805e028a172334c3b680f93e71126f2327622faef2ec3d893c0a4ad77"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "aws-lc-rs"
@@ -467,11 +447,11 @@ dependencies = [
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools",
  "lazy_static",
  "lazycell",
  "log",
- "prettyplease 0.2.16",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -784,7 +764,7 @@ dependencies = [
  "log4rs",
  "mysql",
  "prometheus",
- "prost 0.12.3",
+ "prost",
  "rocksdb",
  "serde",
  "serde_json",
@@ -1028,27 +1008,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1311,15 +1270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,18 +1288,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1376,7 +1314,7 @@ dependencies = [
  "log",
  "metadata-struct",
  "mobc",
- "prost 0.12.3",
+ "prost",
  "protocol",
  "regex",
  "serde_json",
@@ -1472,15 +1410,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1732,18 +1661,9 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi 0.3.4",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
 ]
 
 [[package]]
@@ -1802,7 +1722,7 @@ dependencies = [
  "grpc-clients",
  "log",
  "metadata-struct",
- "prost 0.12.3",
+ "prost",
  "protocol",
  "rocksdb-engine",
  "rustls-pemfile",
@@ -1857,17 +1777,6 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
-name = "libredox"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
-dependencies = [
- "bitflags 2.4.2",
- "libc",
- "redox_syscall",
-]
 
 [[package]]
 name = "librocksdb-sys"
@@ -1991,15 +1900,6 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
-]
 
 [[package]]
 name = "matchit"
@@ -2380,16 +2280,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.4",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
+ "hermit-abi",
  "libc",
 ]
 
@@ -2648,35 +2539,24 @@ dependencies = [
  "axum 0.7.4",
  "bincode",
  "byteorder",
- "bytes",
  "common-base",
  "dashmap",
- "futures",
- "futures-util",
  "grpc-clients",
- "lazy_static",
  "log",
  "metadata-struct",
  "mobc",
  "openraft",
- "prost 0.12.3",
+ "prost",
  "protocol",
- "raft",
  "rand",
  "rocksdb",
  "rocksdb-engine",
  "serde",
  "serde_json",
- "slog",
- "slog-async",
- "slog-term",
  "thiserror",
- "time",
  "tokio",
- "toml",
  "tonic",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2690,16 +2570,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "prettyplease"
@@ -2770,44 +2640,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
- "prost-derive 0.12.3",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease 0.1.25",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2818,31 +2656,18 @@ checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.11.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.16",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prettyplease",
+ "prost",
+ "prost-types",
  "regex",
  "syn 2.0.48",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2852,19 +2677,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
-dependencies = [
- "prost 0.11.9",
 ]
 
 [[package]]
@@ -2873,7 +2689,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
- "prost 0.12.3",
+ "prost",
 ]
 
 [[package]]
@@ -2881,30 +2697,6 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
-name = "protobuf-build"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c852d9625b912c3e50480cdc701f60f49890b5d7ad46198dd583600f15e7c6ec"
-dependencies = [
- "bitflags 1.3.2",
- "proc-macro2",
- "prost-build 0.11.9",
- "protobuf-src",
- "quote",
- "regex",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "protobuf-src"
-version = "1.1.0+21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
-dependencies = [
- "autotools",
-]
 
 [[package]]
 name = "protocol"
@@ -2915,7 +2707,7 @@ dependencies = [
  "bytes",
  "common-base",
  "futures",
- "prost 0.12.3",
+ "prost",
  "serde",
  "thiserror",
  "tokio",
@@ -2961,31 +2753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "raft"
-version = "0.7.0"
-source = "git+https://github.com/robustmq/raft-rs#5729eb9510ef70b0f85c936cf84b17b6749d6d8b"
-dependencies = [
- "fxhash",
- "getset",
- "protobuf",
- "raft-proto",
- "rand",
- "slog",
- "thiserror",
-]
-
-[[package]]
-name = "raft-proto"
-version = "0.7.0"
-source = "git+https://github.com/robustmq/raft-rs#5729eb9510ef70b0f85c936cf84b17b6749d6d8b"
-dependencies = [
- "lazy_static",
- "prost 0.12.3",
- "protobuf",
- "protobuf-build",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,17 +2792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
-dependencies = [
- "getrandom",
- "libredox",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,17 +2799,8 @@ checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.5",
- "regex-syntax 0.8.2",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3064,14 +2811,8 @@ checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3511,37 +3252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slog"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
-
-[[package]]
-name = "slog-async"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c8038f898a2c79507940990f05386455b3a317d8f18d4caea7cbc3d5096b84"
-dependencies = [
- "crossbeam-channel",
- "slog",
- "take_mut",
- "thread_local",
-]
-
-[[package]]
-name = "slog-term"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
-dependencies = [
- "atty",
- "slog",
- "term",
- "thread_local",
- "time",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3660,12 +3370,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,17 +3386,6 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
 ]
 
 [[package]]
@@ -3760,12 +3453,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
- "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
- "serde",
  "time-core",
  "time-macros",
 ]
@@ -3951,7 +3640,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.3",
+ "prost",
  "tokio",
  "tokio-stream",
  "tower",
@@ -3966,9 +3655,9 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
- "prettyplease 0.2.16",
+ "prettyplease",
  "proc-macro2",
- "prost-build 0.12.3",
+ "prost-build",
  "quote",
  "syn 2.0.48",
 ]
@@ -4065,14 +3754,10 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "matchers",
  "nu-ansi-term",
- "once_cell",
- "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/src/placement-center/Cargo.toml
+++ b/src/placement-center/Cargo.toml
@@ -27,34 +27,17 @@ thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 rocksdb-engine.workspace = true
-futures.workspace = true
-futures-util.workspace = true
-bytes.workspace = true
-lazy_static.workspace = true
 bincode.workspace = true
 dashmap.workspace = true
 byteorder.workspace = true
 axum.workspace = true
-toml.workspace = true
 grpc-clients.workspace = true
 metadata-struct.workspace = true
 openraft.workspace = true
 rand.workspace = true
-# raft = { version = "0.7", features = ["prost-codec"], default-features = false }
-#prost = "0.11"
-
-raft = { git = "https://github.com/robustmq/raft-rs", features = [
-    "prost-codec",
-], default-features = false }
 prost = "0.12.3"
-
-slog = "2"
-slog-term = "2.9.0"
-slog-async = "2.8.0"
-time = "0.3.36"
 log.workspace = true
 mobc.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 rocksdb.workspace = true
 

--- a/src/placement-center/src/core/cache.rs
+++ b/src/placement-center/src/core/cache.rs
@@ -21,16 +21,12 @@ use metadata_struct::placement::node::BrokerNode;
 use serde::{Deserialize, Serialize};
 
 use super::heartbeat::NodeHeartbeatData;
-use crate::core::cluster::ClusterMetadata;
 use crate::storage::placement::cluster::ClusterStorage;
 use crate::storage::placement::node::NodeStorage;
 use crate::storage::rocksdb::RocksDBEngine;
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct PlacementCacheManager {
-    // placement raft cluster
-    pub placement_cluster: DashMap<String, ClusterMetadata>,
-
     // broker cluster & node
     pub cluster_list: DashMap<String, ClusterInfo>,
     pub node_list: DashMap<String, DashMap<u64, BrokerNode>>,
@@ -43,7 +39,6 @@ impl PlacementCacheManager {
             cluster_list: DashMap::with_capacity(2),
             node_heartbeat: DashMap::with_capacity(2),
             node_list: DashMap::with_capacity(2),
-            placement_cluster: DashMap::with_capacity(2),
         };
         cache.load_cache(rocksdb_engine_handler);
         cache
@@ -152,16 +147,9 @@ impl PlacementCacheManager {
                 self.add_broker_node(bn);
             }
         }
-
-        let placement_cluster = DashMap::with_capacity(2);
-        placement_cluster.insert(self.cluster_key(), ClusterMetadata::new());
-        self.placement_cluster = placement_cluster;
     }
 
     fn node_key(&self, cluster_name: &str, node_id: u64) -> String {
         format!("{}_{}", cluster_name, node_id)
-    }
-    fn cluster_key(&self) -> String {
-        "cluster".to_string()
     }
 }

--- a/src/placement-center/src/core/cluster.rs
+++ b/src/placement-center/src/core/cluster.rs
@@ -14,9 +14,14 @@
 
 use std::sync::Arc;
 
-use common_base::config::placement_center::placement_center_conf;
+use super::cache::PlacementCacheManager;
+use super::error::PlacementCenterError;
+use crate::journal::controller::call_node::{
+    update_cache_by_add_journal_node, update_cache_by_delete_journal_node, JournalInnerCallManager,
+};
+use crate::route::apply::RaftMachineApply;
+use crate::route::data::{StorageData, StorageDataType};
 use common_base::tools::now_mills;
-use dashmap::DashMap;
 use grpc_clients::pool::ClientPool;
 use metadata_struct::placement::cluster::ClusterInfo;
 use metadata_struct::placement::node::BrokerNode;
@@ -24,91 +29,6 @@ use prost::Message as _;
 use protocol::placement_center::placement_center_inner::{
     ClusterType, RegisterNodeRequest, UnRegisterNodeRequest,
 };
-use raft::StateRole;
-use serde::{Deserialize, Serialize};
-
-use super::cache::PlacementCacheManager;
-use super::error::PlacementCenterError;
-use crate::journal::controller::call_node::{
-    update_cache_by_add_journal_node, update_cache_by_delete_journal_node, JournalInnerCallManager,
-};
-use crate::raft::raft_node::Node;
-use crate::route::apply::RaftMachineApply;
-use crate::route::data::{StorageData, StorageDataType};
-
-#[derive(Clone, Default, Debug, Serialize, Deserialize)]
-pub struct ClusterMetadata {
-    pub local: Node,
-    pub leader: Option<Node>,
-    pub raft_role: String,
-    pub votes: DashMap<u64, Node>,
-    pub members: DashMap<u64, Node>,
-}
-
-impl ClusterMetadata {
-    pub fn new() -> ClusterMetadata {
-        let config = placement_center_conf();
-
-        if !(1..=65536).contains(&config.node.node_id) {
-            panic!("node ids can range from 1 to 65536");
-        }
-
-        let node_addr = if let Some(addr) =
-            config.node.nodes.get(&format!("{}", config.node.node_id))
-        {
-            addr.to_string()
-        } else {
-            panic!("node id {} There is no corresponding service address, check the nodes configuration",config.node.node_id);
-        };
-
-        let local = Node {
-            node_id: config.node.node_id,
-            rpc_addr: node_addr,
-        };
-
-        let votes = DashMap::with_capacity(2);
-        for (node_id, addr) in config.node.nodes.clone() {
-            let id: u64 = match node_id.to_string().trim().parse() {
-                Ok(id) => id,
-                Err(_) => {
-                    panic!("Node id must be u64");
-                }
-            };
-
-            if addr.to_string().is_empty() {
-                panic!(
-                    "Address corresponding to the node id {} cannot be empty",
-                    id
-                );
-            }
-
-            let node = Node {
-                node_id: id,
-                rpc_addr: addr.to_string(),
-            };
-
-            votes.insert(id, node);
-        }
-
-        ClusterMetadata {
-            local,
-            leader: None,
-            raft_role: role_to_string(StateRole::Candidate),
-            votes,
-            members: DashMap::with_capacity(2),
-        }
-    }
-}
-
-fn role_to_string(role: StateRole) -> String {
-    match role {
-        StateRole::Leader => "Leader".to_string(),
-        StateRole::Follower => "Follower".to_string(),
-        StateRole::Candidate => "Candidate".to_string(),
-        StateRole::PreCandidate => "PreCandidate".to_string(),
-    }
-}
-
 pub async fn register_node_by_req(
     cluster_cache: &Arc<PlacementCacheManager>,
     raft_machine_apply: &Arc<RaftMachineApply>,
@@ -171,7 +91,7 @@ async fn sync_save_node(
     node: &BrokerNode,
 ) -> Result<(), PlacementCenterError> {
     let data = StorageData::new(StorageDataType::ClusterAddNode, serde_json::to_vec(&node)?);
-    if (raft_machine_apply.client_write(data).await?).is_some() {
+    if raft_machine_apply.client_write(data).await?.is_some() {
         return Ok(());
     }
     Err(PlacementCenterError::ExecutionResultIsEmpty)
@@ -185,7 +105,7 @@ pub async fn sync_delete_node(
         StorageDataType::ClusterDeleteNode,
         UnRegisterNodeRequest::encode_to_vec(req),
     );
-    if (raft_machine_apply.client_write(data).await?).is_some() {
+    if raft_machine_apply.client_write(data).await?.is_some() {
         return Ok(());
     }
     Err(PlacementCenterError::ExecutionResultIsEmpty)
@@ -199,7 +119,7 @@ async fn sync_save_cluster(
         StorageDataType::ClusterAddCluster,
         serde_json::to_vec(&node)?,
     );
-    if (raft_machine_apply.client_write(data).await?).is_some() {
+    if raft_machine_apply.client_write(data).await?.is_some() {
         return Ok(());
     }
     Err(PlacementCenterError::ExecutionResultIsEmpty)

--- a/src/placement-center/src/core/controller.rs
+++ b/src/placement-center/src/core/controller.rs
@@ -66,14 +66,11 @@ impl ClusterController {
                 val = stop_recv.recv() =>{
                     if let Ok(flag) = val {
                         if flag {
-
                             break;
                         }
                     }
                 }
-                _ = heartbeat.start()=>{
-
-                }
+                _ = heartbeat.start()=>{}
             }
         }
     }

--- a/src/placement-center/src/raft/raft_node.rs
+++ b/src/placement-center/src/raft/raft_node.rs
@@ -84,7 +84,7 @@ pub async fn start_openraft_node(raft_node: Raft<TypeConfig>) {
     if init_node_id == conf.node.node_id {
         match raft_node.is_initialized().await {
             Ok(flag) => {
-                info!("Whether nodes should be initialized, flag={}", flag);
+                info!("Whether the node has been initialized, flag={}", flag);
                 if !flag {
                     match raft_node.initialize(nodes.clone()).await {
                         Ok(_) => {


### PR DESCRIPTION
- Remove ClusterMetadata struct and related functions
- Delete unused imports and crates
- Simplify PlacementCacheManager struct
- Update register_node_by_req and other functions to use new structure
