### PR TITLE
feat: add validation for get_share_sub_leader method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/rlog/log/server.log
 .idea/modules.xml
 .idea/robustmq.iml
 .idea/vcs.xml
+.idea/workspace.xml
 logs
 nohup.out
 .idea/checkstyle-idea.xml

--- a/src/grpc-clients/tests/placement/mqtt/mqtt_share_sub_test.rs
+++ b/src/grpc-clients/tests/placement/mqtt/mqtt_share_sub_test.rs
@@ -68,5 +68,25 @@ mod tests {
                 panic!("{:?}", e);
             }
         }
+
+        let request = GetShareSubLeaderRequest {
+            group_name: group_name.clone(),
+            cluster_name: "".to_string(),
+        };
+        assert!(
+            placement_get_share_sub_leader(client_pool.clone(), &addrs, request)
+                .await
+                .is_err()
+        );
+
+        let request = GetShareSubLeaderRequest {
+            group_name: "".to_string(),
+            cluster_name: cluster_name.clone(),
+        };
+        assert!(
+            placement_get_share_sub_leader(client_pool.clone(), &addrs, request)
+                .await
+                .is_err()
+        );
     }
 }

--- a/src/placement-center/src/server/grpc/service_mqtt.rs
+++ b/src/placement-center/src/server/grpc/service_mqtt.rs
@@ -38,6 +38,7 @@ use crate::mqtt::services::share_sub::ShareSubLeader;
 use crate::mqtt::services::topic::{create_topic_req, set_topic_retain_message_req};
 use crate::route::apply::RaftMachineApply;
 use crate::route::data::{StorageData, StorageDataType};
+use crate::server::grpc::validate::ValidateExt;
 use crate::storage::mqtt::acl::AclStorage;
 use crate::storage::mqtt::blacklist::MqttBlackListStorage;
 use crate::storage::mqtt::session::MqttSessionStorage;
@@ -72,6 +73,7 @@ impl MqttService for GrpcMqttService {
         request: Request<GetShareSubLeaderRequest>,
     ) -> Result<Response<GetShareSubLeaderReply>, Status> {
         let req = request.into_inner();
+        let _ = req.validate_ext()?;
         let cluster_name = req.cluster_name;
         let group_name = req.group_name;
         let mut reply = GetShareSubLeaderReply::default();

--- a/src/placement-center/src/server/grpc/validate.rs
+++ b/src/placement-center/src/server/grpc/validate.rs
@@ -19,6 +19,7 @@ use protocol::placement_center::placement_center_inner::{
     ClusterType, DeleteIdempotentDataRequest, GetResourceConfigRequest, RegisterNodeRequest,
     SetIdempotentDataRequest, SetResourceConfigRequest, UnRegisterNodeRequest,
 };
+use protocol::placement_center::placement_center_mqtt::GetShareSubLeaderRequest;
 use tonic::Status;
 
 pub trait ValidateExt {
@@ -143,6 +144,15 @@ impl ValidateExt for SetIdempotentDataRequest {
     fn validate_ext(&self) -> Result<(), Status> {
         ensure_param_not_empty("cluster_name", &self.cluster_name)?;
         ensure_param_not_empty("producer_id", &self.producer_id)?;
+
+        Ok(())
+    }
+}
+
+impl ValidateExt for GetShareSubLeaderRequest {
+    fn validate_ext(&self) -> Result<(), Status> {
+        ensure_param_not_empty("group_name", &self.group_name)?;
+        ensure_param_not_empty("cluster_name", &self.cluster_name)?;
 
         Ok(())
     }


### PR DESCRIPTION
## What's changed and what's your intention?

add validation for get_share_sub_leader method

* group_name shoud not be empty
* cluster_name should not be empty

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
https://github.com/robustmq/robustmq/issues/541

close #541 