### PR TITLE
feat: subscribe support queue mode

### DIFF
--- a/.github/actions/build-linux-artifacts/action.yml
+++ b/.github/actions/build-linux-artifacts/action.yml
@@ -51,7 +51,7 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         name: sqlness-logs
-        path: /tmp/robust-*.log
+        path: ./robust-data-*.log
         retention-days: 3
 
     - name: Build standard robust

--- a/.github/actions/build-macos-artifacts/action.yml
+++ b/.github/actions/build-macos-artifacts/action.yml
@@ -84,7 +84,7 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         name: sqlness-logs
-        path: /tmp/robust-*.log
+        path: ./robust-data-*.log
         retention-days: 3
 
     - name: Build robust binary

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ logs
 nohup.out
 .idea
 /precommit_venv/
+robust-data*

--- a/.gitignore
+++ b/.gitignore
@@ -6,15 +6,7 @@ build
 .DS_Store
 log/*
 src/rlog/log/server.log
-.idea/.gitignore
-.idea/modules.xml
-.idea/robustmq.iml
-.idea/vcs.xml
-.idea/workspace.xml
 logs
 nohup.out
-.idea/checkstyle-idea.xml
-.idea/misc.xml
-.idea/codeStyles/Project.xml
-.idea/codeStyles/codeStyleConfig.xml
+.idea
 /precommit_venv/

--- a/config/journal-server.toml
+++ b/config/journal-server.toml
@@ -28,8 +28,8 @@ runtime_work_threads = 100
 
 [storage]
 data_path = [
-    "/tmp/robust/journal-server/storage/data1",
-    "/tmp/robust/journal-server/storage/data2",
+    "./robust-data/journal-server/storage/data1",
+    "./robust-data/journal-server/storage/data2",
 ]
 rocksdb_max_open_files = 10000
 

--- a/config/mqtt-server.toml
+++ b/config/mqtt-server.toml
@@ -56,4 +56,4 @@ storage_type = "memory"
 
 [log]
 log_config = "./config/log4rs.yaml"
-log_path = "/tmp/robust/mqtt-broker/logs"
+log_path = "./robust-data/mqtt-broker/logs"

--- a/config/placement-center.toml
+++ b/config/placement-center.toml
@@ -37,9 +37,9 @@ port = 3306
 # header = ""
 
 [rocksdb]
-data_path = "/tmp/robust/placement-center/data"
+data_path = "./robust-data/placement-center/data"
 max_open_files = 10000
 
 [log]
 log_config = "./config/log4rs.yaml"
-log_path = "/tmp/robust/placement-center/logs"
+log_path = "./robust-data/placement-center/logs"

--- a/docs/cn/系统架构/配置说明/mqtt-server.md
+++ b/docs/cn/系统架构/配置说明/mqtt-server.md
@@ -99,5 +99,5 @@ mysql_addr = ""
 # 日志配置文件路径, 默认./config/log4rs.yaml
 log_config = "./config/log4rs.yaml"
 # 日志文件保存路径, 当前./logs目录
-log_path = "/tmp/robust/mqtt-broker/logs"
+log_path = "./robust-data/mqtt-broker/logs"
 ```

--- a/docs/cn/系统架构/配置说明/placement-center.md
+++ b/docs/cn/系统架构/配置说明/placement-center.md
@@ -46,7 +46,7 @@ heartbeat_check_time_ms = 1000
 ```
 [rocksdb]
 # 定义数据存储路径，rocksdb
-data_path = "/tmp/robust/placement-center/data"
+data_path = "./robust-data/placement-center/data"
 
 # 配置RocksDB数据库的最大打开文件数,支持大量并发读取操作，默认10000
 max_open_files = 10000
@@ -59,5 +59,5 @@ max_open_files = 10000
 log_config = "./config/log4rs.yaml"
 
 # 日志文件存储目录，默认目录./logs/placement-center
-log_path = "/tmp/robust/placement-center/logs"
+log_path = "./robust-data/placement-center/logs"
 ```

--- a/example/mqtt-cluster/journal-server/node-1.toml
+++ b/example/mqtt-cluster/journal-server/node-1.toml
@@ -28,8 +28,8 @@ runtime_work_threads = 100
 
 [storage]
 data_path = [
-    "/tmp/robust-test/journal-server/storage/data1",
-    "/tmp/robust-test/journal-server/storage/data2",
+    "./robust-data-test/journal-server/storage/data1",
+    "./robust-data-test/journal-server/storage/data2",
 ]
 rocksdb_max_open_files = 10000
 
@@ -51,4 +51,4 @@ header = ""
 
 [log]
 log_config = "./config/log4rs.yaml"
-log_path = "/tmp/robust-test/journal-server/logs/journal-server"
+log_path = "./robust-data-test/journal-server/logs/journal-server"

--- a/example/mqtt-cluster/mqtt-server/node-1.toml
+++ b/example/mqtt-cluster/mqtt-server/node-1.toml
@@ -56,4 +56,4 @@ storage_type = "memory"
 
 [log]
 log_config = "./config/log4rs.yaml"
-log_path = "/tmp/robust-test/mqtt-broker-1/logs"
+log_path = "./robust-data-test/mqtt-broker-1/logs"

--- a/example/mqtt-cluster/mqtt-server/node-2.toml
+++ b/example/mqtt-cluster/mqtt-server/node-2.toml
@@ -56,5 +56,5 @@ storage_type = "memory"
 
 [log]
 log_config = "./config/log4rs.yaml"
-log_path = "/tmp/robust/mqtt-broker-2/logs"
+log_path = "./robust-data/mqtt-broker-2/logs"
 

--- a/example/mqtt-cluster/mqtt-server/node-3.toml
+++ b/example/mqtt-cluster/mqtt-server/node-3.toml
@@ -56,5 +56,5 @@ storage_type = "memory"
 
 [log]
 log_config = "./config/log4rs.yaml"
-log_path = "/tmp/robust/mqtt-broker-3/logs"
+log_path = "./robust-data/mqtt-broker-3/logs"
 

--- a/example/mqtt-cluster/placement-center/node-1.toml
+++ b/example/mqtt-cluster/placement-center/node-1.toml
@@ -31,9 +31,9 @@ heartbeat_timeout_ms = 5000
 heartbeat_check_time_ms = 1000
 
 [rocksdb]
-data_path = "/tmp/robust-test/placement-center-1/data"
+data_path = "./robust-data-test/placement-center-1/data"
 max_open_files = 10000
 
 [log]
 log_config = "./config/log4rs.yaml"
-log_path = "/tmp/robust-test/placement-center-1/logs"
+log_path = "./robust-data-test/placement-center-1/logs"

--- a/example/mqtt-cluster/placement-center/node-2.toml
+++ b/example/mqtt-cluster/placement-center/node-2.toml
@@ -30,9 +30,9 @@ heartbeat_timeout_ms = 5000
 heartbeat_check_time_ms = 1000
 
 [rocksdb]
-data_path = "/tmp/robust/placement-center-2/data"
+data_path = "./robust-data/placement-center-2/data"
 max_open_files = 10000
 
 [log]
 log_config = "./config/log4rs.yaml"
-log_path = "/tmp/robust/placement-center-2/logs"
+log_path = "./robust-data/placement-center-2/logs"

--- a/example/mqtt-cluster/placement-center/node-3.toml
+++ b/example/mqtt-cluster/placement-center/node-3.toml
@@ -30,9 +30,9 @@ heartbeat_timeout_ms = 5000
 heartbeat_check_time_ms = 1000
 
 [rocksdb]
-data_path = "/tmp/robust/placement-center-3/data"
+data_path = "./robust-data/placement-center-3/data"
 max_open_files = 10000
 
 [log]
 log_config = "./config/log4rs.yaml"
-log_path = "/tmp/robust/placement-center-3/logs"
+log_path = "./robust-data/placement-center-3/logs"

--- a/example/mqtt-cluster/stop.sh
+++ b/example/mqtt-cluster/stop.sh
@@ -37,9 +37,9 @@ stop_pc_cluster(){
 
     sleep 3
 
-    rm -rf  /tmp/robust/placement-center-1/data
-    # rm -rf  /tmp/robust/placement-center-2/data
-    # rm -rf  /tmp/robust/placement-center-3/data
+    rm -rf  ./robust-data/placement-center-1/data
+    # rm -rf  ./robust-data/placement-center-2/data
+    # rm -rf  ./robust-data/placement-center-3/data
 }
 
 stop_mqtt_cluster(){

--- a/scripts/journal-ig-test.sh
+++ b/scripts/journal-ig-test.sh
@@ -53,8 +53,8 @@ stop_journal_server(){
 }
 
 # Clean up
-rm -rf /tmp/robust-test/placement-center*
-rm -rf /tmp/robust-test/journal-server*
+rm -rf ./robust-data-test/placement-center*
+rm -rf ./robust-data-test/journal-server*
 
 # Start Server
 start_placement_server

--- a/scripts/mqtt-ig-test.sh
+++ b/scripts/mqtt-ig-test.sh
@@ -53,8 +53,8 @@ stop_mqtt_server(){
 }
 
 # Clean up
-rm -rf /tmp/robust-test/placement-center*
-rm -rf /tmp/robust-test/mqtt-server*
+rm -rf ./robust-data-test/placement-center*
+rm -rf ./robust-data-test/mqtt-server*
 
 # Start Server
 start_placement_server

--- a/scripts/place-ig-test.sh
+++ b/scripts/place-ig-test.sh
@@ -33,7 +33,7 @@ stop_server(){
     fi
 }
 # Clean up
-rm -rf /tmp/robust-test/placement-center*
+rm -rf ./robust-data-test/placement-center*
 
 # Start Server
 start_server

--- a/src/common/base/src/config/broker_mqtt.rs
+++ b/src/common/base/src/config/broker_mqtt.rs
@@ -209,7 +209,7 @@ mod tests {
 
         assert_eq!(
             config.log.log_path,
-            "/tmp/robust/mqtt-broker/logs".to_string()
+            "./robust-data/mqtt-broker/logs".to_string()
         );
         assert_eq!(config.log.log_config, "./config/log4rs.yaml");
 
@@ -260,7 +260,7 @@ mod tests {
 
         assert_eq!(
             config.log.log_path,
-            "/tmp/robust/mqtt-broker/logs".to_string()
+            "./robust-data/mqtt-broker/logs".to_string()
         );
         assert_eq!(config.log.log_config, "./config/log4rs.yaml");
 

--- a/src/common/base/src/config/default_placement_center.rs
+++ b/src/common/base/src/config/default_placement_center.rs
@@ -58,7 +58,7 @@ pub fn default_runtime_work_threads() -> usize {
 }
 
 pub fn default_data_path() -> String {
-    "/tmp/robust/placement-center/data".to_string()
+    "./robust-data/placement-center/data".to_string()
 }
 
 pub fn default_log() -> Log {

--- a/src/common/base/src/config/placement_center.rs
+++ b/src/common/base/src/config/placement_center.rs
@@ -201,15 +201,15 @@ mod tests {
         assert_eq!(config.network.http_port, 1227);
         assert_eq!(config.system.runtime_work_threads, 100);
         println!("{}", config.rocksdb.data_path);
-        println!("/tmp/robust/placement-center/data");
+        println!("./robust-data/placement-center/data");
         assert_eq!(
             config.rocksdb.data_path,
-            "/tmp/robust/placement-center/data".to_string()
+            "./robust-data/placement-center/data".to_string()
         );
         assert_eq!(
             config.log,
             Log {
-                log_path: "/tmp/robust/placement-center/logs".to_string(),
+                log_path: "./robust-data/placement-center/logs".to_string(),
                 log_config: "./config/log4rs.yaml".to_string(),
             }
         );

--- a/src/mqtt-broker/src/subscribe/sub_common.rs
+++ b/src/mqtt-broker/src/subscribe/sub_common.rs
@@ -143,7 +143,7 @@ pub fn decode_share_info(sub_name: String) -> (String, String) {
 pub fn decode_queue_info(sub_name: String) -> String {
     let mut str_slice: Vec<&str> = sub_name.split("/").collect();
     str_slice.remove(0);
-    str_slice.remove(0).to_string()
+    format!("/{}", str_slice.join("/"))
 }
 
 pub async fn get_share_sub_leader(

--- a/src/mqtt-broker/src/subscribe/sub_common.rs
+++ b/src/mqtt-broker/src/subscribe/sub_common.rs
@@ -48,6 +48,8 @@ use crate::storage::message::MessageStorage;
 
 const SHARE_SUB_PREFIX: &str = "$share";
 
+const QUEUE_SUB_PREFIX: &str = "$queue";
+
 pub fn path_contain_sub(_: &str) -> bool {
     true
 }
@@ -126,12 +128,22 @@ pub fn is_share_sub(sub_name: String) -> bool {
     sub_name.starts_with(SHARE_SUB_PREFIX)
 }
 
+pub fn is_queue_sub(sub_name: String) -> bool {
+    sub_name.starts_with(QUEUE_SUB_PREFIX)
+}
+
 pub fn decode_share_info(sub_name: String) -> (String, String) {
     let mut str_slice: Vec<&str> = sub_name.split("/").collect();
     str_slice.remove(0);
     let group_name = str_slice.remove(0).to_string();
     let sub_name = format!("/{}", str_slice.join("/"));
     (group_name, sub_name)
+}
+
+pub fn decode_queue_info(sub_name: String) -> String {
+    let mut str_slice: Vec<&str> = sub_name.split("/").collect();
+    str_slice.remove(0);
+    str_slice.remove(0).to_string()
 }
 
 pub async fn get_share_sub_leader(

--- a/src/mqtt-broker/src/subscribe/subscribe_manager.rs
+++ b/src/mqtt-broker/src/subscribe/subscribe_manager.rs
@@ -30,8 +30,8 @@ use tokio::sync::broadcast::Sender;
 use tokio::time::sleep;
 
 use super::sub_common::{
-    decode_share_info, delete_exclusive_topic, get_share_sub_leader, is_share_sub,
-    path_regex_match, set_nx_exclusive_topic,
+    decode_queue_info, decode_share_info, delete_exclusive_topic, get_share_sub_leader,
+    is_queue_sub, is_share_sub, path_regex_match, set_nx_exclusive_topic,
 };
 use crate::handler::cache::CacheManager;
 use crate::subscribe::subscriber::Subscriber;
@@ -55,6 +55,19 @@ pub struct ShareLeaderSubscribeData {
     pub sub_name: String,
     // (client_id_sub_path, subscriber)
     pub sub_list: DashMap<String, Subscriber>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+struct ParseShareQueueSubscribeRequest {
+    topic_name: String,
+    topic_id: String,
+    client_id: String,
+    protocol: MqttProtocol,
+    subscribe: Subscribe,
+    sub_identifier: Option<usize>,
+    filter: Filter,
+    sub_name: String,
+    group_name: String,
 }
 
 #[derive(Clone)]
@@ -309,6 +322,63 @@ impl SubscribeManager {
         Ok(())
     }
 
+    async fn parse_share_subscribe(&self, req: &mut ParseShareQueueSubscribeRequest) {
+        let (group_name, sub_name) = decode_share_info(req.filter.path.clone());
+        req.group_name = group_name;
+        req.sub_name = sub_name;
+        self.parse_share_queue_subscribe_common(req).await;
+    }
+
+    async fn parse_queue_subscribe(&self, req: &mut ParseShareQueueSubscribeRequest) {
+        let sub_name = decode_queue_info(req.filter.path.clone());
+        // queueSub is a special shareSub
+        let group_name = format!("$queue/{}", req.topic_name);
+        req.group_name = group_name;
+        req.sub_name = sub_name;
+        self.parse_share_queue_subscribe_common(req).await;
+    }
+
+    async fn parse_share_queue_subscribe_common(&self, req: &ParseShareQueueSubscribeRequest) {
+        let conf = broker_mqtt_conf();
+        if path_regex_match(req.topic_name.clone(), req.sub_name.clone()) {
+            match get_share_sub_leader(self.client_pool.clone(), req.group_name.clone()).await {
+                Ok(reply) => {
+                    if reply.broker_id == conf.broker_id {
+                        self.parse_share_subscribe_leader(
+                            req.topic_name.clone(),
+                            req.topic_id.clone(),
+                            req.client_id.clone(),
+                            req.protocol.clone(),
+                            req.sub_identifier,
+                            req.filter.clone(),
+                            req.group_name.clone(),
+                            req.sub_name.clone(),
+                        )
+                        .await;
+                    } else {
+                        self.parse_share_subscribe_follower(
+                            req.topic_id.clone(),
+                            req.client_id.clone(),
+                            req.protocol.clone(),
+                            req.sub_identifier,
+                            req.filter.clone(),
+                            req.group_name.clone(),
+                            req.sub_name.clone(),
+                            req.subscribe.clone(),
+                        )
+                        .await;
+                    }
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to get Leader for shared subscription, error message: {}",
+                        e
+                    );
+                }
+            }
+        }
+    }
+
     async fn parse_subscribe(
         &self,
         topic_name: String,
@@ -326,45 +396,31 @@ impl SubscribeManager {
 
         for filter in subscribe.filters.clone() {
             if is_share_sub(filter.path.clone()) {
-                let conf = broker_mqtt_conf();
-                let (group_name, sub_name) = decode_share_info(filter.path.clone());
-                if path_regex_match(topic_name.clone(), sub_name.clone()) {
-                    match get_share_sub_leader(self.client_pool.clone(), group_name.clone()).await {
-                        Ok(reply) => {
-                            if reply.broker_id == conf.broker_id {
-                                self.parse_share_subscribe_leader(
-                                    topic_name.clone(),
-                                    topic_id.clone(),
-                                    client_id.clone(),
-                                    protocol.clone(),
-                                    sub_identifier,
-                                    filter,
-                                    group_name.clone(),
-                                    sub_name.clone(),
-                                )
-                                .await;
-                            } else {
-                                self.parse_share_subscribe_follower(
-                                    topic_id.clone(),
-                                    client_id.clone(),
-                                    protocol.clone(),
-                                    sub_identifier,
-                                    filter,
-                                    group_name.clone(),
-                                    sub_name.clone(),
-                                    subscribe.clone(),
-                                )
-                                .await;
-                            }
-                        }
-                        Err(e) => {
-                            error!(
-                                "Failed to get Leader for shared subscription, error message: {}",
-                                e
-                            );
-                        }
-                    }
-                }
+                self.parse_share_subscribe(&mut ParseShareQueueSubscribeRequest {
+                    topic_name: topic_name.clone(),
+                    topic_id: topic_id.clone(),
+                    client_id: client_id.clone(),
+                    protocol: protocol.clone(),
+                    subscribe: subscribe.clone(),
+                    sub_identifier,
+                    filter,
+                    sub_name: "".to_string(),
+                    group_name: "".to_string(),
+                })
+                .await;
+            } else if is_queue_sub(filter.path.clone()) {
+                self.parse_queue_subscribe(&mut ParseShareQueueSubscribeRequest {
+                    topic_name: topic_name.clone(),
+                    topic_id: topic_id.clone(),
+                    client_id: client_id.clone(),
+                    protocol: protocol.clone(),
+                    subscribe: subscribe.clone(),
+                    sub_identifier,
+                    filter,
+                    sub_name: "".to_string(),
+                    group_name: "".to_string(),
+                })
+                .await;
             } else {
                 self.parse_exclusive_subscribe(
                     topic_name.clone(),
@@ -393,36 +449,22 @@ impl SubscribeManager {
         let share_leader_key = self.share_leader_key(&group_name, &sub_name, &topic_id);
         let leader_sub_key = self.share_leader_sub_key(client_id.clone(), filter.path.clone());
 
+        let sub = Subscriber {
+            protocol: protocol.clone(),
+            client_id: client_id.clone(),
+            topic_name: topic_name.clone(),
+            group_name: Some(group_name.clone()),
+            topic_id: topic_id.clone(),
+            qos: filter.qos,
+            nolocal: filter.nolocal,
+            preserve_retain: filter.preserve_retain,
+            retain_forward_rule: filter.retain_forward_rule.clone(),
+            subscription_identifier: sub_identifier,
+            sub_path: filter.path.clone(),
+        };
         if let Some(share_sub) = self.share_leader_subscribe.get_mut(&share_leader_key) {
-            let sub = Subscriber {
-                protocol: protocol.clone(),
-                client_id: client_id.clone(),
-                topic_name: topic_name.clone(),
-                group_name: Some(group_name.clone()),
-                topic_id: topic_id.clone(),
-                qos: filter.qos,
-                nolocal: filter.nolocal,
-                preserve_retain: filter.preserve_retain,
-                retain_forward_rule: filter.retain_forward_rule.clone(),
-                subscription_identifier: sub_identifier,
-                sub_path: filter.path.clone(),
-            };
             share_sub.sub_list.insert(leader_sub_key, sub);
         } else {
-            let sub = Subscriber {
-                protocol: protocol.clone(),
-                client_id: client_id.clone(),
-                topic_name: topic_name.clone(),
-                group_name: Some(group_name.clone()),
-                topic_id: topic_id.clone(),
-                qos: filter.qos,
-                nolocal: filter.nolocal,
-                preserve_retain: filter.preserve_retain,
-                retain_forward_rule: filter.retain_forward_rule.clone(),
-                subscription_identifier: sub_identifier,
-                sub_path: filter.path.clone(),
-            };
-
             let sub_list = DashMap::with_capacity(8);
             sub_list.insert(leader_sub_key, sub);
 

--- a/src/mqtt-broker/src/subscribe/subscribe_manager.rs
+++ b/src/mqtt-broker/src/subscribe/subscribe_manager.rs
@@ -324,7 +324,7 @@ impl SubscribeManager {
 
     async fn parse_share_subscribe(&self, req: &mut ParseShareQueueSubscribeRequest) {
         let (group_name, sub_name) = decode_share_info(req.filter.path.clone());
-        req.group_name = group_name;
+        req.group_name = format!("{}{}", group_name, sub_name);
         req.sub_name = sub_name;
         self.parse_share_queue_subscribe_common(req).await;
     }
@@ -332,7 +332,7 @@ impl SubscribeManager {
     async fn parse_queue_subscribe(&self, req: &mut ParseShareQueueSubscribeRequest) {
         let sub_name = decode_queue_info(req.filter.path.clone());
         // queueSub is a special shareSub
-        let group_name = format!("$queue/{}", req.topic_name);
+        let group_name = format!("$queue{}", sub_name);
         req.group_name = group_name;
         req.sub_name = sub_name;
         self.parse_share_queue_subscribe_common(req).await;

--- a/tests/tests/mqtt_protocol/share_sub_test.rs
+++ b/tests/tests/mqtt_protocol/share_sub_test.rs
@@ -37,6 +37,24 @@ mod tests {
         simple_test(topic.clone(), sub_topic.clone(), sub_qos, "3".to_string()).await;
     }
 
+    #[tokio::test]
+    async fn client5_queue_subscribe_test() {
+        let sub_qos = &[0];
+        let topic = format!("/tests/{}", unique_id());
+        let sub_topic = format!("$queue{}", topic);
+        simple_test(topic.clone(), sub_topic.clone(), sub_qos, "2".to_string()).await;
+
+        let sub_qos = &[1];
+        let topic = format!("/tests/{}", unique_id());
+        let sub_topic = format!("$queue{}", topic);
+        simple_test(topic.clone(), sub_topic.clone(), sub_qos, "1".to_string()).await;
+
+        let sub_qos = &[2];
+        let topic = format!("/tests/{}", unique_id());
+        let sub_topic = format!("$queue{}", topic);
+        simple_test(topic.clone(), sub_topic.clone(), sub_qos, "3".to_string()).await;
+    }
+
     async fn simple_test(
         pub_topic: String,
         sub_topic: String,

--- a/tests/tests/place_server/share_sub.rs
+++ b/tests/tests/place_server/share_sub.rs
@@ -64,4 +64,43 @@ mod tests {
         println!("node_id:{}", node_id);
         assert_eq!(resp.broker_id, node_id);
     }
+
+    #[tokio::test]
+    async fn test_queue_sub() {
+        let client_pool = Arc::new(ClientPool::new(3));
+        let addrs = vec!["127.0.0.1:1228".to_string()];
+
+        let cluster_type = ClusterType::MqttBrokerServer.into();
+        let cluster_name = unique_id();
+        let node_ip = "127.0.0.1".to_string();
+        let node_id = 7;
+        let node_inner_addr = "127.0.0.1:8228".to_string();
+        let extend_info = "".to_string();
+        let request = RegisterNodeRequest {
+            cluster_type,
+            cluster_name: cluster_name.clone(),
+            node_ip,
+            node_id,
+            node_inner_addr,
+            extend_info,
+        };
+
+        sleep(Duration::from_secs(2));
+
+        let res = register_node(&client_pool, &addrs, request).await.unwrap();
+        info!("{:?}", res);
+
+        let group_name = "$queue/topic1".to_string();
+        let req = GetShareSubLeaderRequest {
+            cluster_name: cluster_name.clone(),
+            group_name,
+        };
+
+        let resp = placement_get_share_sub_leader(&client_pool, &addrs, req)
+            .await
+            .unwrap();
+        println!("resp broker_id:{}", resp.broker_id);
+        println!("node_id:{}", node_id);
+        assert_eq!(resp.broker_id, node_id);
+    }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

subscribe support queue mode

- parse_subscribe method support decode queue example like '$queue/t/1'
- reusing shared subscription logic with group set to $queue/{topic_name}

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
https://github.com/robustmq/robustmq/issues/550