### PR TITLE
chore: Add validation to exists_idempotent_data and test

### DIFF
--- a/src/placement-center/src/server/grpc/service_inner.rs
+++ b/src/placement-center/src/server/grpc/service_inner.rs
@@ -270,6 +270,9 @@ impl PlacementCenterService for GrpcPlacementService {
         request: Request<ExistsIdempotentDataRequest>,
     ) -> Result<Response<ExistsIdempotentDataReply>, Status> {
         let req = request.into_inner();
+
+        let _ = req.validate_ext()?;
+
         let storage = IdempotentStorage::new(self.rocksdb_engine_handler.clone());
         match storage.exists(&req.cluster_name, &req.producer_id, req.seq_num) {
             Ok(flag) => {

--- a/src/placement-center/src/server/grpc/validate.rs
+++ b/src/placement-center/src/server/grpc/validate.rs
@@ -16,8 +16,9 @@ use std::net::{IpAddr, SocketAddr};
 
 use common_base::error::common::CommonError;
 use protocol::placement_center::placement_center_inner::{
-    ClusterType, DeleteIdempotentDataRequest, GetResourceConfigRequest, NodeListRequest,
-    RegisterNodeRequest, SetIdempotentDataRequest, SetResourceConfigRequest, UnRegisterNodeRequest,
+    ClusterType, DeleteIdempotentDataRequest, ExistsIdempotentDataRequest,
+    GetResourceConfigRequest, NodeListRequest, RegisterNodeRequest, SetIdempotentDataRequest,
+    SetResourceConfigRequest, UnRegisterNodeRequest,
 };
 use protocol::placement_center::placement_center_mqtt::GetShareSubLeaderRequest;
 use tonic::Status;
@@ -161,6 +162,15 @@ impl ValidateExt for GetShareSubLeaderRequest {
 impl ValidateExt for NodeListRequest {
     fn validate_ext(&self) -> Result<(), Status> {
         ensure_param_not_empty("cluster_name", &self.cluster_name)?;
+        Ok(())
+    }
+}
+
+impl ValidateExt for ExistsIdempotentDataRequest {
+    fn validate_ext(&self) -> Result<(), Status> {
+        println!("here!!!!!!");
+        ensure_param_not_empty("cluster_name", &self.cluster_name)?;
+        ensure_param_not_empty("producer_id", &self.producer_id)?;
         Ok(())
     }
 }

--- a/src/placement-center/src/server/grpc/validate.rs
+++ b/src/placement-center/src/server/grpc/validate.rs
@@ -168,7 +168,6 @@ impl ValidateExt for NodeListRequest {
 
 impl ValidateExt for ExistsIdempotentDataRequest {
     fn validate_ext(&self) -> Result<(), Status> {
-        println!("here!!!!!!");
         ensure_param_not_empty("cluster_name", &self.cluster_name)?;
         ensure_param_not_empty("producer_id", &self.producer_id)?;
         Ok(())


### PR DESCRIPTION
close #546 

Add validation to `exists_idempotent_data` method (`cluster_name` and `producer_id` field should not be empty) and filled in the test case.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
