### PR TITLE
chore: Add validation to the delete_resource_config method and test

### DIFF
--- a/src/grpc-clients/tests/placement/mqtt/cluster_test.rs
+++ b/src/grpc-clients/tests/placement/mqtt/cluster_test.rs
@@ -17,14 +17,14 @@ mod tests {
     use std::sync::Arc;
 
     use grpc_clients::placement::inner::call::{
-        cluster_status, delete_idempotent_data, exists_idempotent_data, get_resource_config,
-        node_list, register_node, set_resource_config, unregister_node,
+        cluster_status, delete_idempotent_data, delete_resource_config, exists_idempotent_data,
+        get_resource_config, node_list, register_node, set_resource_config, unregister_node,
     };
     use grpc_clients::pool::ClientPool;
     use protocol::placement_center::placement_center_inner::{
         ClusterStatusRequest, ClusterType, DeleteIdempotentDataRequest,
-        ExistsIdempotentDataRequest, GetResourceConfigRequest, NodeListRequest,
-        RegisterNodeRequest, SetResourceConfigRequest, UnRegisterNodeRequest,
+        DeleteResourceConfigRequest, ExistsIdempotentDataRequest, GetResourceConfigRequest,
+        NodeListRequest, RegisterNodeRequest, SetResourceConfigRequest, UnRegisterNodeRequest,
     };
 
     use crate::common::get_placement_addr;
@@ -288,6 +288,31 @@ mod tests {
         };
 
         assert!(exists_idempotent_data(&client_pool, &addrs, request)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_resource_config_test() {
+        let client_pool: Arc<ClientPool> = Arc::new(ClientPool::new(1));
+        let addrs = vec![get_placement_addr()];
+
+        let request = ClusterStatusRequest::default();
+        assert!(cluster_status(&client_pool, &addrs, request).await.is_ok());
+
+        let request = DeleteResourceConfigRequest {
+            cluster_name: "test-cluster-name".to_string(),
+            resources: Vec::new(),
+        };
+        assert!(delete_resource_config(&client_pool, &addrs, request)
+            .await
+            .is_ok());
+
+        let request = DeleteResourceConfigRequest {
+            cluster_name: "".to_string(),
+            resources: Vec::new(),
+        };
+        assert!(delete_resource_config(&client_pool, &addrs, request)
             .await
             .is_err());
     }

--- a/src/placement-center/src/server/grpc/service_inner.rs
+++ b/src/placement-center/src/server/grpc/service_inner.rs
@@ -233,6 +233,9 @@ impl PlacementCenterService for GrpcPlacementService {
         request: Request<DeleteResourceConfigRequest>,
     ) -> Result<Response<DeleteResourceConfigReply>, Status> {
         let req = request.into_inner();
+
+        let _ = req.validate_ext()?;
+
         let data = StorageData::new(
             StorageDataType::ClusterDeleteResourceConfig,
             DeleteResourceConfigRequest::encode_to_vec(&req),

--- a/src/placement-center/src/server/grpc/validate.rs
+++ b/src/placement-center/src/server/grpc/validate.rs
@@ -16,9 +16,9 @@ use std::net::{IpAddr, SocketAddr};
 
 use common_base::error::common::CommonError;
 use protocol::placement_center::placement_center_inner::{
-    ClusterType, DeleteIdempotentDataRequest, ExistsIdempotentDataRequest,
-    GetResourceConfigRequest, NodeListRequest, RegisterNodeRequest, SetIdempotentDataRequest,
-    SetResourceConfigRequest, UnRegisterNodeRequest,
+    ClusterType, DeleteIdempotentDataRequest, DeleteResourceConfigRequest,
+    ExistsIdempotentDataRequest, GetResourceConfigRequest, NodeListRequest, RegisterNodeRequest,
+    SetIdempotentDataRequest, SetResourceConfigRequest, UnRegisterNodeRequest,
 };
 use protocol::placement_center::placement_center_mqtt::GetShareSubLeaderRequest;
 use tonic::Status;
@@ -170,6 +170,13 @@ impl ValidateExt for ExistsIdempotentDataRequest {
     fn validate_ext(&self) -> Result<(), Status> {
         ensure_param_not_empty("cluster_name", &self.cluster_name)?;
         ensure_param_not_empty("producer_id", &self.producer_id)?;
+        Ok(())
+    }
+}
+
+impl ValidateExt for DeleteResourceConfigRequest {
+    fn validate_ext(&self) -> Result<(), Status> {
+        ensure_param_not_empty("cluster_name", &self.cluster_name)?;
         Ok(())
     }
 }


### PR DESCRIPTION
close #544 

## What's changed and what's your intention?

Add validation to the `delete_resource_config` method (`cluster_name` should not be empty) and add the corresponding test case.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
