### PR TITLE
build: Change rust toolchain version from nightly to stable

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -32,7 +32,7 @@ runs:
         apt-get install -y cmake
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly-2024-11-08
+        toolchain: stable
         default: true
     - name: configure cargo cache
       uses: actions/cache@v4

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -27,7 +27,7 @@ on:
 name: Build API docs
 
 env:
-  RUST_TOOLCHAIN: nightly-2023-12-19
+  RUST_TOOLCHAIN: stable
 
 jobs:
   apidoc:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 [toolchain]
-channel = "nightly-2024-11-08"
+channel = "stable"
 components = [ "rustfmt", "rust-src", "miri", "rust-analyzer"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -12,5 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+edition = "2024"
 group_imports = "StdExternalCrate"
 imports_granularity = "Module"


### PR DESCRIPTION
close #738 

## What's changed and what's your intention?

It seems like all unit tests and integration tests work properly when stable toolchain is used.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.
