### PR TITLE
feat: add cli-command yaml to  k8s-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,3 +73,17 @@ COPY --from=builder /robustmq/target/release/journal-server /robustmq/libs/journ
 COPY --from=builder /robustmq/config/* /robustmq/config/
 
 ENTRYPOINT ["/robustmq/libs/journal-server","--conf","config/cluster/journal-server/node.toml"]
+
+# cli-command
+FROM rust:bullseye AS cli-command
+
+RUN sed -i "s@http://\(deb\|security\).debian.org@https://mirrors.aliyun.com@g" /etc/apt/sources.list && \
+    apt-get update && apt-get install -y clang libclang-dev
+
+WORKDIR /robustmq
+
+COPY --from=builder bin/* /robustmq/bin/
+COPY --from=builder /robustmq/target/release/cli-command /robustmq/libs/cli-command
+COPY --from=builder /robustmq/config/* /robustmq/config/
+
+ENTRYPOINT ["/robustmq/libs/cli-command","-h"]

--- a/example/test-network-k8s/kube/cli-command.yaml
+++ b/example/test-network-k8s/kube/cli-command.yaml
@@ -1,0 +1,42 @@
+# Copyright 2023 RobustMQ Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: ${NAMESPACE}
+  name: cli-command
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cli-command
+  template:
+    metadata:
+      labels:
+        app: cli-command
+    spec:
+      containers:
+        - name: cli-command
+          imagePullPolicy: IfNotPresent
+          image: docker.io/library/${CLI_COMMAND_IMAGE_NAME}:${IMAGE_VERSION}
+          resources:
+            requests:
+              memory: "200Mi"
+              cpu: "500m"
+          command:
+            - sh
+            - -c
+            - |
+              tail -f /dev/null

--- a/example/test-network-k8s/kube/mqtt-server.yaml
+++ b/example/test-network-k8s/kube/mqtt-server.yaml
@@ -26,6 +26,8 @@ spec:
       name: grpc
     - port: 9982
       name: http
+    - port: 1883
+      name: mqtt
   selector:
     app: mqtt-server
 ---
@@ -35,7 +37,7 @@ metadata:
   namespace: ${NAMESPACE}
   name: mqtt-server
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: mqtt-server
@@ -57,6 +59,8 @@ spec:
               name: grpc
             - containerPort: 9982
               name: http
+            - containerPort: 1883
+              name: mqtt
           env:
             - name: MQTT_SERVER_PLACEMENT_CENTER
               value: |
@@ -69,7 +73,7 @@ spec:
             - sh
             - -c
             - |
-              export BROKER_ID=$(echo ${INDEX} | sed -E 's/.*-([^-]+)$/\1/; s/[^0-9]//g') && /robustmq/libs/mqtt-server --conf /robustmq/config/cluster/mqtt-server/node.toml
+              export BROKER_ID=1 && /robustmq/libs/mqtt-server --conf /robustmq/config/cluster/mqtt-server/node.toml
           volumeMounts:
             - name: config
               mountPath: /robustmq/config/cluster/mqtt-server/node.toml

--- a/example/test-network-k8s/network.sh
+++ b/example/test-network-k8s/network.sh
@@ -32,6 +32,7 @@ context NGINX_HTTPS_PORT                443
 context MQTT_SERVER_IMAGE_NAME          mqtt-server-test
 context JOURNAL_SERVER_IMAGE_NAME       journal-server-test
 context PLACEMENT_CENTER_IMAGE_NAME     placement-center-test
+context CLI_COMMAND_IMAGE_NAME          cli-command-test
 context IMAGE_VERSION                   0.2
 
 context NAMESPACE                       robustmq

--- a/example/test-network-k8s/scripts/docker.sh
+++ b/example/test-network-k8s/scripts/docker.sh
@@ -16,7 +16,9 @@
 function docker_build() {
     local mqtt_server_tag=${MQTT_SERVER_IMAGE_NAME}:${IMAGE_VERSION}
     local placement_center_tag=${PLACEMENT_CENTER_IMAGE_NAME}:${IMAGE_VERSION}
+    local cli_command_tag=${CLI_COMMAND_IMAGE_NAME}:${IMAGE_VERSION}
     cd ../../
     docker build --target placement-center -t ${placement_center_tag} .
     docker build --target mqtt-server -t ${mqtt_server_tag} .
+    docker build --target cli-command -t ${cli_command_tag} .
 }

--- a/example/test-network-k8s/scripts/kind.sh
+++ b/example/test-network-k8s/scripts/kind.sh
@@ -66,9 +66,11 @@ EOF
 function kind_load_docker_images() {
     local mqtt_server_tag=${MQTT_SERVER_IMAGE_NAME}:${IMAGE_VERSION}
     local placement_center_tag=${PLACEMENT_CENTER_IMAGE_NAME}:${IMAGE_VERSION}
+    local cli_command_tag=${CLI_COMMAND_IMAGE_NAME}:${IMAGE_VERSION}
     # 加载的镜像只在当前 Kind 集群有效。如果你销毁并重新创建集群，需要重新加载镜像。
     kind load docker-image ${mqtt_server_tag}      --name ${CLUSTER_NAME}
     kind load docker-image ${placement_center_tag} --name ${CLUSTER_NAME}
+    kind load docker-image ${cli_command_tag}     --name ${CLUSTER_NAME}
 
     kind load docker-image k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1 --name ${CLUSTER_NAME}
     kind load docker-image k8s.gcr.io/ingress-nginx/controller:v1.1.2 --name ${CLUSTER_NAME}

--- a/example/test-network-k8s/scripts/robustmq.sh
+++ b/example/test-network-k8s/scripts/robustmq.sh
@@ -21,6 +21,7 @@ function network_up() {
     apply_template kube/cfg-mqtt-server.yaml ${NAMESPACE}
     apply_template kube/mqtt-server.yaml ${NAMESPACE}
     apply_template kube/mqtt-server-ingress.yaml ${NAMESPACE}
+    apply_template kube/cli-command.yaml ${NAMESPACE}
 }
 
 function network_down() {
@@ -28,6 +29,7 @@ function network_down() {
     kubectl delete statefulset placement-center -n ${NAMESPACE}
     kubectl delete configmap placement-center-config -n ${NAMESPACE}
     kubectl delete configmap mqtt-server-config -n ${NAMESPACE}
+    kubectl delete deployment cli-command -n ${NAMESPACE}
     kubectl delete namespace ${NAMESPACE}
-    kubectl delete ingress mqtt-server-ingress -n ${NAMESPACE}
+#    kubectl delete ingress mqtt-server-ingress -n ${NAMESPACE}
 }


### PR DESCRIPTION
1. cli-command image build added to Dockerfile
2. Start a cli-command in k8s to facilitate testing cluster functions in a cloud environment

   2.1 Demo

      ```console
      % kubectl exec -it cli-command-6fbf8b6cc-7ldqp -n robustmq -- /bin/sh
      # ./cli-command mqtt --server=mqtt-server-cs.robustmq.svc.cluster.local:1883 publish --username=admin --password=pwd123 --topic=test/topic1 --qos=0
      able to connect: "mqtt-server-cs.robustmq.svc.cluster.local:1883"
      you can post a message on the terminal:
      1
      > You typed: 1
      2 
      > You typed: 2
      3
      > You typed: 3
      ^C>  Ctrl+C detected,  Please press ENTER to end the program. 
      ```
      ```console
      kubectl exec -it cli-command-6fbf8b6cc-7ldqp -n robustmq -- /bin/sh
      # cd libs
      # ./cli-command mqtt --server=mqtt-server-cs.robustmq.svc.cluster.local:1883  subscribe --username=admin --password=pwd123 --topic=test/topic1 --qos=0
      able to connect: "mqtt-server-cs.robustmq.svc.cluster.local:1883"
      subscribe success
      payload: 1
      payload: 2
      payload: 3
      ^C Ctrl+C detected,  Please press ENTER to end the program. 
      End of input stream.
       ```

