### PR TITLE
refactor:  retained message 

### DIFF
--- a/docs/en/RobustMQ-Command/Mqtt-Broker.md
+++ b/docs/en/RobustMQ-Command/Mqtt-Broker.md
@@ -62,6 +62,25 @@
     End of input stream.
     ```
 
+    send retain message
+
+    ```console
+        % ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 publish --username=admin --password=pwd123 --topic=\$share/group1/test/topic1 --qos=1 --retained
+        able to connect: "127.0.0.1:1883"
+        you can post a message on the terminal:
+        helloworld!
+        > You typed: helloworld!
+        published retained message
+    ```
+
+    ```console
+        % ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 subscribe --username=admin --password=pwd123 --topic=\$share/group1/test/topic1 --qos=0
+        able to connect: "127.0.0.1:1883"
+        subscribe success
+        Retain message: helloworld!
+
+    ```
+
 3. Enable Slow Subscription Feature
 
    3.1 The slow subscription statistics function is mainly used to calculate the time (latency) it takes for the Broker to complete message processing and transmission after the message arrives at the Broker. If the latency exceeds the threshold, we will record a related piece of information in the cluster's slow subscription log. Operations personnel can query slow subscription records across the entire cluster using commands to address issues based on this information.

--- a/docs/zh/RobustMQ-Command/Mqtt-Broker.md
+++ b/docs/zh/RobustMQ-Command/Mqtt-Broker.md
@@ -64,6 +64,23 @@ Deleted successfully!
     ^C Ctrl+C detected,  Please press ENTER to end the program.
     End of input stream.
 ```
+### 2.3 发布保留消息
+
+```console
+    % ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 publish --username=admin --password=pwd123 --topic=\$share/group1/test/topic1 --qos=1 --retained
+    able to connect: "127.0.0.1:1883"
+    you can post a message on the terminal:
+    helloworld!
+    > You typed: helloworld!
+    published retained message
+```
+
+```console
+    % ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 subscribe --username=admin --password=pwd123 --topic=\$share/group1/test/topic1 --qos=0
+    able to connect: "127.0.0.1:1883"
+    subscribe success
+    Retain message: helloworld!
+```
 
 ## 3. 开启慢订阅功能
 

--- a/src/cli-command/src/lib.rs
+++ b/src/cli-command/src/lib.rs
@@ -76,12 +76,6 @@ pub fn build_v5_pros() -> Properties {
         .push_val(PropertyCode::RequestProblemInformation, 1)
         .unwrap();
     props
-        .push_string_pair(PropertyCode::UserProperty, "lobo1", "1")
-        .unwrap();
-    props
-        .push_string_pair(PropertyCode::UserProperty, "lobo2", "2")
-        .unwrap();
-    props
 }
 
 pub fn build_create_pros(client_id: &str, addr: &str) -> CreateOptions {

--- a/src/cli-command/src/mqtt.rs
+++ b/src/cli-command/src/mqtt.rs
@@ -146,27 +146,23 @@ impl MqttBrokerCommand {
             false,
         );
         let topic = args.topic;
-        let mut props = Properties::new();
-        props
-            .push_u32(PropertyCode::MessageExpiryInterval, 50)
-            .unwrap();
+        let props = Properties::new();
+        let disconnect_opts = DisconnectOptionsBuilder::new()
+            .reason_code(ReasonCode::DisconnectWithWillMessage)
+            .finalize();
         println!("you can post a message on the terminal:");
         let j = tokio::spawn(async move {
             loop {
                 print!("> ");
                 select! {
-                        _ = signal::ctrl_c() => {
+                    _ = signal::ctrl_c() => {
                         println!(" Ctrl+C detected,  Please press ENTER to end the program. ");
-
-                     let disconnect_opts = DisconnectOptionsBuilder::new()
-                    .reason_code(ReasonCode::DisconnectWithWillMessage)
-                    .finalize();
-                cli.disconnect(disconnect_opts).unwrap();
+                        cli.disconnect(disconnect_opts).unwrap();
                         break;
+                    }
 
-                        }
                         // Read from stdin
-                        line = lines.next_line() => {
+                    line = lines.next_line() => {
                         match line {
                             Ok(Some(input)) => {
                                     println!("You typed: {}", input);
@@ -184,6 +180,11 @@ impl MqttBrokerCommand {
                                         Err(e) => {
                                             panic!("{:?}", e);
                                         }
+                                    }
+                                    if retained {
+                                        println!("published retained message");
+                                        cli.disconnect(disconnect_opts).unwrap(); // only one message retained
+                                        break;
                                     }
                             }
                             Ok(None) => {
@@ -240,6 +241,19 @@ impl MqttBrokerCommand {
         while let Some(msg) = rx.iter().next() {
             match msg {
                 Some(msg) => {
+                    let raw = msg
+                        .properties()
+                        .get_string_pair_at(PropertyCode::UserProperty, 0);
+                    match raw {
+                        Some(raw) => {
+                            if raw.0 == "retain_push_flag" && raw.1 == "true" {
+                                let payload = String::from_utf8(msg.payload().to_vec()).unwrap();
+                                println!("Retain message: {}", payload);
+                            }
+                            continue;
+                        }
+                        None => {}
+                    }
                     let payload = String::from_utf8(msg.payload().to_vec()).unwrap();
                     println!("payload: {}", payload);
                 }


### PR DESCRIPTION
1.  Close the connection after sending only one retained message

2. add docs ,retained message command

    ```console
    % ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 publish --username=admin --password=pwd123 --topic=\$share/group1/test/topic1 --qos=1 --retained
    able to connect: "127.0.0.1:1883"
    you can post a message on the terminal:
    helloworld!
    > You typed: helloworld!
    published retained message
    ```