### PR TITLE
refactor: remove unnecessary code in `try_auto_create_shard`

### DIFF
--- a/src/journal-server/src/core/shard.rs
+++ b/src/journal-server/src/core/shard.rs
@@ -194,19 +194,5 @@ pub async fn try_auto_create_shard(
     }
 
     create_shard_to_place(cache_manager, client_pool, namespace, shard_name).await?;
-    let mut i = 0;
-    loop {
-        if i >= 30 {
-            break;
-        }
-        if cache_manager.get_shard(namespace, shard_name).is_some() {
-            return Ok(());
-        }
-        i += 1;
-        sleep(Duration::from_secs(1)).await;
-    }
-
-    Err(JournalServerError::ShardNotExist(shard_name_iden(
-        namespace, shard_name,
-    )))
+    Ok(())
 }


### PR DESCRIPTION
relate #809 

## What's changed and what's your intention?

The retry loop in `try_auto_create_shard` is redundant since `create_shard_to_place` ensures that new shard metadata will be in the cache manager upon return.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
