### PR TITLE
refactor(placement-center): start controller only if node is leader

### DIFF
--- a/src/placement-center/src/lib.rs
+++ b/src/placement-center/src/lib.rs
@@ -124,9 +124,11 @@ impl PlacementCenter {
 
         let placement_center_storage = Arc::new(RaftMachineApply::new(openraft_node.clone()));
 
-        self.start_controller(placement_center_storage.clone(), stop_send.clone());
-
         self.start_raft_machine(openraft_node.clone());
+
+        if is_leader(&openraft_node) {
+            self.start_controller(placement_center_storage.clone(), stop_send.clone());
+        };
 
         self.start_http_server(placement_center_storage.clone());
 
@@ -317,4 +319,23 @@ impl PlacementCenter {
             Err(e) => panic!("Failed to load Journal Cache,{}", e),
         }
     }
+}
+/// Check whether the current node is the leader of the Raft cluster.
+///
+/// This function compares the ID of the current node with the ID of the current leader recorded
+/// by the Raft cluster to determine whether it is in the leader state.
+///
+/// # Arguments
+/// * 'openraft_node' - An immutable reference to a Raft node, containing node state and metric information
+///
+/// # Returns
+/// Return a Boolean value:
+/// - 'true' indicates that the current node is the leader
+/// - 'false' indicates that the current node is not a leader or leader information does not exist
+pub fn is_leader(openraft_node: &Raft<TypeConfig>) -> bool {
+    openraft_node
+        .metrics()
+        .borrow()
+        .current_leader
+        .is_some_and(|leader| leader == openraft_node.metrics().borrow().id)
 }


### PR DESCRIPTION
- Add is_leader function to check if current node is leader
- Move start_controller call inside is_leader condition
- This change ensures the controller is only started when the node becomes leader
