### PR TITLE
feat: dynamic configuration and the local static configuration are merged

### DIFF
--- a/src/common/base/src/config/broker_mqtt.rs
+++ b/src/common/base/src/config/broker_mqtt.rs
@@ -34,7 +34,10 @@ use serde::{Deserialize, Serialize};
 
 use super::common::{override_default_by_env, Auth, Log, Storage, Telemetry};
 use super::default_mqtt::{
-    default_auth, default_grpc_port, default_http_port, default_log, default_network,
+    default_auth, default_grpc_port, default_http_port, default_log,
+    default_mqtt_cluster_dynamic_feature, default_mqtt_cluster_dynamic_flapping_detect,
+    default_mqtt_cluster_dynamic_network, default_mqtt_cluster_dynamic_protocol,
+    default_mqtt_cluster_dynamic_security, default_mqtt_cluster_dynamic_slow_sub, default_network,
     default_network_quic_port, default_network_tcp_port, default_network_tcps_port,
     default_network_websocket_port, default_network_websockets_port, default_offline_message,
     default_placement_center, default_storage, default_system, default_tcp_thread,
@@ -68,6 +71,112 @@ pub struct BrokerMqttConfig {
     pub offline_messages: OfflineMessage,
     #[serde(default = "default_telemetry")]
     pub telemetry: Telemetry,
+
+    #[serde(default = "default_mqtt_cluster_dynamic_slow_sub")]
+    pub cluster_dynamic_config_slow_sub: MqttClusterDynamicSlowSub,
+    #[serde(default = "default_mqtt_cluster_dynamic_flapping_detect")]
+    pub cluster_dynamic_config_flapping_detect: MqttClusterDynamicFlappingDetect,
+    #[serde(default = "default_mqtt_cluster_dynamic_protocol")]
+    pub cluster_dynamic_config_protocol: MqttClusterDynamicConfigProtocol,
+    #[serde(default = "default_mqtt_cluster_dynamic_feature")]
+    pub cluster_dynamic_config_feature: MqttClusterDynamicConfigFeature,
+    #[serde(default = "default_mqtt_cluster_dynamic_security")]
+    pub cluster_dynamic_config_security: MqttClusterDynamicConfigSecurity,
+    #[serde(default = "default_mqtt_cluster_dynamic_network")]
+    pub cluster_dynamic_config_network: MqttClusterDynamicConfigNetwork,
+}
+
+// MQTT cluster protocol related dynamic configuration
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct MqttClusterDynamicConfigProtocol {
+    pub session_expiry_interval: u32,
+    pub topic_alias_max: u16,
+    pub max_qos: u8,
+    pub max_packet_size: u32,
+    pub max_server_keep_alive: u16,
+    pub default_server_keep_alive: u16,
+    pub receive_max: u16,
+    pub max_message_expiry_interval: u64,
+    pub client_pkid_persistent: bool,
+}
+
+impl MqttClusterDynamicConfigProtocol {
+    pub fn encode(&self) -> Vec<u8> {
+        serde_json::to_vec(&self).unwrap()
+    }
+}
+
+// MQTT cluster security related dynamic configuration
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct MqttClusterDynamicConfigSecurity {
+    pub is_self_protection_status: bool,
+    pub secret_free_login: bool,
+}
+
+impl MqttClusterDynamicConfigSecurity {
+    pub fn encode(&self) -> Vec<u8> {
+        serde_json::to_vec(&self).unwrap()
+    }
+}
+
+// MQTT cluster network related dynamic configuration
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct MqttClusterDynamicConfigNetwork {
+    pub tcp_max_connection_num: u64,
+    pub tcps_max_connection_num: u64,
+    pub websocket_max_connection_num: u64,
+    pub websockets_max_connection_num: u64,
+    pub response_max_try_mut_times: u64,
+    pub response_try_mut_sleep_time_ms: u64,
+}
+
+// MQTT cluster Feature related dynamic configuration
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct MqttClusterDynamicConfigFeature {
+    pub retain_available: ConfigAvailableFlag,
+    pub wildcard_subscription_available: ConfigAvailableFlag,
+    pub subscription_identifiers_available: ConfigAvailableFlag,
+    pub shared_subscription_available: ConfigAvailableFlag,
+    pub exclusive_subscription_available: ConfigAvailableFlag,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct MqttClusterDynamicSlowSub {
+    pub enable: bool,
+    pub whole_ms: u64,
+    pub internal_ms: u32,
+    pub response_ms: u32,
+}
+impl MqttClusterDynamicSlowSub {
+    pub fn encode(&self) -> Vec<u8> {
+        serde_json::to_vec(&self).unwrap()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct MqttClusterDynamicFlappingDetect {
+    pub enable: bool,
+    pub window_time: u32,
+    pub max_client_connections: u64,
+    pub ban_time: u32,
+}
+
+impl MqttClusterDynamicFlappingDetect {
+    pub fn encode(&self) -> Vec<u8> {
+        serde_json::to_vec(&self).unwrap()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct MqttClusterDynamicOfflineMessage {
+    pub enable: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Default, Clone)]
+pub enum ConfigAvailableFlag {
+    #[default]
+    Disable,
+    Enable,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]

--- a/src/common/base/src/config/default_mqtt.rs
+++ b/src/common/base/src/config/default_mqtt.rs
@@ -12,7 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::broker_mqtt::{Network, OfflineMessage, System, TcpThread};
+use super::broker_mqtt::{
+    ConfigAvailableFlag, MqttClusterDynamicConfigFeature, MqttClusterDynamicConfigNetwork,
+    MqttClusterDynamicConfigProtocol, MqttClusterDynamicConfigSecurity,
+    MqttClusterDynamicFlappingDetect, MqttClusterDynamicSlowSub, Network, OfflineMessage, System,
+    TcpThread,
+};
 use super::common::{Auth, Log, Storage, Telemetry};
 
 pub fn default_grpc_port() -> u32 {
@@ -113,5 +118,65 @@ pub fn default_telemetry() -> Telemetry {
         enable: false,
         exporter_endpoint: "grpc://127.0.0.1:4317".to_string(),
         exporter_type: "otlp".to_string(),
+    }
+}
+
+pub fn default_mqtt_cluster_dynamic_feature() -> MqttClusterDynamicConfigFeature {
+    MqttClusterDynamicConfigFeature {
+        retain_available: ConfigAvailableFlag::Enable,
+        wildcard_subscription_available: ConfigAvailableFlag::Enable,
+        subscription_identifiers_available: ConfigAvailableFlag::Enable,
+        shared_subscription_available: ConfigAvailableFlag::Enable,
+        exclusive_subscription_available: ConfigAvailableFlag::Enable,
+    }
+}
+
+pub fn default_mqtt_cluster_dynamic_security() -> MqttClusterDynamicConfigSecurity {
+    MqttClusterDynamicConfigSecurity {
+        secret_free_login: false,
+        is_self_protection_status: false,
+    }
+}
+
+pub fn default_mqtt_cluster_dynamic_protocol() -> MqttClusterDynamicConfigProtocol {
+    MqttClusterDynamicConfigProtocol {
+        session_expiry_interval: 1800,
+        topic_alias_max: 65535,
+        max_qos: 2,
+        max_packet_size: 1024 * 1024 * 10,
+        max_server_keep_alive: 3600,
+        default_server_keep_alive: 60,
+        receive_max: 65535,
+        client_pkid_persistent: false,
+        max_message_expiry_interval: 3600,
+    }
+}
+
+pub fn default_mqtt_cluster_dynamic_slow_sub() -> MqttClusterDynamicSlowSub {
+    MqttClusterDynamicSlowSub {
+        enable: false,
+        whole_ms: 0,
+        internal_ms: 0,
+        response_ms: 0,
+    }
+}
+
+pub fn default_mqtt_cluster_dynamic_flapping_detect() -> MqttClusterDynamicFlappingDetect {
+    MqttClusterDynamicFlappingDetect {
+        enable: false,
+        window_time: 1,
+        max_client_connections: 15,
+        ban_time: 5,
+    }
+}
+
+pub fn default_mqtt_cluster_dynamic_network() -> MqttClusterDynamicConfigNetwork {
+    MqttClusterDynamicConfigNetwork {
+        tcp_max_connection_num: 1000,
+        tcps_max_connection_num: 1000,
+        websocket_max_connection_num: 1000,
+        websockets_max_connection_num: 1000,
+        response_max_try_mut_times: 128,
+        response_try_mut_sleep_time_ms: 100,
     }
 }

--- a/src/common/metadata-struct/src/mqtt/cluster.rs
+++ b/src/common/metadata-struct/src/mqtt/cluster.rs
@@ -19,6 +19,9 @@ pub const DEFAULT_DYNAMIC_CONFIG_SLOW_SUB: &str = "slow_sub";
 pub const DEFAULT_DYNAMIC_CONFIG_FLAPPING_DETECT: &str = "flapping_detect";
 pub const DEFAULT_DYNAMIC_CONFIG_PROTOCOL: &str = "protocol";
 pub const DEFAULT_DYNAMIC_CONFIG_OFFLINE_MESSAGE: &str = "offline_message";
+pub const DEFAULT_DYNAMIC_CONFIG_FEATURE: &str = "feature";
+pub const DEFAULT_DYNAMIC_CONFIG_SECURITY: &str = "security";
+pub const DEFAULT_DYNAMIC_CONFIG_NETWORK: &str = "network";
 
 // Dynamic configuration of MQTT cluster latitude
 #[derive(Serialize, Deserialize, Default, Clone)]


### PR DESCRIPTION
1. New fields in local configuration
```
    #[serde(default = "default_mqtt_cluster_dynamic_slow_sub")]
    pub cluster_dynamic_config_slow_sub: MqttClusterDynamicSlowSub,
    #[serde(default = "default_mqtt_cluster_dynamic_flapping_detect")]
    pub cluster_dynamic_config_flapping_detect: MqttClusterDynamicFlappingDetect,
    #[serde(default = "default_mqtt_cluster_dynamic_protocol")]
    pub cluster_dynamic_config_protocol: MqttClusterDynamicConfigProtocol,
    #[serde(default = "default_mqtt_cluster_dynamic_feature")]
    pub cluster_dynamic_config_feature: MqttClusterDynamicConfigFeature,
    #[serde(default = "default_mqtt_cluster_dynamic_security")]
    pub cluster_dynamic_config_security: MqttClusterDynamicConfigSecurity,
    #[serde(default = "default_mqtt_cluster_dynamic_network")]
    pub cluster_dynamic_config_network: MqttClusterDynamicConfigNetwork,
```