### PR TITLE
feat: load mqtt connector to PC MQTT cache

### DIFF
--- a/src/placement-center/src/mqtt/cache.rs
+++ b/src/placement-center/src/mqtt/cache.rs
@@ -25,6 +25,7 @@ use super::controller::session_expire::ExpireLastWill;
 use super::is_send_last_will;
 use crate::core::cache::PlacementCacheManager;
 use crate::core::error::PlacementCenterError;
+use crate::storage::mqtt::connector::MqttConnectorStorage;
 use crate::storage::mqtt::topic::MqttTopicStorage;
 use crate::storage::mqtt::user::MqttUserStorage;
 use crate::storage::rocksdb::RocksDBEngine;
@@ -209,6 +210,13 @@ pub fn load_mqtt_cache(
             let data = user.list(&cluster.cluster_name)?;
             for user in data {
                 mqtt_cache.add_user(&cluster.cluster_name, user);
+            }
+
+            // connector
+            let connector = MqttConnectorStorage::new(rocksdb_engine_handler.clone());
+            let data = connector.list(&cluster.cluster_name)?;
+            for connector in data {
+                mqtt_cache.add_connector(&cluster.cluster_name, &connector);
             }
         }
     }


### PR DESCRIPTION
## What's changed and what's your intention?

Load all connectors from rocksdb to MQTTCache when the placement center starts.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

