### PR TITLE
chore: no need to send update connector request to PC during GC

### DIFF
--- a/src/mqtt-broker/src/bridge/core.rs
+++ b/src/mqtt-broker/src/bridge/core.rs
@@ -137,13 +137,6 @@ async fn check_connector<S>(
             }
             if let Some(mut connector) = connector_manager.get_connector(&raw.connector_name) {
                 connector.status = MQTTStatus::Idle;
-                let storage = ConnectorStorage::new(client_pool.clone());
-                if let Err(e) = storage.update_connector(connector.clone()).await {
-                    error!(
-                        "Failed to update connector {} status with error message: {}",
-                        connector.connector_name, e
-                    );
-                }
             }
         }
     }

--- a/src/mqtt-broker/src/bridge/core.rs
+++ b/src/mqtt-broker/src/bridge/core.rs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{handler::error::MqttBrokerError, storage::connector::ConnectorStorage};
+use crate::handler::error::MqttBrokerError;
 use axum::async_trait;
 use common_base::config::broker_mqtt::broker_mqtt_conf;
-use grpc_clients::pool::ClientPool;
 use log::{error, info};
 use metadata_struct::mqtt::bridge::{
     config_local_file::LocalFileConnectorConfig, connector::MQTTConnector,
@@ -46,7 +45,6 @@ pub trait BridgePlugin {
 pub async fn start_connector_thread<S>(
     message_storage: Arc<S>,
     connector_manager: Arc<ConnectorManager>,
-    client_pool: Arc<ClientPool>,
     stop_send: broadcast::Sender<bool>,
 ) where
     S: StorageAdapter + Sync + Send + 'static + Clone,
@@ -65,7 +63,6 @@ pub async fn start_connector_thread<S>(
             _ = check_connector(
                 &message_storage,
                 &connector_manager,
-                &client_pool
             ) => {
                 sleep(Duration::from_secs(1)).await;
             }
@@ -73,11 +70,8 @@ pub async fn start_connector_thread<S>(
     }
 }
 
-async fn check_connector<S>(
-    message_storage: &Arc<S>,
-    connector_manager: &Arc<ConnectorManager>,
-    client_pool: &Arc<ClientPool>,
-) where
+async fn check_connector<S>(message_storage: &Arc<S>, connector_manager: &Arc<ConnectorManager>)
+where
     S: StorageAdapter + Sync + Send + 'static + Clone,
 {
     let config = broker_mqtt_conf();

--- a/src/mqtt-broker/src/lib.rs
+++ b/src/mqtt-broker/src/lib.rs
@@ -283,10 +283,8 @@ where
     fn start_connector_thread(&self, stop_send: broadcast::Sender<bool>) {
         let message_storage = self.message_storage_adapter.clone();
         let connector_manager = self.connector_manager.clone();
-        let client_poll = self.client_pool.clone();
         self.runtime.spawn(async move {
-            start_connector_thread(message_storage, connector_manager, client_poll, stop_send)
-                .await;
+            start_connector_thread(message_storage, connector_manager, stop_send).await;
         });
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

Update GC logic in `src/mqtt-broker/src/bridge/core.rs` - no need to send `update_connector` request to the placement center.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
