### PR TITLE
fix(rdkafka): Fixed Win compilation issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,6 +3883,7 @@ version = "4.8.0+2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced38182dc436b3d9df0c77976f37a67134df26b050df1f0006688e46fc4c8be"
 dependencies = [
+ "cmake",
  "libc",
  "libz-sys",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,8 +140,8 @@ valico = "4.0.0"
 apache-avro = { version = "0.17.0" }
 protobuf = "3.7.1"
 protobuf-codegen = "3.7.1"
-protofish = { version = "0.5.2"}
-rdkafka = { version = "0.37.0" }
+protofish = { version = "0.5.2" }
+rdkafka = { version = "0.37.0", features = ["cmake-build"] }
 crc32fast = "1.4.2"
 
 #format


### PR DESCRIPTION
- Enable the CMake-build feature of rdkafka to solve the compilation problem on Windows.
