### PR TITLE
refactor: remove calc_init_node function and update log config path

### DIFF
--- a/example/mqtt-cluster/placement-center/node-2.toml
+++ b/example/mqtt-cluster/placement-center/node-2.toml
@@ -39,5 +39,5 @@ data_path = "./robust-data/placement-center-2/data"
 max_open_files = 10000
 
 [log]
-log_config = "./config/log4rs.yaml"
+log_config = "./config/log-config/place-log4rs.yaml"
 log_path = "./robust-data/placement-center-2/logs"

--- a/example/mqtt-cluster/placement-center/node-3.toml
+++ b/example/mqtt-cluster/placement-center/node-3.toml
@@ -39,5 +39,5 @@ data_path = "./robust-data/placement-center-3/data"
 max_open_files = 10000
 
 [log]
-log_config = "./config/log4rs.yaml"
+log_config = "./config/log-config/place-log4rs.yaml"
 log_path = "./robust-data/placement-center-3/logs"

--- a/src/placement-center/src/raft/raft_node.rs
+++ b/src/placement-center/src/raft/raft_node.rs
@@ -80,33 +80,25 @@ pub async fn start_openraft_node(raft_node: Raft<TypeConfig>) {
     }
 
     info!("Raft Nodes:{:?}", nodes);
-    let init_node_id = calc_init_node(&nodes);
-    if init_node_id == conf.node.node_id {
-        match raft_node.is_initialized().await {
-            Ok(flag) => {
-                info!("Whether nodes should be initialized, flag={}", flag);
-                if !flag {
-                    match raft_node.initialize(nodes.clone()).await {
-                        Ok(_) => {
-                            info!("Node {:?} was initialized successfully", nodes);
-                        }
-                        Err(e) => {
-                            panic!("openraft init fail,{}", e);
-                        }
+
+    match raft_node.is_initialized().await {
+        Ok(flag) => {
+            info!("Whether nodes should be initialized, flag={}", flag);
+            if !flag {
+                match raft_node.initialize(nodes.clone()).await {
+                    Ok(_) => {
+                        info!("Node {:?} was initialized successfully", nodes);
+                    }
+                    Err(e) => {
+                        panic!("openraft init fail,{}", e);
                     }
                 }
             }
-            Err(e) => {
-                panic!("openraft initialized fail,{}", e);
-            }
+        }
+        Err(e) => {
+            panic!("openraft initialized fail,{}", e);
         }
     }
-}
-
-pub fn calc_init_node(nodes: &BTreeMap<u64, Node>) -> u64 {
-    let mut node_ids: Vec<u64> = nodes.keys().copied().collect();
-    node_ids.sort();
-    *node_ids.first().unwrap()
 }
 
 pub async fn create_raft_node(
@@ -134,7 +126,7 @@ pub async fn create_raft_node(
         log_store,
         state_machine_store,
     )
-    .await
+        .await
     {
         Ok(data) => data,
         Err(e) => {

--- a/src/placement-center/src/raft/raft_node.rs
+++ b/src/placement-center/src/raft/raft_node.rs
@@ -126,7 +126,7 @@ pub async fn create_raft_node(
         log_store,
         state_machine_store,
     )
-        .await
+    .await
     {
         Ok(data) => data,
         Err(e) => {


### PR DESCRIPTION
- Remove calc_init_node function from raft_node.rs
- Update log_config path in placement center config files
- Refactor node initialization logic for better readability and efficiency

Reason:  Raft::initialize() this method is called on more than one node simultaneously with the same membership, it is safe, as the voting protocol ensures consistency.
