### PR TITLE
test(placement-center): add unit tests for KvStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,6 +3341,7 @@ dependencies = [
  "rocksdb-engine",
  "serde",
  "serde_json",
+    "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ metadata-struct = { path = "src/common/metadata-struct" }
 third-driver = { path = "src/common/third-driver" }
 protocol = { path = "src/protocol" }
 robustmq-test = { path = "tests" }
-
+tempfile = "3.9.0"
 [profile.dev]
 overflow-checks = false
 incremental = true

--- a/src/placement-center/Cargo.toml
+++ b/src/placement-center/Cargo.toml
@@ -44,3 +44,4 @@ tower.workspace = true
 futures.workspace = true
 prometheus-client.workspace = true
 prost-validate = { workspace = true, features = ["derive"] }
+tempfile.workspace = true

--- a/src/placement-center/src/storage/placement/kv.rs
+++ b/src/placement-center/src/storage/placement/kv.rs
@@ -66,3 +66,90 @@ impl KvStorage {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn setup_kv_storage() -> KvStorage {
+        let temp_dir = tempdir().unwrap();
+        let engine = RocksDBEngine::new(
+            temp_dir.path().to_str().unwrap(),
+            100,
+            vec!["cluster".to_string()],
+        );
+        KvStorage::new(Arc::new(engine))
+    }
+
+    #[test]
+    fn test_set_and_get() {
+        let kv = setup_kv_storage();
+        kv.set("key1".to_string(), "value1".to_string()).unwrap();
+        assert_eq!(
+            kv.get("key1".to_string()).unwrap(),
+            Some("value1".to_string())
+        );
+    }
+
+    #[test]
+    fn test_set_overwrite() {
+        let kv = setup_kv_storage();
+        kv.set("key1".to_string(), "value1".to_string()).unwrap();
+        kv.set("key1".to_string(), "value2".to_string()).unwrap();
+        assert_eq!(
+            kv.get("key1".to_string()).unwrap(),
+            Some("value2".to_string())
+        );
+    }
+
+    #[test]
+    fn test_get_non_existent() {
+        let kv = setup_kv_storage();
+        assert_eq!(kv.get("nonexistent".to_string()).unwrap(), None);
+    }
+
+    #[test]
+    fn test_delete_existing() {
+        let kv = setup_kv_storage();
+        kv.set("key1".to_string(), "value1".to_string()).unwrap();
+        kv.delete("key1".to_string()).unwrap();
+        assert!(!kv.exists("key1".to_string()).unwrap());
+    }
+
+    #[test]
+    fn test_delete_non_existent() {
+        let kv = setup_kv_storage();
+        kv.delete("nonexistent".to_string()).unwrap();
+    }
+
+    #[test]
+    fn test_exists() {
+        let kv = setup_kv_storage();
+        assert!(!kv.exists("key1".to_string()).unwrap());
+        kv.set("key1".to_string(), "value1".to_string()).unwrap();
+        assert!(kv.exists("key1".to_string()).unwrap());
+    }
+
+    #[test]
+    fn test_get_prefix() {
+        let kv = setup_kv_storage();
+        kv.set("prefix/key1".to_string(), "value1".to_string())
+            .unwrap();
+        kv.set("prefix/key2".to_string(), "value2".to_string())
+            .unwrap();
+        kv.set("other/key3".to_string(), "value3".to_string())
+            .unwrap();
+
+        let mut result = kv.get_prefix("prefix/".to_string()).unwrap();
+        result.sort();
+        assert_eq!(result, vec!["value1".to_string(), "value2".to_string()]);
+    }
+
+    #[test]
+    fn test_get_prefix_non_existent() {
+        let kv = setup_kv_storage();
+        let result = kv.get_prefix("nonexistent/".to_string()).unwrap();
+        assert!(result.is_empty());
+    }
+}


### PR DESCRIPTION
- Implement unit tests for KvStorage to ensure basic functionality- Add tests for set, get, delete, and exists operations
- Include tests for prefix-based retrieval
- Update dependencies to include tempfile for temporary directory creation
