### PR TITLE
fix: Use POSIX compatible array syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,7 +3341,7 @@ dependencies = [
  "rocksdb-engine",
  "serde",
  "serde_json",
-    "tempfile",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tonic",

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -63,9 +63,9 @@ cross_build(){
 
     mkdir -p ${package_path}/{bin,libs,config}
 
-    binaries=(mqtt-server placement-center journal-server cli-command-mqtt cli-command-placement)
+    binaries="mqtt-server placement-center journal-server cli-command-mqtt cli-command-placement"
 
-    for binary in "${binaries[@]}"; do
+    for binary in ${binaries}; do
         local bin_path="target/${arc}/release/${binary}"
         if [ -f "${bin_path}" ]; then
         cp "${bin_path}" ${package_path}/libs/
@@ -155,9 +155,9 @@ build_local(){
 
     mkdir -p ${package_path}/{bin,libs,config}
 
-    binaries=(mqtt-server placement-center journal-server cli-command-mqtt cli-command-placement)
+    binaries="mqtt-server placement-center journal-server cli-command-mqtt cli-command-placement"
 
-    for binary in "${binaries[@]}"; do
+    for binary in ${binaries}; do
         local bin_path="target/debug/${binary}"
         if [ -f "${bin_path}" ]; then
             cp "${bin_path}" ${package_path}/libs/


### PR DESCRIPTION
## What's changed and what's your intention?

- Change bash-specific array syntax `binaries=()` to POSIX shell compatible string form
- Improve cross-platform compatibility of scripts to ensure that they can run properly in different shell implementations (such as dash)
- Adjust ident for the `Cargo.lock`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [X]  This PR does not require documentation updates.
