### PR TITLE
test: Add unit test for MqttSubscribeStorage

### DIFF
--- a/src/common/metadata-struct/src/mqtt/subscribe_data.rs
+++ b/src/common/metadata-struct/src/mqtt/subscribe_data.rs
@@ -15,7 +15,7 @@
 use protocol::mqtt::common::{Filter, MqttProtocol, SubscribeProperties};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq)]
 pub struct MqttSubscribe {
     pub client_id: String,
     pub path: String,

--- a/src/placement-center/src/storage/mqtt/subscribe.rs
+++ b/src/placement-center/src/storage/mqtt/subscribe.rs
@@ -170,7 +170,130 @@ impl MqttSubscribeStorage {
 
 #[cfg(test)]
 mod tests {
+    use crate::storage::mqtt::subscribe::MqttSubscribeStorage;
+    use crate::storage::rocksdb::column_family_list;
+    use common_base::config::placement_center::placement_center_test_conf;
+    use metadata_struct::mqtt::auto_subscribe_rule::MqttAutoSubscribeRule;
+    use metadata_struct::mqtt::subscribe_data::MqttSubscribe;
+    use protocol::mqtt::common::{Filter, QoS, RetainForwardRule};
+    use rocksdb_engine::RocksDBEngine;
+    use std::fs::remove_dir_all;
+    use std::sync::Arc;
 
     #[tokio::test]
-    async fn subscribe_storage_test() {}
+    async fn subscribe_storage_ops() {
+        let config = placement_center_test_conf();
+        let db = Arc::new(RocksDBEngine::new(
+            &config.rocksdb.data_path,
+            config.rocksdb.max_open_files.unwrap(),
+            column_family_list(),
+        ));
+        let storage = MqttSubscribeStorage::new(db);
+        let cluster = "test_cluster".to_string();
+        let client1 = "client_a".to_string();
+        let client2 = "client_b".to_string();
+        let topic1 = "topic_a".to_string();
+        let topic2 = "topic_b".to_string();
+
+        assert!(storage
+            .list_by_client_id(&cluster, &client1)
+            .unwrap()
+            .is_empty());
+
+        let sub1 = MqttSubscribe {
+            cluster_name: cluster.clone(),
+            client_id: client1.clone(),
+            filter: Filter {
+                path: topic1.clone(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        storage
+            .save(&cluster, &client1, &topic1, sub1.clone())
+            .unwrap();
+
+        let sub2 = MqttSubscribe {
+            cluster_name: cluster.clone(),
+            client_id: client1.clone(),
+            filter: Filter {
+                path: topic2.clone(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        storage
+            .save(&cluster, &client1, &topic2, sub2.clone())
+            .unwrap();
+
+        let all_subs = storage.list_by_cluster(&cluster).unwrap();
+        assert_eq!(all_subs.len(), 2);
+
+        let client_subs = storage.list_by_client_id(&cluster, &client1).unwrap();
+        assert_eq!(client_subs, vec![sub1.clone(), sub2.clone()]);
+
+        let queried = storage.get(&cluster, &client1, &topic1).unwrap();
+        assert_eq!(queried, Some(sub1.clone()));
+
+        storage.delete_by_path(&cluster, &client1, &topic1).unwrap();
+        assert!(storage.get(&cluster, &client1, &topic1).unwrap().is_none());
+        assert!(storage.get(&cluster, &client1, &topic2).unwrap().is_some());
+
+        storage
+            .save(&cluster, &client2, &topic1, sub1.clone())
+            .unwrap();
+        storage.delete_by_client_id(&cluster, &client1).unwrap();
+
+        assert!(storage.get(&cluster, &client1, &topic2).unwrap().is_none());
+
+        assert!(storage
+            .list_by_client_id(&cluster, &client1)
+            .unwrap()
+            .is_empty());
+
+        storage.delete_by_path(&cluster, &client2, &topic1).unwrap();
+        assert!(storage
+            .list_by_client_id(&cluster, &client2)
+            .unwrap()
+            .is_empty());
+
+        remove_dir_all(config.rocksdb.data_path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn auto_subscribe_rule_storage_basic_ops() {
+        let config = placement_center_test_conf();
+        let db = Arc::new(RocksDBEngine::new(
+            &config.rocksdb.data_path,
+            config.rocksdb.max_open_files.unwrap(),
+            column_family_list(),
+        ));
+
+        let storage = MqttSubscribeStorage::new(db);
+
+        let cluster = "test_cluster";
+        let topic = "devices/temperature";
+
+        let rule = MqttAutoSubscribeRule {
+            cluster: cluster.to_string(),
+            topic: topic.to_string(),
+            qos: QoS::AtLeastOnce,
+            no_local: true,
+            retain_as_published: false,
+            retained_handling: RetainForwardRule::OnEverySubscribe,
+        };
+
+        storage
+            .save_auto_subscribe_rule(cluster, topic, rule.clone())
+            .unwrap();
+
+        let rules = storage.list_auto_subscribe_rule(cluster).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0], rule);
+
+        storage.delete_auto_subscribe_rule(cluster, topic).unwrap();
+
+        let rules_after_delete = storage.list_auto_subscribe_rule(cluster).unwrap();
+        assert!(rules_after_delete.is_empty());
+    }
 }

--- a/src/protocol/src/mqtt/common.rs
+++ b/src/protocol/src/mqtt/common.rs
@@ -872,7 +872,7 @@ pub struct Subscribe {
 }
 
 /// Subscription filter
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Filter {
     //  in mqtt v4, there are only path and qos valid
     pub path: String,


### PR DESCRIPTION
## What's changed and what's your intention?

Add unit test for MqttSubscribeStorage under src/placement-center/src/storage/mqtt/subscribe.rs

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link
close [#979](https://github.com/robustmq/robustmq/issues/979)
