### PR TITLE
fix: fix resource busy bug when running multiple rocksdb instances concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4221,6 +4221,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/src/common/rocksdb-engine/Cargo.toml
+++ b/src/common/rocksdb-engine/Cargo.toml
@@ -28,6 +28,7 @@ rocksdb.workspace = true
 dashmap.workspace = true
 futures.workspace = true
 metadata-struct.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/src/common/rocksdb-engine/src/engine.rs
+++ b/src/common/rocksdb-engine/src/engine.rs
@@ -169,11 +169,16 @@ mod tests {
         RocksDBEngine,
     };
 
+    use tempfile::tempdir;
+
     #[tokio::test]
     async fn base_rw_str_test() {
-        let path = "/tmp/test";
-        let rocksdb_engine_handler =
-            Arc::new(RocksDBEngine::new(path, 100, vec!["default".to_string()]));
+        let path = tempdir().unwrap().path().to_str().unwrap().to_string();
+        let rocksdb_engine_handler = Arc::new(RocksDBEngine::new(
+            path.as_str(),
+            100,
+            vec!["default".to_string()],
+        ));
         let key = "test_key".to_string();
         let value = "test_value".to_string();
         let result = rocksdb_engine_save(
@@ -196,9 +201,12 @@ mod tests {
 
     #[tokio::test]
     async fn base_rw_session_test() {
-        let path = "/tmp/test";
-        let rocksdb_engine_handler =
-            Arc::new(RocksDBEngine::new(path, 100, vec!["default".to_string()]));
+        let path = tempdir().unwrap().path().to_str().unwrap().to_string();
+        let rocksdb_engine_handler = Arc::new(RocksDBEngine::new(
+            path.as_str(),
+            100,
+            vec!["default".to_string()],
+        ));
         let key = "test_key".to_string();
         let value = MqttSession::default();
         let result = rocksdb_engine_save(


### PR DESCRIPTION
## What's changed and what's your intention?

Fix resource busy bug when running multiple rocksdb instances concurrently.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
