### PR TITLE
feat: Robustctl MQTT Command support Acl and Blacklist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
@@ -3002,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",

--- a/src/cli-command/src/mqtt.rs
+++ b/src/cli-command/src/mqtt.rs
@@ -57,12 +57,18 @@ pub struct MqttCliCommandParam {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MqttActionType {
+    // cluster status
     Status,
 
-    // User admin
+    // user admin
+    ListUser,
     CreateUser(CreateUserRequest),
     DeleteUser(DeleteUserRequest),
-    ListUser,
+
+    // access control list admin
+    // ListACL,
+    // CreateACL(CreateACLRequest),
+    // DeleteACL(DeleteACLRequest),
 
     // connection
     ListConnection,

--- a/src/cmd/src/cli-command/command.rs
+++ b/src/cmd/src/cli-command/command.rs
@@ -38,7 +38,7 @@ use protocol::placement_center::placement_center_openraft::{
 };
 
 use crate::mqtt::admin::{
-    process_slow_sub_args, process_user_args, FlappingDetectArgs, MqttUserCommand, SlowSubArgs,
+    process_slow_sub_args, process_user_args, FlappingDetectArgs, UserArgs, SlowSubArgs,
 };
 use crate::mqtt::publish::{process_publish_args, PubSubArgs};
 
@@ -83,8 +83,8 @@ struct MqttArgs {
 #[derive(Debug, Subcommand)]
 enum MQTTAction {
     Status,
-    // User admin
-    User(MqttUserCommand),
+    // user admin
+    User(UserArgs),
 
     // Connections
     ListConnection,

--- a/src/cmd/src/cli-command/command.rs
+++ b/src/cmd/src/cli-command/command.rs
@@ -38,7 +38,7 @@ use protocol::placement_center::placement_center_openraft::{
 };
 
 use crate::mqtt::admin::{
-    process_slow_sub_args, process_user_args, FlappingDetectArgs, UserArgs, SlowSubArgs,
+    process_slow_sub_args, process_user_args, AclArgs, FlappingDetectArgs, SlowSubArgs, UserArgs,
 };
 use crate::mqtt::publish::{process_publish_args, PubSubArgs};
 
@@ -82,9 +82,12 @@ struct MqttArgs {
 
 #[derive(Debug, Subcommand)]
 enum MQTTAction {
+    // cluster status
     Status,
     // user admin
     User(UserArgs),
+    // access control list admin
+    Acl(AclArgs),
 
     // Connections
     ListConnection,
@@ -212,7 +215,6 @@ async fn handle_mqtt(args: MqttArgs, cmd: MqttBrokerCommand) {
 
             // user
             MQTTAction::User(args) => process_user_args(args),
-
 
             MQTTAction::ListConnection => MqttActionType::ListConnection,
             MQTTAction::ListTopic(args) => MqttActionType::ListTopic(ListTopicRequest {

--- a/src/cmd/src/cli-command/command.rs
+++ b/src/cmd/src/cli-command/command.rs
@@ -37,7 +37,10 @@ use protocol::placement_center::placement_center_openraft::{
     AddLearnerRequest, ChangeMembershipRequest, Node,
 };
 
-use crate::mqtt::admin::{process_slow_sub_args, process_user_args, AclArgs, BlacklistArgs, FlappingDetectArgs, SlowSubArgs, UserArgs};
+use crate::mqtt::admin::{
+    process_acl_args, process_blacklist_args, process_slow_sub_args, process_user_args, AclArgs,
+    BlacklistArgs, FlappingDetectArgs, SlowSubArgs, UserArgs,
+};
 use crate::mqtt::publish::{process_publish_args, PubSubArgs};
 
 #[derive(Parser)] // requires `derive` feature
@@ -216,6 +219,8 @@ async fn handle_mqtt(args: MqttArgs, cmd: MqttBrokerCommand) {
             MQTTAction::User(args) => process_user_args(args),
             // access control list admin
             MQTTAction::Acl(args) => process_acl_args(args),
+            // blacklist admin
+            MQTTAction::Blacklist(args) => process_blacklist_args(args),
             MQTTAction::ListConnection => MqttActionType::ListConnection,
             MQTTAction::ListTopic(args) => MqttActionType::ListTopic(ListTopicRequest {
                 topic_name: args.topic_name,

--- a/src/cmd/src/cli-command/command.rs
+++ b/src/cmd/src/cli-command/command.rs
@@ -49,9 +49,6 @@ use crate::mqtt::publish::{process_publish_args, PubSubArgs};
 #[command(author="RobustMQ", version="0.0.1", about="Command line tool for RobustMQ", long_about = None)]
 #[command(next_line_help = true)]
 struct RobustMQCli {
-    // Mqtt(MqttArgs),
-    // Place(PlacementArgs),
-    // Journal(JournalArgs),
     #[command(subcommand)]
     command: RobustMQCliCommand,
 }
@@ -88,11 +85,11 @@ enum MQTTAction {
     Status,
     // User admin
     User(MqttUserCommand),
+
     // Connections
     ListConnection,
 
     // flapping detect feat
-    #[clap(name = "flapping-detect")]
     FlappingDetect(FlappingDetectArgs),
 
     ListTopic(ListTopicArgs),
@@ -101,37 +98,24 @@ enum MQTTAction {
 
     Subscribe(PubSubArgs),
     // observability: slow-sub feat
-    #[clap(name = "slow-sub")]
     SlowSub(SlowSubArgs),
 
     // connector
-    #[clap(name = "list-connector")]
     ListConnector(ListConnectorArgs),
-    #[clap(name = "create-connector")]
     CreateConnector(CreateConnectorArgs),
-    #[clap(name = "update-connector")]
     UpdateConnector(UpdateConnectorArgs),
-    #[clap(name = "delete-connector")]
     DeleteConnector(DeleteConnectorArgs),
 
     // schema
-    #[clap(name = "list-schema")]
     ListSchema(ListSchemaArgs),
-    #[clap(name = "create-schema")]
     CreateSchema(CreateSchemaArgs),
-    #[clap(name = "update-schema")]
     UpdateSchema(UpdateSchemaArgs),
-    #[clap(name = "delete-schema")]
     DeleteSchema(DeleteSchemaArgs),
-    #[clap(name = "list-bind-schema")]
     ListBindSchema(ListBindSchemaArgs),
-    #[clap(name = "bind-schema")]
     BindSchema(BindSchemaArgs),
-    #[clap(name = "unbind-schema")]
     UnbindSchema(UnbindSchemaArgs),
 
     //auto subscribe
-    #[clap(name = "auto-subscribe-rule")]
     AutoSubscribeRule(MqttAutoSubscribeRuleCommand),
 }
 
@@ -223,8 +207,13 @@ async fn handle_mqtt(args: MqttArgs, cmd: MqttBrokerCommand) {
     let params = MqttCliCommandParam {
         server: args.server,
         action: match args.action {
+            // cluster status
             MQTTAction::Status => MqttActionType::Status,
+
+            // user
             MQTTAction::User(args) => process_user_args(args),
+
+
             MQTTAction::ListConnection => MqttActionType::ListConnection,
             MQTTAction::ListTopic(args) => MqttActionType::ListTopic(ListTopicRequest {
                 topic_name: args.topic_name,

--- a/src/cmd/src/cli-command/command.rs
+++ b/src/cmd/src/cli-command/command.rs
@@ -37,9 +37,7 @@ use protocol::placement_center::placement_center_openraft::{
     AddLearnerRequest, ChangeMembershipRequest, Node,
 };
 
-use crate::mqtt::admin::{
-    process_slow_sub_args, process_user_args, AclArgs, FlappingDetectArgs, SlowSubArgs, UserArgs,
-};
+use crate::mqtt::admin::{process_slow_sub_args, process_user_args, AclArgs, BlacklistArgs, FlappingDetectArgs, SlowSubArgs, UserArgs};
 use crate::mqtt::publish::{process_publish_args, PubSubArgs};
 
 #[derive(Parser)] // requires `derive` feature
@@ -88,6 +86,8 @@ enum MQTTAction {
     User(UserArgs),
     // access control list admin
     Acl(AclArgs),
+    // blacklist admin
+    Blacklist(BlacklistArgs),
 
     // Connections
     ListConnection,
@@ -212,10 +212,10 @@ async fn handle_mqtt(args: MqttArgs, cmd: MqttBrokerCommand) {
         action: match args.action {
             // cluster status
             MQTTAction::Status => MqttActionType::Status,
-
-            // user
+            // user admin
             MQTTAction::User(args) => process_user_args(args),
-
+            // access control list admin
+            MQTTAction::Acl(args) => process_acl_args(args),
             MQTTAction::ListConnection => MqttActionType::ListConnection,
             MQTTAction::ListTopic(args) => MqttActionType::ListTopic(ListTopicRequest {
                 topic_name: args.topic_name,

--- a/src/cmd/src/cli-command/mqtt/admin.rs
+++ b/src/cmd/src/cli-command/mqtt/admin.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::option::Option::Some;
-
 use clap::builder::{
     ArgAction, BoolishValueParser, EnumValueParser, NonEmptyStringValueParser, RangedU64ValueParser,
 };
 use clap::{arg, Parser};
 use cli_command::mqtt::MqttActionType;
 use common_base::enum_type::sort_type::SortType;
+use core::option::Option::Some;
 use protocol::broker_mqtt::broker_mqtt_admin::{
     CreateUserRequest, DeleteAutoSubscribeRuleRequest, DeleteUserRequest,
     ListAutoSubscribeRuleRequest, SetAutoSubscribeRuleRequest,
@@ -27,9 +26,10 @@ use protocol::broker_mqtt::broker_mqtt_admin::{
 use protocol::broker_mqtt::broker_mqtt_admin::{
     EnableSlowSubscribeRequest, ListSlowSubscribeRequest,
 };
+use std::fs::Permissions;
 
 #[derive(clap::Args, Debug)]
-#[command(author="RobustMQ", about="related operations of mqtt users, such as listing, creating, and deleting ", long_about = None)]
+#[command(author="RobustMQ", about="related operations of mqtt users, such as listing, creating, and deleting", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct UserArgs {
     #[command(subcommand)]
@@ -65,6 +65,46 @@ pub(crate) struct CreateUserArgs {
 pub(crate) struct DeleteUserArgs {
     #[arg(short, long, required = true)]
     pub(crate) username: String,
+}
+
+#[derive(clap::Args, Debug)]
+#[command(author="RobustMQ", about="related operations of access control list, such as listing, creating, and deleting", long_about = None)]
+#[command(next_line_help = true)]
+pub(crate) struct AclArgs {
+    #[command(subcommand)]
+    pub action: Option<AclActionType>,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum AclActionType {
+    #[command(author="RobustMQ", about="action: acl list", long_about = None)]
+    List,
+    #[command(author="RobustMQ", about="action: create acl", long_about = None)]
+    Create(CreateAclArgs),
+    #[command(author="RobustMQ", about="action: delete acl", long_about = None)]
+    Delete(DeleteAclArgs),
+}
+
+#[derive(clap::Args, Debug)]
+#[command(author="RobustMQ", about="action: create acl", long_about = None)]
+#[command(next_line_help = true)]
+pub(crate) struct CreateAclArgs {
+    #[arg(short, long, required = true)]
+    pub(crate) username: String,
+    #[arg(short, long, required = true)]
+    pub(crate) topic: String,
+    #[arg(short, long, default_value_t = false)]
+    pub(crate) permission: String,
+}
+
+#[derive(clap::Args, Debug)]
+#[command(author="RobustMQ", about="action: delete acl", long_about = None)]
+#[command(next_line_help = true)]
+pub(crate) struct DeleteAclArgs {
+    #[arg(short, long, required = true)]
+    pub(crate) username: String,
+    #[arg(short, long, required = true)]
+    pub(crate) topic: String,
 }
 
 // flapping detect feat

--- a/src/cmd/src/cli-command/mqtt/admin.rs
+++ b/src/cmd/src/cli-command/mqtt/admin.rs
@@ -31,17 +31,19 @@ use protocol::broker_mqtt::broker_mqtt_admin::{
 #[derive(clap::Args, Debug)]
 #[command(author="RobustMQ", about="related operations of mqtt users, such as listing, creating, and deleting ", long_about = None)]
 #[command(next_line_help = true)]
-pub(crate) struct MqttUserCommand {
+pub(crate) struct UserArgs {
     #[command(subcommand)]
-    pub action: Option<MqttUserActionType>,
+    pub action: Option<UserActionType>,
 }
 
 #[derive(Debug, clap::Subcommand)]
-pub enum MqttUserActionType {
-    #[command(author="RobustMQ", about="action: user list", long_about = None)]
+pub enum UserActionType {
+    #[command(author="RobustMQ", about="action: list users", long_about = None)]
     List,
-    Delete(DeleteUserArgs),
+    #[command(author="RobustMQ", about="action: create user", long_about = None)]
     Create(CreateUserArgs),
+    #[command(author="RobustMQ", about="action: delete user", long_about = None)]
+    Delete(DeleteUserArgs),
 }
 
 // security: user feat
@@ -51,10 +53,8 @@ pub enum MqttUserActionType {
 pub(crate) struct CreateUserArgs {
     #[arg(short, long, required = true)]
     pub(crate) username: String,
-
     #[arg(short, long, required = true)]
     pub(crate) password: String,
-
     #[arg(short, long, default_value_t = false)]
     pub(crate) is_superuser: bool,
 }
@@ -251,16 +251,16 @@ pub fn process_slow_sub_args(args: SlowSubArgs) -> MqttActionType {
     }
 }
 
-pub fn process_user_args(args: MqttUserCommand) -> MqttActionType {
+pub fn process_user_args(args: UserArgs) -> MqttActionType {
     match args.action {
         Some(user_action) => match user_action {
-            MqttUserActionType::List => MqttActionType::ListUser,
-            MqttUserActionType::Create(arg) => MqttActionType::CreateUser(CreateUserRequest {
+            UserActionType::List => MqttActionType::ListUser,
+            UserActionType::Create(arg) => MqttActionType::CreateUser(CreateUserRequest {
                 username: arg.username,
                 password: arg.password,
                 is_superuser: arg.is_superuser,
             }),
-            MqttUserActionType::Delete(arg) => MqttActionType::DeleteUser(DeleteUserRequest {
+            UserActionType::Delete(arg) => MqttActionType::DeleteUser(DeleteUserRequest {
                 username: arg.username,
             }),
         },

--- a/src/cmd/src/cli-command/mqtt/admin.rs
+++ b/src/cmd/src/cli-command/mqtt/admin.rs
@@ -107,6 +107,40 @@ pub(crate) struct DeleteAclArgs {
     pub(crate) topic: String,
 }
 
+#[derive(clap::Args, Debug)]
+#[command(author="RobustMQ", about="related operations of blacklist, such as listing, creating, and deleting", long_about = None)]
+#[command(next_line_help = true)]
+pub(crate) struct BlacklistArgs {
+    #[command(subcommand)]
+    pub action: Option<BlackListActionType>,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum BlackListActionType {
+    #[command(author="RobustMQ", about="action: blacklist list", long_about = None)]
+    List,
+    #[command(author="RobustMQ", about="action: create blacklist", long_about = None)]
+    Create(CreateBlacklistArgs),
+    #[command(author="RobustMQ", about="action: delete blacklist", long_about = None)]
+    Delete(DeleteBlacklistArgs),
+}
+
+#[derive(clap::Args, Debug)]
+#[command(author="RobustMQ", about="action: create blacklist", long_about = None)]
+#[command(next_line_help = true)]
+pub(crate) struct CreateBlacklistArgs {
+    #[arg(short, long, required = true)]
+    pub(crate) identifier: String,
+}
+
+#[derive(clap::Args, Debug)]
+#[command(author="RobustMQ", about="action: delete blacklist", long_about = None)]
+#[command(next_line_help = true)]
+pub(crate) struct DeleteBlacklistArgs {
+    #[arg(short, long, required = true)]
+    pub(crate) identifier: String,
+}
+
 // flapping detect feat
 #[derive(Debug, Parser)]
 #[command(author="RobustMQ", about="", long_about = None)]
@@ -307,6 +341,24 @@ pub fn process_user_args(args: UserArgs) -> MqttActionType {
         None => unreachable!(),
     }
 }
+
+// pub fn process_acl_args(args: AclArgs) -> MqttActionType {
+//     match args.action {
+//         Some(acl_action) => match acl_action {
+//             AclActionType::List => MqttActionType::ListAcl,
+//             AclActionType::Create(arg) => MqttActionType::CreateAcl(CreateAclArgs {
+//                 username: arg.username,
+//                 topic: arg.topic,
+//                 permission: arg.permission,
+//             }),
+//             AclActionType::Delete(arg) => MqttActionType::DeleteAcl(DeleteAclArgs {
+//                 username: arg.username,
+//                 topic: arg.topic,
+//             }),
+//         },
+//         None => unreachable!(),
+//     }
+// }
 
 #[derive(clap::Args, Debug)]
 #[command(author="RobustMQ", about="related operations of mqtt auto subscribe, such as listing, setting, and deleting ", long_about = None)]

--- a/src/common/metadata-struct/src/acl/mqtt_acl.rs
+++ b/src/common/metadata-struct/src/acl/mqtt_acl.rs
@@ -66,8 +66,38 @@ pub enum MqttAclAction {
     Qos,
 }
 
+impl fmt::Display for MqttAclAction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                MqttAclAction::All => "All",
+                MqttAclAction::Subscribe => "Subscribe",
+                MqttAclAction::Publish => "Publish",
+                MqttAclAction::PubSub => "PubSub",
+                MqttAclAction::Retain => "Retain",
+                MqttAclAction::Qos => "Qos",
+            }
+        )
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Clone)]
 pub enum MqttAclPermission {
     Allow,
     Deny,
+}
+
+impl fmt::Display for MqttAclPermission {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                MqttAclPermission::Allow => "Allow",
+                MqttAclPermission::Deny => "Deny",
+            }
+        )
+    }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

- The current CLI capabilities supported by the Robustctl MQTT command line are not comprehensive enough. Every service in src/mgtt-broker/src/admin needs to have a corresponding command line tool. Therefore, it is necessary to compare the differences between the current Robustctl and the services provided by admin, and then improve the CLI.

- In this PR, I focus on acl and blacklist. The implementation of Robustctl MQTT Command now does not support them, so I decide to complete this.

- There are still many areas where the current command support is incomplete, and there is much room for optimization in the code structure and style. I plan to make more improvements and enhancements to the command module in the near future.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link
close [#1020](https://github.com/robustmq/robustmq/issues/1020)
