### PR TITLE
test: Add unit test and documents for mqtt topic rewrite

### DIFF
--- a/docs/en/RobustMQ-MQTT/TopicRewrite.md
+++ b/docs/en/RobustMQ-MQTT/TopicRewrite.md
@@ -1,0 +1,56 @@
+## Topic Rewrite
+Topic Rewrite allows users to configure rules to change the topic strings that
+the client requests to subscribe or publish.
+
+This feature is very useful when there's a need to transform between different topic structures.
+For example, an old device that has already been issued and cannot
+be upgraded may use old topic designs, but for some reason, we adjusted the format of topics. We can use this feature 
+to rewrite the old topics as the new format to eliminate these differences.
+
+More introduction about [Topic Rewrite](https://www.emqx.io/docs/en/v5.0/mqtt/mqtt-topic-rewrite.html).
+
+See [List all rewrite rules](https://www.emqx.io/docs/en/v5.0/admin/api-docs.html#tag/MQTT/paths/~1mqtt~1topic_rewrite/get)
+and [Create or Update rewrite rules](https://www.emqx.io/docs/en/v5.0/admin/api-docs.html#tag/MQTT/paths/~1mqtt~1topic_rewrite/put).
+
+### Configure Topic Rewrite Rules
+RobustMQ topic rewrite rules are configured by the placement amin service. You may add multiple topic rewrite rules. The number of rules is 
+not limited, but any MQTT message that carries a topic needs to match the rewrite rule again. Therefore, 
+the performance overhead in high-throughput scenarios is proportional to the number of rules, 
+so, use this feature with caution.
+
+The request format of rewrite rule for each topic is as follows:
+```rust
+let action: String = "All".to_string();
+let source_topic: String = "x/#".to_string();
+let dest_topic: String = "x/y/z/$1".to_string();
+let re: String = "^x/y/(.+)$".to_string();
+
+let req = CreateTopicRewriteRuleRequest {
+    action: action.clone(),
+    source_topic: source_topic.clone(),
+    dest_topic: dest_topic.clone(),
+    regex: re.clone(),
+};
+```
+Each rewrite rule consists of a filter, regular expression.
+
+The rewrite rules are divided into publish, subscribe and all rules. The publish rule matches the topics carried 
+by PUBLISH messages, and the subscribe rule matches the topics carried by SUBSCRIBE and UNSUBSCRIBE messages. 
+The all rule is valid for topics carried by PUBLISH, SUBSCRIBE and UNSUBSCRIBE messages.
+
+On the premise that the topic rewrite is enabled, when receiving MQTT packet such as PUBLISH messages with a topic,
+RobustMQ will use the topic in the packet to sequentially match the topic filter part of the rules in the configuration 
+file. Once the match is successful the regular expression is used to extract the information in the topic, 
+and then the old topic is replaced by the target expression to form a new topic.
+
+The target expression can use variables in the format of $N to match the elements extracted from the regular expression.
+The value of $N is the Nth element extracted from the regular expression, for example, $1 is the first element 
+extracted by the regular expression.
+
+And the target expression alose support use ${clientid} to represent the client ID and ${username} to represent the client username.
+
+It should be noted that RobustMQ reads the rewrite rules in order of the configuration file. When a topic can match the 
+topic filters of multiple topic rewrite rules at the same time, RobustMQ uses the first matching rule to rewrite the topic.
+
+If the regular expression in the rule does not match the topic of the MQTT packet, the rewrite fails, and no other 
+rule will be used to rewrite. Therefore, users need to carefully design MQTT packet topics and topic rewrite rules.

--- a/src/mqtt-broker/src/handler/topic_rewrite.rs
+++ b/src/mqtt-broker/src/handler/topic_rewrite.rs
@@ -37,6 +37,7 @@ pub fn process_sub_topic_rewrite(
             {
                 continue;
             }
+            // rewrite performed only for the first match
             if path_regex_match(&filter.path, &topic_rewrite_rule.source_topic) {
                 if let Some(val) = gen_rewrite_topic(
                     &filter.path,
@@ -45,6 +46,7 @@ pub fn process_sub_topic_rewrite(
                 ) {
                     filter.path = val;
                 }
+                break;
             }
         }
     }
@@ -66,6 +68,7 @@ pub fn process_unsub_topic_rewrite(
             {
                 continue;
             }
+            // rewrite performed only for the first match
             if path_regex_match(filter, &topic_rewrite_rule.source_topic) {
                 if let Some(val) = gen_rewrite_topic(
                     filter,
@@ -74,6 +77,7 @@ pub fn process_unsub_topic_rewrite(
                 ) {
                     *filter = val;
                 }
+                break;
             }
         }
     }
@@ -108,4 +112,157 @@ pub fn process_publish_topic_rewrite(
         }
     }
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use protocol::mqtt::common::{Filter, QoS, RetainForwardRule, Subscribe};
+    use common_base::tools;
+    use super::*;
+
+    /// Assume that the following topic rewrite rules have been added to the conf file:
+    /// ```bash
+    /// rewrite = [
+    ///   {
+    ///     action:       "all"
+    ///     source_topic: "y/+/z/#"
+    ///     dest_topic:   "y/z/$2"
+    ///     re:           "^y/(.+)/z/(.+)$"
+    ///   }
+    ///   {
+    ///     action:       "all"
+    ///     source_topic: "x/#"
+    ///     dest_topic:   "z/y/x/$1"
+    ///     re:           "^x/y/(.+)$"
+    ///   }
+    ///   {
+    ///     action:       "all"
+    ///     source_topic: "x/y/+"
+    ///     dest_topic:   "z/y/$1"
+    ///     re:           "^x/y/(\d+)$"
+    ///   }
+    /// ]
+    /// ```
+    /// At this time we subscribe to five topics: `y/a/z/b`, `y/def`, `x/1/2`, `x/y/2`, and `x/y/z`:
+    ///
+    /// - `y/def` does not match any of the topic filters, so it does not perform topic rewriting,
+    /// and just subscribes to `y/def` topics.
+    /// - `y/a/z/b` matches t   1he `y/+/z/#` topic filter, executes the first rule, and matches
+    /// the element \[a、b\] through a regular expression, brings the matched second element
+    /// into `y/z/$2`, and actually subscribes to the topic `y/z/b`.
+    /// - `x/1/2` matches `x/#` topic filter, executes the second rule. It does not match
+    /// elements through regular expressions, does not perform topic rewrite, and actually
+    /// subscribes to the topic of `x/1/2`.
+    /// - `x/y/2` matches two topic filters of `x/#` and `x/y/`+ at the same time, reads the
+    /// configuration in reverse order, so it matches the third preferentially. Through
+    /// regular replacement, it actually subscribed to the `z/y/2` topic.
+    /// - `x/y/z` matches two topic filters of `x/#` and `x/y/+` at the same time, reads the
+    /// configuration in reverse order, so it matches the third preferentially. The element is
+    /// not matched through the regular expression, the topic rewrite is not performed, and it
+    /// actually subscribes to the `x/y/z` topic. It should be noted that even if the regular
+    /// expression matching of the third fails, it will not match the rules of the second again.
+    ///
+    const SRC_TOPICS: [&str; 5] = ["y/a/z/b", "y/def", "x/1/2", "x/y/2", "x/y/z"];
+    const DST_TOPICS: [&str; 5] = ["y/z/b", "y/def", "x/1/2", "z/y/2", "x/y/z"];
+    const REGEX_MATCHES: [bool; 5] = [true, false, true, true, true];
+
+    #[test]
+    fn sub_topic_rewrite_test() {
+        let filters = SRC_TOPICS.map(|src_topic| {
+            Filter {
+                path: src_topic.to_string(),
+                qos: QoS::AtMostOnce,
+                nolocal: false,
+                preserve_retain: false,
+                retain_forward_rule: RetainForwardRule::Never,
+            }
+        });
+        let mut subscribe = Subscribe {
+            packet_identifier: 0,
+            filters: filters.to_vec(),
+        };
+        let rules = build_rules();
+        process_sub_topic_rewrite(&mut subscribe, &rules);
+
+        // verify rewrote topics
+        for (index, filter) in subscribe.filters.iter().enumerate() {
+            assert_eq!(filter.path, DST_TOPICS[index]);
+        }
+    }
+
+    #[test]
+    fn unsub_topic_rewrite_test() {
+        let filters = SRC_TOPICS.map(|src_topic| {src_topic.to_string()}).to_vec();
+        let mut unsub = Unsubscribe{
+            pkid: 0,
+            filters,
+        };
+
+        let rules = build_rules();
+        process_unsub_topic_rewrite(&mut unsub, &rules);
+
+        // verify rewrote topics
+        for (index, filter) in unsub.filters.iter().enumerate() {
+            assert_eq!(filter, DST_TOPICS[index]);
+        }
+
+    }
+
+    #[test]
+    fn publish_topic_rewrite_test() {
+        let rules = build_rules();
+        for (index, src_topic) in SRC_TOPICS.iter().enumerate() {
+            let result = process_publish_topic_rewrite(src_topic.to_string(), &rules);
+            assert!(result.is_ok());
+            let option = result.unwrap();
+            
+            let matches = REGEX_MATCHES[index];
+            assert_eq!(option.is_some(), matches);
+            if matches {
+                let dst_topic = option.unwrap();
+                assert_eq!(dst_topic, DST_TOPICS[index]);
+            } else {
+                assert!(option.is_none());
+            }
+
+        }
+    }
+
+    fn build_rules() -> DashMap<String, MqttTopicRewriteRule> {
+        let rules = vec![
+            SimpleRule::new(r"y/+/z/#", r"y/z/$2", r"^y/(.+)/z/(.+)$"),
+            SimpleRule::new(r"x/#", r"z/y/x/$1", r"^x/y/(.+)$"),
+            SimpleRule::new(r"x/y/+", r"z/y/$1",r"^x/y/(\d+)$")
+        ];
+
+        let map = DashMap::with_capacity(rules.len());
+        for (index, rule) in rules.iter().enumerate() {
+            let rule = MqttTopicRewriteRule {
+                cluster: "default".to_string(),
+                action: TopicRewriteActionEnum::All.to_string(),
+                source_topic: rule.source.to_string(),
+                dest_topic: rule.destination.to_string(),
+                regex: rule.regex.to_string(),
+                timestamp: tools::now_nanos(),
+            };
+            map.insert(format!("rule{}",index), rule);
+        }
+        map
+    }
+
+    struct SimpleRule {
+        source: String,
+        destination: String,
+        regex: String,
+    }
+
+    impl SimpleRule {
+        fn new(source: &str, destination: &str, regex: &str) -> Self {
+            SimpleRule {
+                source: source.to_string(),
+                destination: destination.to_string(),
+                regex: regex.to_string(),
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What's changed and what's your intention?
Add unit test and documents for mqtt topic rewrite.

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Add document to illustrthe the topic rewrite function.
- Fix topic filter with both "+" and "#" wildcasts.
- Rollback unstable async closure.

## Checklist
- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link
#837
