### PR TITLE
refactor: Refactor Connector and add Topic Rewrite support in MQTT Command 

### DIFF
--- a/src/cli-command/src/mqtt.rs
+++ b/src/cli-command/src/mqtt.rs
@@ -19,8 +19,9 @@ use common_base::tools::unique_id;
 use grpc_clients::mqtt::admin::call::{
     mqtt_broker_bind_schema, mqtt_broker_cluster_status, mqtt_broker_create_acl,
     mqtt_broker_create_blacklist, mqtt_broker_create_connector, mqtt_broker_create_schema,
-    mqtt_broker_create_user, mqtt_broker_delete_acl, mqtt_broker_delete_auto_subscribe_rule,
-    mqtt_broker_delete_blacklist, mqtt_broker_delete_connector, mqtt_broker_delete_schema,
+    mqtt_broker_create_topic_rewrite_rule, mqtt_broker_create_user, mqtt_broker_delete_acl,
+    mqtt_broker_delete_auto_subscribe_rule, mqtt_broker_delete_blacklist,
+    mqtt_broker_delete_connector, mqtt_broker_delete_schema, mqtt_broker_delete_topic_rewrite_rule,
     mqtt_broker_delete_user, mqtt_broker_enable_flapping_detect, mqtt_broker_enable_slow_subscribe,
     mqtt_broker_list_acl, mqtt_broker_list_auto_subscribe_rule, mqtt_broker_list_bind_schema,
     mqtt_broker_list_blacklist, mqtt_broker_list_connection, mqtt_broker_list_connector,
@@ -409,6 +410,7 @@ impl MqttBrokerCommand {
             }
         }
     }
+    // ------------ cluster status ------------
     async fn status(&self, client_pool: &ClientPool, params: MqttCliCommandParam) {
         let request = ClusterStatusRequest {};
         match mqtt_broker_cluster_status(client_pool, &grpc_addr(params.server), request).await {
@@ -426,6 +428,7 @@ impl MqttBrokerCommand {
             }
         }
     }
+    // ------------ user admin ------------
 
     async fn create_user(
         &self,
@@ -481,6 +484,7 @@ impl MqttBrokerCommand {
             }
         }
     }
+    // -------------- acl admin --------------
 
     async fn create_acl(
         &self,
@@ -551,6 +555,7 @@ impl MqttBrokerCommand {
         }
     }
 
+    // -------------- blacklist admin --------------
     async fn create_blacklist(
         &self,
         client_pool: &ClientPool,
@@ -616,6 +621,7 @@ impl MqttBrokerCommand {
         }
     }
 
+    // -------------- list connections --------------
     async fn list_connections(&self, client_pool: &ClientPool, params: MqttCliCommandParam) {
         let request = ListConnectionRequest {};
         match mqtt_broker_list_connection(client_pool, &grpc_addr(params.server), request).await {
@@ -650,7 +656,7 @@ impl MqttBrokerCommand {
         }
     }
 
-    // flapping detect
+    // -------------- flapping detect --------------
     async fn enable_flapping_detect(
         &self,
         client_pool: &ClientPool,
@@ -902,6 +908,53 @@ impl MqttBrokerCommand {
             }
             Err(e) => {
                 println!("MQTT broker update connector exception");
+                error_info(e.to_string());
+            }
+        }
+    }
+
+    // ------------------ topic rewrite rule ----------------
+    async fn create_topic_rewrite_rule(
+        &self,
+        client_pool: &ClientPool,
+        params: MqttCliCommandParam,
+        cli_request: CreateTopicRewriteRuleRequest,
+    ) {
+        match mqtt_broker_create_topic_rewrite_rule(
+            client_pool,
+            &grpc_addr(params.server),
+            cli_request,
+        )
+        .await
+        {
+            Ok(_) => {
+                println!("Created successfully!")
+            }
+            Err(e) => {
+                println!("MQTT broker create topic rewrite rule exception");
+                error_info(e.to_string());
+            }
+        }
+    }
+
+    async fn delete_topic_rewrite_rule(
+        &self,
+        client_pool: &ClientPool,
+        params: MqttCliCommandParam,
+        cli_request: DeleteTopicRewriteRuleRequest,
+    ) {
+        match mqtt_broker_delete_topic_rewrite_rule(
+            client_pool,
+            &grpc_addr(params.server),
+            cli_request,
+        )
+        .await
+        {
+            Ok(_) => {
+                println!("Deleted successfully!")
+            }
+            Err(e) => {
+                println!("MQTT broker delete topic rewrite rule exception");
                 error_info(e.to_string());
             }
         }

--- a/src/cli-command/src/mqtt.rs
+++ b/src/cli-command/src/mqtt.rs
@@ -36,15 +36,15 @@ use metadata_struct::schema::SchemaData;
 use paho_mqtt::{DisconnectOptionsBuilder, MessageBuilder, Properties, PropertyCode, ReasonCode};
 use prettytable::{row, Table};
 use protocol::broker_mqtt::broker_mqtt_admin::{
-    ClusterStatusRequest, CreateAclRequest, CreateBlacklistRequest, CreateUserRequest,
-    DeleteAclRequest, DeleteAutoSubscribeRuleRequest, DeleteBlacklistRequest, DeleteUserRequest,
-    EnableFlappingDetectRequest, EnableSlowSubscribeRequest, ListAclRequest,
-    ListAutoSubscribeRuleRequest, ListBlacklistRequest, ListConnectionRequest,
-    ListSlowSubscribeRequest, ListTopicRequest, ListUserRequest, MqttBindSchemaRequest,
-    MqttCreateConnectorRequest, MqttCreateSchemaRequest, MqttDeleteConnectorRequest,
-    MqttDeleteSchemaRequest, MqttListBindSchemaRequest, MqttListConnectorRequest,
-    MqttListSchemaRequest, MqttUnbindSchemaRequest, MqttUpdateConnectorRequest,
-    MqttUpdateSchemaRequest, SetAutoSubscribeRuleRequest,
+    ClusterStatusRequest, CreateAclRequest, CreateBlacklistRequest, CreateTopicRewriteRuleRequest,
+    CreateUserRequest, DeleteAclRequest, DeleteAutoSubscribeRuleRequest, DeleteBlacklistRequest,
+    DeleteTopicRewriteRuleRequest, DeleteUserRequest, EnableFlappingDetectRequest,
+    EnableSlowSubscribeRequest, ListAclRequest, ListAutoSubscribeRuleRequest, ListBlacklistRequest,
+    ListConnectionRequest, ListSlowSubscribeRequest, ListTopicRequest, ListUserRequest,
+    MqttBindSchemaRequest, MqttCreateConnectorRequest, MqttCreateSchemaRequest,
+    MqttDeleteConnectorRequest, MqttDeleteSchemaRequest, MqttListBindSchemaRequest,
+    MqttListConnectorRequest, MqttListSchemaRequest, MqttUnbindSchemaRequest,
+    MqttUpdateConnectorRequest, MqttUpdateSchemaRequest, SetAutoSubscribeRuleRequest,
 };
 use std::str::FromStr;
 use std::sync::Arc;
@@ -89,6 +89,10 @@ pub enum MqttActionType {
 
     // flapping detect
     EnableFlappingDetect(EnableFlappingDetectRequest),
+
+    // topic rewrite rule
+    CreateTopicRewriteRule(CreateTopicRewriteRuleRequest),
+    DeleteTopicRewriteRule(DeleteTopicRewriteRuleRequest),
 
     // publish
     Publish(PublishArgsRequest),
@@ -175,9 +179,35 @@ impl MqttBrokerCommand {
                 self.delete_blacklist(&client_pool, params.clone(), request.clone())
                     .await;
             }
-            // connection
+            // list connection
             MqttActionType::ListConnection => {
                 self.list_connections(&client_pool, params.clone()).await;
+            }
+            // connector
+            MqttActionType::ListConnector(ref request) => {
+                self.list_connectors(&client_pool, params.clone(), request.clone())
+                    .await;
+            }
+            MqttActionType::CreateConnector(ref request) => {
+                self.create_connector(&client_pool, params.clone(), request.clone())
+                    .await;
+            }
+            MqttActionType::DeleteConnector(ref request) => {
+                self.delete_connector(&client_pool, params.clone(), request.clone())
+                    .await;
+            }
+            MqttActionType::UpdateConnector(ref request) => {
+                self.update_connector(&client_pool, params.clone(), request.clone())
+                    .await;
+            }
+            // topic rewrite rule
+            MqttActionType::CreateTopicRewriteRule(ref request) => {
+                self.create_topic_rewrite_rule(&client_pool, params.clone(), request.clone())
+                    .await;
+            }
+            MqttActionType::DeleteTopicRewriteRule(ref request) => {
+                self.delete_topic_rewrite_rule(&client_pool, params.clone(), request.clone())
+                    .await;
             }
             MqttActionType::EnableSlowSubscribe(ref request) => {
                 self.enable_slow_subscribe(&client_pool, params.clone(), *request)
@@ -200,22 +230,6 @@ impl MqttBrokerCommand {
             }
             MqttActionType::Subscribe(ref request) => {
                 self.subscribe(params.clone(), request.clone()).await;
-            }
-            MqttActionType::ListConnector(ref request) => {
-                self.list_connectors(&client_pool, params.clone(), request.clone())
-                    .await;
-            }
-            MqttActionType::CreateConnector(ref request) => {
-                self.create_connector(&client_pool, params.clone(), request.clone())
-                    .await;
-            }
-            MqttActionType::DeleteConnector(ref request) => {
-                self.delete_connector(&client_pool, params.clone(), request.clone())
-                    .await;
-            }
-            MqttActionType::UpdateConnector(ref request) => {
-                self.update_connector(&client_pool, params.clone(), request.clone())
-                    .await;
             }
 
             // schema

--- a/src/cmd/src/cli-command/command.rs
+++ b/src/cmd/src/cli-command/command.rs
@@ -91,20 +91,16 @@ enum MQTTAction {
     Acl(AclArgs),
     // blacklist admin
     Blacklist(BlacklistArgs),
-
-    // Connections
-    ListConnection,
-
     // flapping detect feat
     FlappingDetect(FlappingDetectArgs),
-
-    ListTopic(ListTopicArgs),
-
-    Publish(PubSubArgs),
-
-    Subscribe(PubSubArgs),
+    // Connections
+    ListConnection,
     // observability: slow-sub feat
     SlowSub(SlowSubArgs),
+    // list topic
+    ListTopic(ListTopicArgs),
+    // topic rewrite rule
+    // TopicRewriteRule(TopicRewriteArgs),
 
     // connector
     ListConnector(ListConnectorArgs),
@@ -123,6 +119,9 @@ enum MQTTAction {
 
     //auto subscribe
     AutoSubscribeRule(MqttAutoSubscribeRuleCommand),
+
+    Publish(PubSubArgs),
+    Subscribe(PubSubArgs),
 }
 
 #[derive(ValueEnum, Clone, Debug)]
@@ -221,16 +220,7 @@ async fn handle_mqtt(args: MqttArgs, cmd: MqttBrokerCommand) {
             MQTTAction::Acl(args) => process_acl_args(args),
             // blacklist admin
             MQTTAction::Blacklist(args) => process_blacklist_args(args),
-            MQTTAction::ListConnection => MqttActionType::ListConnection,
-            MQTTAction::ListTopic(args) => MqttActionType::ListTopic(ListTopicRequest {
-                topic_name: args.topic_name,
-                match_option: match args.match_option {
-                    MatchOption::E => 0,
-                    MatchOption::P => 1,
-                    MatchOption::S => 2,
-                },
-            }),
-            MQTTAction::SlowSub(args) => process_slow_sub_args(args),
+            // flapping detect
             MQTTAction::FlappingDetect(args) => {
                 MqttActionType::EnableFlappingDetect(EnableFlappingDetectRequest {
                     is_enable: args.is_enable.unwrap_or(false),
@@ -239,6 +229,22 @@ async fn handle_mqtt(args: MqttArgs, cmd: MqttBrokerCommand) {
                     ban_time: args.ban_time.unwrap_or(5),
                 })
             }
+            // Connections
+            MQTTAction::ListConnection => MqttActionType::ListConnection,
+            // list topic
+            MQTTAction::ListTopic(args) => MqttActionType::ListTopic(ListTopicRequest {
+                topic_name: args.topic_name,
+                match_option: match args.match_option {
+                    MatchOption::E => 0,
+                    MatchOption::P => 1,
+                    MatchOption::S => 2,
+                },
+            }),
+
+
+
+            MQTTAction::SlowSub(args) => process_slow_sub_args(args),
+
             MQTTAction::Publish(args) => process_publish_args(args),
             MQTTAction::Subscribe(args) => process_subscribe_args(args),
             MQTTAction::ListConnector(args) => {

--- a/src/cmd/src/cli-command/command.rs
+++ b/src/cmd/src/cli-command/command.rs
@@ -237,12 +237,13 @@ async fn handle_mqtt(args: MqttArgs, cmd: MqttBrokerCommand) {
                     MatchOption::S => 2,
                 },
             }),
+            // topic rewrite rule
             MQTTAction::TopicRewriteRule(args) => process_topic_rewrite_args(args),
             MQTTAction::SlowSub(args) => process_slow_sub_args(args),
 
             MQTTAction::Publish(args) => process_publish_args(args),
             MQTTAction::Subscribe(args) => process_subscribe_args(args),
-
+            // schema
             MQTTAction::ListSchema(args) => MqttActionType::ListSchema(MqttListSchemaRequest {
                 schema_name: args.schema_name,
             }),

--- a/src/cmd/src/cli-command/mqtt/admin.rs
+++ b/src/cmd/src/cli-command/mqtt/admin.rs
@@ -28,8 +28,9 @@ use protocol::broker_mqtt::broker_mqtt_admin::{
     EnableSlowSubscribeRequest, ListSlowSubscribeRequest,
 };
 
+// security: user feat
 #[derive(clap::Args, Debug)]
-#[command(author="RobustMQ", about="related operations of mqtt users, such as listing, creating, and deleting", long_about = None)]
+#[command(author = "RobustMQ", about = "related operations of mqtt users, such as listing, creating, and deleting", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct UserArgs {
     #[command(subcommand)]
@@ -38,17 +39,16 @@ pub(crate) struct UserArgs {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum UserActionType {
-    #[command(author="RobustMQ", about="action: list users", long_about = None)]
+    #[command(author = "RobustMQ", about = "action: list users", long_about = None)]
     List,
-    #[command(author="RobustMQ", about="action: create user", long_about = None)]
+    #[command(author = "RobustMQ", about = "action: create user", long_about = None)]
     Create(CreateUserArgs),
-    #[command(author="RobustMQ", about="action: delete user", long_about = None)]
+    #[command(author = "RobustMQ", about = "action: delete user", long_about = None)]
     Delete(DeleteUserArgs),
 }
 
-// security: user feat
 #[derive(clap::Args, Debug)]
-#[command(author="RobustMQ", about="action: create user", long_about = None)]
+#[command(author = "RobustMQ", about = "action: create user", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct CreateUserArgs {
     #[arg(short, long, required = true)]
@@ -60,15 +60,16 @@ pub(crate) struct CreateUserArgs {
 }
 
 #[derive(clap::Args, Debug)]
-#[command(author="RobustMQ", about="action: delete user", long_about = None)]
+#[command(author = "RobustMQ", about = "action: delete user", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct DeleteUserArgs {
     #[arg(short, long, required = true)]
     pub(crate) username: String,
 }
 
+// acl feat
 #[derive(clap::Args, Debug)]
-#[command(author="RobustMQ", about="related operations of access control list, such as listing, creating, and deleting", long_about = None)]
+#[command(author = "RobustMQ", about = "related operations of access control list, such as listing, creating, and deleting", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct AclArgs {
     #[command(subcommand)]
@@ -77,16 +78,16 @@ pub(crate) struct AclArgs {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum AclActionType {
-    #[command(author="RobustMQ", about="action: acl list", long_about = None)]
+    #[command(author = "RobustMQ", about = "action: acl list", long_about = None)]
     List,
-    #[command(author="RobustMQ", about="action: create acl", long_about = None)]
+    #[command(author = "RobustMQ", about = "action: create acl", long_about = None)]
     Create(CreateAclArgs),
-    #[command(author="RobustMQ", about="action: delete acl", long_about = None)]
+    #[command(author = "RobustMQ", about = "action: delete acl", long_about = None)]
     Delete(DeleteAclArgs),
 }
 
 #[derive(clap::Args, Debug)]
-#[command(author="RobustMQ", about="action: create acl", long_about = None)]
+#[command(author = "RobustMQ", about = "action: create acl", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct CreateAclArgs {
     #[arg(short, long, required = true)]
@@ -96,7 +97,7 @@ pub(crate) struct CreateAclArgs {
 }
 
 #[derive(clap::Args, Debug)]
-#[command(author="RobustMQ", about="action: delete acl", long_about = None)]
+#[command(author = "RobustMQ", about = "action: delete acl", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct DeleteAclArgs {
     #[arg(short, long, required = true)]
@@ -105,8 +106,9 @@ pub(crate) struct DeleteAclArgs {
     pub(crate) acl: String,
 }
 
+// blacklist feat
 #[derive(clap::Args, Debug)]
-#[command(author="RobustMQ", about="related operations of blacklist, such as listing, creating, and deleting", long_about = None)]
+#[command(author = "RobustMQ", about = "related operations of blacklist, such as listing, creating, and deleting", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct BlacklistArgs {
     #[command(subcommand)]
@@ -115,16 +117,16 @@ pub(crate) struct BlacklistArgs {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum BlackListActionType {
-    #[command(author="RobustMQ", about="action: blacklist list", long_about = None)]
+    #[command(author = "RobustMQ", about = "action: blacklist list", long_about = None)]
     List,
-    #[command(author="RobustMQ", about="action: create blacklist", long_about = None)]
+    #[command(author = "RobustMQ", about = "action: create blacklist", long_about = None)]
     Create(CreateBlacklistArgs),
-    #[command(author="RobustMQ", about="action: delete blacklist", long_about = None)]
+    #[command(author = "RobustMQ", about = "action: delete blacklist", long_about = None)]
     Delete(DeleteBlacklistArgs),
 }
 
 #[derive(clap::Args, Debug)]
-#[command(author="RobustMQ", about="action: create blacklist", long_about = None)]
+#[command(author = "RobustMQ", about = "action: create blacklist", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct CreateBlacklistArgs {
     #[arg(short, long, required = true)]
@@ -134,7 +136,7 @@ pub(crate) struct CreateBlacklistArgs {
 }
 
 #[derive(clap::Args, Debug)]
-#[command(author="RobustMQ", about="action: delete blacklist", long_about = None)]
+#[command(author = "RobustMQ", about = "action: delete blacklist", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct DeleteBlacklistArgs {
     #[arg(short, long, required = true)]
@@ -146,78 +148,131 @@ pub(crate) struct DeleteBlacklistArgs {
 }
 
 // flapping detect feat
-#[derive(Debug, Parser)]
-#[command(author="RobustMQ", about="", long_about = None)]
+#[derive(clap::Args, Debug)]
+#[command(author = "RobustMQ", about = "action: flapping detect feat", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct FlappingDetectArgs {
-    #[arg(long = "enable")]
-    #[arg(value_parser =  BoolishValueParser::new())]
-    #[arg(default_missing_value = "false")]
-    #[arg(action = ArgAction::Set, num_args = 0..=1)]
-    #[arg(required = true, require_equals = true, exclusive = true)]
-    #[arg(help = "Enable or disable the feature")]
+    #[arg(
+        long = "enable",
+        value_parser = BoolishValueParser::new(),
+        default_missing_value = "false",
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        required = true,
+        require_equals = true,
+        exclusive = true,
+        help = "Enable or disable the feature"
+    )]
     pub(crate) is_enable: Option<bool>,
-    #[arg(long = "window-time")]
-    #[arg(value_parser = RangedU64ValueParser::<u32>::new())]
-    #[arg(default_missing_value = "1")]
-    #[arg(action = ArgAction::Set, num_args = 0..=1)]
-    #[arg(require_equals = true)]
-    #[arg(help = "unit is minutes")]
+    #[arg(
+        long = "window-time",
+        value_parser = RangedU64ValueParser::<u32>::new(),
+        default_missing_value = "1",
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        help = "Unit is minutes"
+    )]
     pub(crate) window_time: Option<u32>,
-    #[arg(long = "max-client-connections")]
-    #[arg(value_parser = RangedU64ValueParser::<u32>::new())]
-    #[arg(default_missing_value = "15")]
-    #[arg(action = ArgAction::Set, num_args = 0..=1)]
+    #[arg(
+        long = "max-client-connections",
+        value_parser = RangedU64ValueParser::<u32>::new(),
+        default_missing_value = "15",
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        help = "Max client connections"
+    )]
     pub(crate) max_client_connections: Option<u32>,
-    #[arg(long = "ban-time")]
-    #[arg(value_parser = RangedU64ValueParser::<u32>::new())]
-    #[arg(default_missing_value = "5")]
-    #[arg(action = ArgAction::Set, num_args = 0..=1)]
-    #[arg(help = "unit is minutes")]
+    #[arg(
+        long = "ban-time",
+        value_parser = RangedU64ValueParser::<u32>::new(),
+        default_missing_value = "5",
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        help = "Unit is minutes"
+    )]
     pub(crate) ban_time: Option<u32>,
 }
 
 // observability: slow-sub feat
-#[derive(Debug, Parser)]
-#[command(author="RobustMQ", about="", long_about = None)]
+#[derive(clap::Args, Debug)]
+#[command(author = "RobustMQ", about = "action: slow-sub", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct SlowSubArgs {
-    #[arg(long = "enable")]
-    #[arg(value_parser =  BoolishValueParser::new())]
-    #[arg(action = ArgAction::Set, num_args = 0..=1)]
-    #[arg(required = false, require_equals = true, exclusive = true)]
-    #[arg(conflicts_with_all = ["list", "sort", "topic", "sub_name", "client_id"])]
-    #[arg(help = "Enable or disable the feature")]
-    is_enable: Option<bool>,
-    #[arg(long = "list")]
-    #[arg(value_parser = RangedU64ValueParser::<u64>::new())]
-    #[arg(default_missing_value = "100")]
-    #[arg(action = ArgAction::Set, num_args = 0..=1)]
-    #[arg(require_equals = true)]
-    list: Option<u64>,
-    #[arg(long = "sort")]
-    #[arg(required = false, requires = "list", require_equals = true)]
-    #[arg(value_parser = EnumValueParser::<SortType>::new())]
-    #[arg(default_missing_value = "DESC", ignore_case = true)]
-    #[arg(action = ArgAction::Set, num_args = 0..=1)]
-    #[arg(help = "Sort the results")]
-    sort: Option<SortType>,
-    #[arg(long = "topic")]
-    #[arg(required = false, requires = "list", require_equals = true)]
-    #[arg(action = ArgAction::Set, num_args = 0..=1)]
-    #[arg(value_parser = NonEmptyStringValueParser::new())]
-    topic: Option<String>,
-    #[arg(long = "sub-name")]
-    #[arg(required = false, requires = "list", require_equals = true)]
-    #[arg(action = ArgAction::Set, num_args = 0..=1)]
-    #[arg(value_parser = NonEmptyStringValueParser::new())]
-    sub_name: Option<String>,
-    #[arg(long = "client-id")]
-    #[arg(required = false, requires = "list", require_equals = true)]
-    #[arg(action = ArgAction::Set, num_args = 0..=1)]
-    #[arg(value_parser = NonEmptyStringValueParser::new())]
-    client_id: Option<String>,
+    #[arg(
+        long = "enable",
+        value_parser = BoolishValueParser::new(),
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        required = false,
+        require_equals = true,
+        exclusive = true,
+        conflicts_with_all = ["list", "sort", "topic", "sub_name", "client_id"],
+        help = "Enable or disable the feature"
+    )]
+    pub(crate) is_enable: Option<bool>,
+    #[arg(
+        long = "list",
+        value_parser = RangedU64ValueParser::<u64>::new(),
+        default_missing_value = "100",
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        require_equals = true,
+        help = "List the slow subscriptions"
+    )]
+    pub(crate) list: Option<u64>,
+
+    #[arg(
+        long = "sort",
+        required = false,
+        requires = "list",
+        require_equals = true,
+        value_parser = EnumValueParser::<SortType>::new(),
+        default_missing_value = "DESC",
+        ignore_case = true,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        help = "Sort the results"
+    )]
+    pub(crate) sort: Option<SortType>,
+
+    #[arg(
+        long = "topic",
+        required = false,
+        requires = "list",
+        require_equals = true,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        value_parser = NonEmptyStringValueParser::new(),
+        help = "Filter the results by topic"
+    )]
+    pub(crate) topic: Option<String>,
+
+    #[arg(
+        long = "sub-name",
+        required = false,
+        requires = "list",
+        require_equals = true,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        value_parser = NonEmptyStringValueParser::new(),
+        help = "Filter the results by subscription name"
+    )]
+    pub(crate) sub_name: Option<String>,
+
+    #[arg(
+        long = "client-id",
+        required = false,
+        requires = "list",
+        require_equals = true,
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        value_parser = NonEmptyStringValueParser::new(),
+        help = "Filter the results by client ID"
+    )]
+    pub(crate) client_id: Option<String>,
 }
+
 
 #[derive(Debug, Parser)]
 #[command(author="RobustMQ", about="", long_about = None)]

--- a/src/cmd/src/cli-command/mqtt/admin.rs
+++ b/src/cmd/src/cli-command/mqtt/admin.rs
@@ -20,9 +20,8 @@ use cli_command::mqtt::MqttActionType;
 use common_base::enum_type::sort_type::SortType;
 use core::option::Option::Some;
 use protocol::broker_mqtt::broker_mqtt_admin::{
-    CreateAclRequest, CreateBlacklistRequest, CreateTopicRewriteRuleReply,
-    CreateTopicRewriteRuleRequest, CreateUserRequest, DeleteAclRequest,
-    DeleteAutoSubscribeRuleRequest, DeleteBlacklistRequest, DeleteTopicRewriteRuleReply,
+    CreateAclRequest, CreateBlacklistRequest, CreateTopicRewriteRuleRequest, CreateUserRequest,
+    DeleteAclRequest, DeleteAutoSubscribeRuleRequest, DeleteBlacklistRequest,
     DeleteTopicRewriteRuleRequest, DeleteUserRequest, ListAutoSubscribeRuleRequest,
     MqttCreateConnectorRequest, MqttDeleteConnectorRequest, MqttListConnectorRequest,
     MqttUpdateConnectorRequest, SetAutoSubscribeRuleRequest,
@@ -278,7 +277,7 @@ pub(crate) struct SlowSubArgs {
 
 // topic rewrite rule
 #[derive(clap::Args, Debug)]
-#[command(author = "RobustMQ", about = "related operations of topic rewrite, such as  creating and deleting", long_about = None)]
+#[command(author = "RobustMQ", about = "related operations of topic rewrite, such as creating and deleting", long_about = None)]
 #[command(next_line_help = true)]
 pub(crate) struct TopicRewriteArgs {
     #[command(subcommand)]


### PR DESCRIPTION
## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- The current CLI capabilities supported by the robustctl MQTT command line are not comprehensive enough. The principle is that all services in src/mqtt-broker/src/admin need to have corresponding command line tools. Therefore, it is necessary to compare the differences between the current robustctl and the services provided by admin, and then improve the CLI.
Compare: src/cmd/src/cli-command/command.rs and https://github.com/robustmq/robustmq-proto/blob/main/protos/broker_mqtt/proto/admin.proto to obtain the information.
- First, I noticed the the existing implementation of the MQTT command related to the connector is non-standard and lacks readability.So I refectored it to make its code more readable and standardized, ensuring consistency with the existing implementations of other modules.
- Then, I add support for topic rewrite rules to the MQTT command.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link
close [#1026](https://github.com/robustmq/robustmq/issues/1026)
