### PR TITLE
docs: add mqtt command doc for acl and blacklist

### DIFF
--- a/docs/en/RobustMQ-Command/Mqtt-Broker.md
+++ b/docs/en/RobustMQ-Command/Mqtt-Broker.md
@@ -1,9 +1,15 @@
-## 1. User
+# MQTT Broker Command
+
+## 1. User Management
+
+MQTT Broker has enabled user authentication. Clients must provide valid usernames and passwords before publishing or subscribing to messages to pass the authentication. Clients that fail authentication will not be able to communicate with the Broker. This feature enhances system security and prevents unauthorized access.
 
 ### 1.1 Create User
 
+Create a new MQTT Broker user.
+
 ```console
-% ./bin/robust-ctl mqtt mqtt user create --username=testp --password=7355608
+% ./bin/robust-ctl mqtt mqtt user create --username=testp --password=7355608 --is_superuser=false
 Created successfully!
 ```
 
@@ -75,20 +81,94 @@ helloworld!
 published retained message
 ```
 
-## 3. Slow Subscription
+## 3. ACL (Access Control List) Management
+
+### 3.1 Create ACL
+
+Create a new ACL rule.
+
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 acl create --cluster-name=admin --acl=xxx
+able to connect: "127.0.0.1:1883"
+Created successfully!
+```
+
+### 3.2 Delete ACL
+
+Delete an existing ACL rule.
+
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 acl delete --cluster-name=admin --acl=xxx
+able to connect: "127.0.0.1:1883"
+Deleted successfully!
+```
+
+### 3.3 ACL List
+
+List all created ACL rules.
+
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 acl list
++---------------+---------------+-------+----+--------+------------+
+| resource_type | resource_name | topic | ip | action | permission |
++---------------+---------------+-------+----+--------+------------+
+```
+
+## 4. Blacklist Management
+
+### 4.1 Create Blacklist
+
+Create a new blacklist rule.
+
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 blacklist create --cluster-name=admin --blacklist=client_id
+able to connect: "127.0.0.1:1883"
+Created successfully!
+```
+
+### 4.2 Delete Blacklist
+
+Delete an existing blacklist rule.
+
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 blacklist delete --cluster-name=admin --blacklist-type=client_id --resource-name=client1
+able to connect: "127.0.0.1:1883"
+Deleted successfully!
+```
+
+### 4.3 Blacklist List
+
+List all created blacklist rules.
+
+```console
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 blacklist list
++----------------+---------------+----------+----------------+
+| blacklist_type | resource_name | end_time | blacklist_type |
++----------------+---------------+----------+----------------+
+```
+
+## 5. Slow Subscription
 
 The slow subscription statistics function is mainly used to calculate the time (latency) it takes for the Broker to complete message processing and transmission after the message arrives at the Broker. If the latency exceeds the threshold, we will record a related piece of information in the cluster's slow subscription log. Operations personnel can query slow subscription records across the entire cluster using commands to address issues based on this information
 
-### 3.1 Enable Slow Subscription
+### 5.1 Enable Slow Subscription
 
-Enable slow subscription
+- Enable slow subscription
 
 ```console
 % ./bin/robust-ctl mqtt mqtt slow-sub --enable=true
 The slow subscription feature has been successfully enabled.
 ```
 
-### 3.2 View slow subscription records
+- Close slow subscription
+
+```console
+% ./bin/robust-ctl mqtt mqtt slow-sub --enable=false
+The slow subscription feature has been successfully closed.
+```
+
+### 5.2 View slow subscription records
 
 After enabling the slow subscription statistics function, the cluster begins recording slow subscriptions. To query corresponding slow subscription records, clients can enter the following command:
 
@@ -99,7 +179,7 @@ After enabling the slow subscription statistics function, the cluster begins rec
 +-----------+-------+----------+---------+-------------+
 ```
 
-### 3.3 Sorting Functionality
+### 5.3 Sorting Functionality
 
 To obtain more slow subscription records and sort them in ascending order from smallest to largest, you can use the following command:
 
@@ -110,7 +190,7 @@ To obtain more slow subscription records and sort them in ascending order from s
 +-----------+-------+----------+---------+-------------+
 ```
 
-### 3.4 Filtering Query Functionality
+### 5.4 Filtering Query Functionality
 
 For slow subscription queries, filtering queries are also supported. You can retrieve filtered results by fields such as topic, sub_name, and client_id. By default, the results are sorted in descending order from largest to smallest. Refer to the usage command below:
 

--- a/docs/zh/RobustMQ-Command/Mqtt-Broker.md
+++ b/docs/zh/RobustMQ-Command/Mqtt-Broker.md
@@ -2,19 +2,23 @@
 
 ## 1. 用户管理
 
-### 1.1 创建用户
-
 MQTT Broker 启用了用户验证功能，客户端在发布或订阅消息前，
 必须提供有效的用户名和密码以通过验证。
 未通过验证的客户端将无法与 Broker 通信。
 这一功能可以增强系统的安全性，防止未经授权的访问。
 
+### 1.1 创建用户
+
+创建新的 MQTT Broker 用户。
+
 ```console
-% ./bin/robust-ctl mqtt  mqtt user create --username=testp --password=7355608
+% ./bin/robust-ctl mqtt  mqtt user create --username=testp --password=7355608 --is_superuser=false
 Created successfully!
 ```
 
 ### 1.2 删除用户
+
+删除已有的 MQTT Broker 用户。
 
 ```console
 % ./bin/robust-ctl mqtt  mqtt user delete --username=testp
@@ -22,6 +26,8 @@ Deleted successfully!
 ```
 
 ### 1.3 用户列表
+
+列出所有已创建的用户。
 
 ```console
 % ./bin/robust-ctl mqtt  mqtt user list
@@ -34,64 +40,129 @@ Deleted successfully!
 +----------+--------------+
 ```
 
-## 2. MQTT 发布、订阅消息
+## 2. 发布、订阅消息
 
 ### 2.1 发布 MQTT 消息
 
 ```console
-    % ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 publish --username=admin --password=pwd123 --topic=test/topic1 --qos=0
-    able to connect: "127.0.0.1:1883"
-    you can post a message on the terminal:
-    1
-    > You typed: 1
-    2
-    > You typed: 2
-    3
-    > You typed: 3
-    4
-    > You typed: 4
-    5
-    > You typed: 5
-    ^C>  Ctrl+C detected,  Please press ENTER to end the program.
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 publish --username=admin --password=pwd123 --topic=test/topic1 --qos=0
+able to connect: "127.0.0.1:1883"
+you can post a message on the terminal:
+1
+> You typed: 1
+2
+> You typed: 2
+3
+> You typed: 3
+4
+> You typed: 4
+5
+> You typed: 5
+^C>  Ctrl+C detected,  Please press ENTER to end the program.
 ```
 
 ### 2.2 订阅 MQTT 消息
 
 ```console
-    % ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 subscribe --username=admin --password=pwd123 --topic=test/topic1 --qos=0
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 subscribe --username=admin --password=pwd123 --topic=test/topic1 --qos=0
 
-    able to connect: "127.0.0.1:1883"
-    subscribe success
-    payload: 1
-    payload: 2
-    payload: 3
-    payload: 4
-    payload: 5
-    ^C Ctrl+C detected,  Please press ENTER to end the program.
-    End of input stream.
+able to connect: "127.0.0.1:1883"
+subscribe success
+payload: 1
+payload: 2
+payload: 3
+payload: 4
+payload: 5
+^C Ctrl+C detected,  Please press ENTER to end the program.
+End of input stream.
 ```
 
 ### 2.3 发布保留消息
 
 ```console
-    % ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 publish --username=admin --password=pwd123 --topic=\$share/group1/test/topic1 --qos=1 --retained
-    able to connect: "127.0.0.1:1883"
-    you can post a message on the terminal:
-    helloworld!
-    > You typed: helloworld!
-    published retained message
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 publish --username=admin --password=pwd123 --topic=\$share/group1/test/topic1 --qos=1 --retained
+able to connect: "127.0.0.1:1883"
+you can post a message on the terminal:
+helloworld!
+> You typed: helloworld!
+published retained message
 ```
 
 ```console
-    % ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 subscribe --username=admin --password=pwd123 --topic=\$share/group1/test/topic1 --qos=0
-    able to connect: "127.0.0.1:1883"
-    subscribe success
-    Retain message: helloworld!
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 subscribe --username=admin --password=pwd123 --topic=\$share/group1/test/topic1 --qos=0
+able to connect: "127.0.0.1:1883"
+subscribe success
+Retain message: helloworld!
 ```
 
-## 3. 开启慢订阅功能
+## 3. ACL（访问控制列表）管理
 
-### 3.1 开启/关闭慢订阅
+### 3.1 创建 ACL
+
+创建新的 ACL 规则。
+
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 acl create --cluster-name=admin --acl=xxx
+able to connect: "127.0.0.1:1883"
+Created successfully!
+```
+
+### 3.2 删除 ACL
+
+删除已有的 ACL 规则。
+
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 acl delete --cluster-name=admin --acl=xxx
+able to connect: "127.0.0.1:1883"
+Deleted successfully!
+```
+
+### 3.3 ACL 列表
+
+列出所有已创建的 ACL 规则。
+
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 acl list
++---------------+---------------+-------+----+--------+------------+
+| resource_type | resource_name | topic | ip | action | permission |
++---------------+---------------+-------+----+--------+------------+
+```
+
+## 4. 黑名单管理
+
+### 4.1 创建黑名单
+
+创建新的黑名单规则。
+
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 blacklist create --cluster-name=admin --blacklist=client_id
+able to connect: "127.0.0.1:1883"
+Created successfully!
+```
+### 4.2 删除黑名单
+
+删除已有的黑名单规则。
+
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 blacklist delete --cluster-name=admin --blacklist-type=client_id --resource-name=client1
+able to connect: "127.0.0.1:1883"
+Deleted successfully!
+```
+
+### 4.3 黑名单列表
+
+列出所有已创建的黑名单规则。
+
+```console
+% ./bin/robust-ctl mqtt mqtt --server=127.0.0.1:1883 blacklist list
++----------------+---------------+----------+------+
+| blacklist_type | resource_name | end_time | desc |
++----------------+---------------+----------+------+
+```
+
+## 5. 开启慢订阅功能
+
+### 5.1 开启/关闭慢订阅
 
 慢订阅统计功能主要是为了在消息到达 Broker 后，
 Broker 来计算完成消息处理以及传输整个流程所消耗的时间(时延),
@@ -99,14 +170,21 @@ Broker 来计算完成消息处理以及传输整个流程所消耗的时间(时
 运维人员可以通过命令查询整个集群下的慢订阅记录信息，
 通过慢订阅信息来解决。
 
-开启慢订阅
+- 开启慢订阅
 
 ```console
 % ./bin/robust-ctl mqtt mqtt slow-sub --enable=true
 The slow subscription feature has been successfully enabled.
 ```
 
-### 3.2 查询慢订阅记录
+- 关闭慢订阅
+
+```console
+% ./bin/robust-ctl mqtt mqtt slow-sub --enable=false
+The slow subscription feature has been successfully closed.
+```
+
+### 5.2 查询慢订阅记录
 
 当我们启动了慢订阅统计功能之后, 集群就开启慢订阅统计功能，
 这样我们可以通过对应的命令来去查询对应的慢订阅记录，
@@ -139,4 +217,20 @@ sub_name 以及 client_id 的方式来获取不同字段过滤后的结果，
 +-----------+-------+----------+---------+-------------+
 | client_id | topic | sub_name | time_ms | create_time |
 +-----------+-------+----------+---------+-------------+
+```
+
+
+## 6. 主题重写规则
+
+### 5.1 创建主题重写规则
+
+```console
+% ./bin/robust-ctl mqtt mqtt topic-rewrite create --action=xxx --source-topic=xxx --dest-topic=xxx --regex=xxx
+Created successfully!
+```
+### 5.2 删除主题重写规则
+
+```console
+% ./bin/robust-ctl mqtt mqtt topic-rewrite delete --action=xxx --source-topic=xxx
+Deleted successfully!
 ```

--- a/src/cli-command/src/mqtt.rs
+++ b/src/cli-command/src/mqtt.rs
@@ -581,7 +581,12 @@ impl MqttBrokerCommand {
             Ok(data) => {
                 // format table
                 let mut table = Table::new();
-                table.add_row(row!["blacklist_type", "resource_name", "end_time", "desc"]);
+                table.add_row(row![
+                    "blacklist_type",
+                    "resource_name",
+                    "end_time",
+                    "blacklist_type"
+                ]);
                 for blacklist in data.blacklists {
                     let mqtt_acl_blacklist =
                         serde_json::from_slice::<MqttAclBlackList>(blacklist.as_slice()).unwrap();

--- a/src/mqtt-broker/src/handler/topic_rewrite.rs
+++ b/src/mqtt-broker/src/handler/topic_rewrite.rs
@@ -146,21 +146,21 @@ mod tests {
     /// At this time we subscribe to five topics: `y/a/z/b`, `y/def`, `x/1/2`, `x/y/2`, and `x/y/z`:
     ///
     /// - `y/def` does not match any of the topic filters, so it does not perform topic rewriting,
-    /// and just subscribes to `y/def` topics.
-    /// - `y/a/z/b` matches t   1he `y/+/z/#` topic filter, executes the first rule, and matches
-    /// the element \[a、b\] through a regular expression, brings the matched second element
-    /// into `y/z/$2`, and actually subscribes to the topic `y/z/b`.
+    ///   and just subscribes to `y/def` topics.
+    /// - `y/a/z/b` matches the `y/+/z/#` topic filter, executes the first rule, and matches
+    ///   the element [a, b] through a regular expression, brings the matched second element
+    ///   into `y/z/$2`, and actually subscribes to the topic `y/z/b`.
     /// - `x/1/2` matches `x/#` topic filter, executes the second rule. It does not match
-    /// elements through regular expressions, does not perform topic rewrite, and actually
-    /// subscribes to the topic of `x/1/2`.
-    /// - `x/y/2` matches two topic filters of `x/#` and `x/y/`+ at the same time, reads the
-    /// configuration in reverse order, so it matches the third preferentially. Through
-    /// regular replacement, it actually subscribed to the `z/y/2` topic.
+    ///   elements through regular expressions, does not perform topic rewrite, and actually
+    ///   subscribes to the topic of `x/1/2`.
+    /// - `x/y/2` matches two topic filters of `x/#` and `x/y/+` at the same time, reads the
+    ///   configuration in reverse order, so it matches the third preferentially. Through
+    ///   regular replacement, it actually subscribed to the `z/y/2` topic.
     /// - `x/y/z` matches two topic filters of `x/#` and `x/y/+` at the same time, reads the
-    /// configuration in reverse order, so it matches the third preferentially. The element is
-    /// not matched through the regular expression, the topic rewrite is not performed, and it
-    /// actually subscribes to the `x/y/z` topic. It should be noted that even if the regular
-    /// expression matching of the third fails, it will not match the rules of the second again.
+    ///   configuration in reverse order, so it matches the third preferentially. The element is
+    ///   not matched through the regular expression, the topic rewrite is not performed, and it
+    ///   actually subscribes to the `x/y/z` topic. It should be noted that even if the regular
+    ///   expression matching of the third fails, it will not match the rules of the second again.
     ///
     const SRC_TOPICS: [&str; 5] = ["y/a/z/b", "y/def", "x/1/2", "x/y/2", "x/y/z"];
     const DST_TOPICS: [&str; 5] = ["y/z/b", "y/def", "x/1/2", "z/y/2", "x/y/z"];

--- a/src/mqtt-broker/src/handler/topic_rewrite.rs
+++ b/src/mqtt-broker/src/handler/topic_rewrite.rs
@@ -116,9 +116,9 @@ pub fn process_publish_topic_rewrite(
 
 #[cfg(test)]
 mod tests {
-    use protocol::mqtt::common::{Filter, QoS, RetainForwardRule, Subscribe};
-    use common_base::tools;
     use super::*;
+    use common_base::tools;
+    use protocol::mqtt::common::{Filter, QoS, RetainForwardRule, Subscribe};
 
     /// Assume that the following topic rewrite rules have been added to the conf file:
     /// ```bash
@@ -168,14 +168,12 @@ mod tests {
 
     #[test]
     fn sub_topic_rewrite_test() {
-        let filters = SRC_TOPICS.map(|src_topic| {
-            Filter {
-                path: src_topic.to_string(),
-                qos: QoS::AtMostOnce,
-                nolocal: false,
-                preserve_retain: false,
-                retain_forward_rule: RetainForwardRule::Never,
-            }
+        let filters = SRC_TOPICS.map(|src_topic| Filter {
+            path: src_topic.to_string(),
+            qos: QoS::AtMostOnce,
+            nolocal: false,
+            preserve_retain: false,
+            retain_forward_rule: RetainForwardRule::Never,
         });
         let mut subscribe = Subscribe {
             packet_identifier: 0,
@@ -192,11 +190,8 @@ mod tests {
 
     #[test]
     fn unsub_topic_rewrite_test() {
-        let filters = SRC_TOPICS.map(|src_topic| {src_topic.to_string()}).to_vec();
-        let mut unsub = Unsubscribe{
-            pkid: 0,
-            filters,
-        };
+        let filters = SRC_TOPICS.map(|src_topic| src_topic.to_string()).to_vec();
+        let mut unsub = Unsubscribe { pkid: 0, filters };
 
         let rules = build_rules();
         process_unsub_topic_rewrite(&mut unsub, &rules);
@@ -205,7 +200,6 @@ mod tests {
         for (index, filter) in unsub.filters.iter().enumerate() {
             assert_eq!(filter, DST_TOPICS[index]);
         }
-
     }
 
     #[test]
@@ -215,7 +209,7 @@ mod tests {
             let result = process_publish_topic_rewrite(src_topic.to_string(), &rules);
             assert!(result.is_ok());
             let option = result.unwrap();
-            
+
             let matches = REGEX_MATCHES[index];
             assert_eq!(option.is_some(), matches);
             if matches {
@@ -224,7 +218,6 @@ mod tests {
             } else {
                 assert!(option.is_none());
             }
-
         }
     }
 
@@ -232,7 +225,7 @@ mod tests {
         let rules = vec![
             SimpleRule::new(r"y/+/z/#", r"y/z/$2", r"^y/(.+)/z/(.+)$"),
             SimpleRule::new(r"x/#", r"z/y/x/$1", r"^x/y/(.+)$"),
-            SimpleRule::new(r"x/y/+", r"z/y/$1",r"^x/y/(\d+)$")
+            SimpleRule::new(r"x/y/+", r"z/y/$1", r"^x/y/(\d+)$"),
         ];
 
         let map = DashMap::with_capacity(rules.len());
@@ -245,7 +238,7 @@ mod tests {
                 regex: rule.regex.to_string(),
                 timestamp: tools::now_nanos(),
             };
-            map.insert(format!("rule{}",index), rule);
+            map.insert(format!("rule{}", index), rule);
         }
         map
     }

--- a/src/mqtt-broker/src/subscribe/sub_common.rs
+++ b/src/mqtt-broker/src/subscribe/sub_common.rs
@@ -237,7 +237,7 @@ pub async fn wait_pub_ack(
     stop_sx: &broadcast::Sender<bool>,
     wait_ack_sx: &broadcast::Sender<QosAckPackageData>,
 ) {
-    let wait_pub_rec_fn = || async  {
+    let wait_pub_rec_fn = || async {
         match timeout(Duration::from_secs(30), wait_packet_ack(wait_ack_sx)).await {
             Ok(Some(data)) => {
                 if data.ack_type == QosAckPackageType::PubAck && data.pkid == sub_pub_param.pkid {
@@ -676,8 +676,8 @@ mod tests {
         let topic_name = r"/sensor/temperature3/tmpq".to_string();
         let sub_regex = r"$share/groupname/sensor/#".to_string();
         assert!(path_regex_match(&topic_name, &sub_regex));
-        
-        let topic_name = r"y/a/z/b".to_string(); 
+
+        let topic_name = r"y/a/z/b".to_string();
         let sub_regex = r"y/+/z/#".to_string();
         assert!(path_regex_match(&topic_name, &sub_regex));
     }


### PR DESCRIPTION
## What's changed and what's your intention?

- add mqtt command doc for acl and blacklist.
- run "Cargo fmt" to format code that is introduced in a previous PR(#1022 ). This PR (https://github.com/robustmq/robustmq/pull/1022 ) was merged despite failing to pass CI.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link
close [#1029](https://github.com/robustmq/robustmq/issues/1029)
