### PR TITLE
test: check placement status before starting test

### DIFF
--- a/scripts/check-place-status.sh
+++ b/scripts/check-place-status.sh
@@ -1,0 +1,46 @@
+# Copyright 2023 RobustMQ Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+check_status() {
+   make > /dev/null
+   if [ $? -ne 0 ]; then
+      echo "Error: Make command failed"
+      return 1
+   fi
+   cd build
+   matched_file=$(ls | grep -E '^robustmq-[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz$')
+   tar -xzf "$matched_file" > /dev/null
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to extract the tarball."
+        return 1
+    fi
+
+    cd robustmq-*/bin
+
+    place_status=$(./robust-ctl place status)
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to get the status of placement center."
+        return 1
+    fi
+
+    while true; do
+      if [[ "$place_status" == *'"running_state":{"Ok":null}'* ]]; then
+        echo "Placement center is ready now!"
+        break
+      else
+        echo "Placement center starts but not ready yet. Waiting..."
+        sleep 2
+      fi
+    done
+}

--- a/scripts/place-ig-test.sh
+++ b/scripts/place-ig-test.sh
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source scripts/check-place-status.sh
 
 start_server(){
     nohup cargo run --package cmd --bin placement-center -- --conf=config/placement-center.toml 2>/tmp/1.log &
@@ -38,7 +39,7 @@ stop_server
 
 # Start Server
 start_server
-sleep 10
+check_status
 
 # Run Placement integration Test
 if [ "$1" = "dev" ]; then


### PR DESCRIPTION
relate #1035 

## What's changed and what's your intention?

Check whether the status of PC is "Running" before starting placement integration test.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
