### PR TITLE
docs: add the social links and doc env guide add windows Installation nodejs

### DIFF
--- a/docs/.vitepress/src/configs/en.mts
+++ b/docs/.vitepress/src/configs/en.mts
@@ -25,6 +25,10 @@ export const enConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
 
         },
 
+        socialLinks: [
+            {icon: 'github', link: 'https://github.com/robustmq/robustmq'}
+        ]
+
     },
 
 }

--- a/docs/.vitepress/src/configs/zh.mts
+++ b/docs/.vitepress/src/configs/zh.mts
@@ -24,6 +24,10 @@ export const zhConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
 
         },
 
+        socialLinks: [
+            {icon: 'github', link: 'https://github.com/robustmq/robustmq'}
+        ]
+
     },
 
 }

--- a/docs/en/ContributionGuide/ContributingDoc/Build-Doc-Env.md
+++ b/docs/en/ContributionGuide/ContributingDoc/Build-Doc-Env.md
@@ -1,23 +1,33 @@
 # How to Build the Documentation Environment
 
-RobustMQ uses [VitePress](https://vitepress.dev/) to build its documentation system. If you need to modify the configuration, you can refer to the [VitePress documentation](https://vitepress.dev/guide/getting-started) to help improve the documentation build for RobustMQ.
+RobustMQ uses [VitePress](https://vitepress.dev/) to build its documentation system. If you need to modify the
+configuration, you can refer to the [VitePress documentation](https://vitepress.dev/guide/getting-started) to help
+improve the documentation build for RobustMQ.
 
-## Mac
+## Mac / Windows
+
 ### Prerequisites
 
-Install `node` using the following command:
+You need to have the `node` environment installed.
+
+- macOS users can install Node.js via `brew`:
+
 ```shell
 brew install node
 ```
 
+- Windows users can install Node.js from the official [Node.js](https://nodejs.org/en/download/) website.
+
 ### Steps
 
 1. Install the packages required by `VitePress` using the following command:
+
 ```shell
 npm install
 ```
 
 2. Start local development with the following command:
+
 ```shell
 npm run docs:dev
 ```

--- a/docs/zh/ContributionGuide/ContributingDoc/Build-Doc-Env.md
+++ b/docs/zh/ContributionGuide/ContributingDoc/Build-Doc-Env.md
@@ -4,13 +4,20 @@ RobustMQ使用的是[VitePress](https://vitepress.dev/)来构建对应的文档�
 如果需要修改配置，可以参考[VitPress文档](https://vitepress.dev/guide/getting-started)
 来帮助RobustMQ的文档构建的更好。
 
-## Mac
+## Mac / Windows
+
 ### 前置准备
 
-通过如下命令安装`node`
+你需要 `node` 环境来运行文档
+
+- MacOS 用户可以通过`brew`来安装node
+
 ```shell
 brew install node
 ```
+
+- Windows 用户可以通过 [Node.js官网](https://nodejs.org/zh-cn/download/) 来安装 Node.js
+
 ### 具体步骤
 
 1. 通过如下命令安装`VitePress`所需要的包


### PR DESCRIPTION
## What's changed and what's your intention?
- Add social links to documents to quickly jump to GitHub repositories
- Build Doc Env Guide Add Windows System Installation Node.js Environment Instructions

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link
close #1044 
