### PR TITLE
fix: Add config grpc_max_decoding_message_size to make the max si…

### DIFF
--- a/config/placement-center.toml
+++ b/config/placement-center.toml
@@ -22,7 +22,7 @@ nodes = { 1 = "127.0.0.1:1228" }
 local_ip = "127.0.0.1"
 grpc_port = 1228
 http_port = 1227
-grpc_max_decoding_message_size = 16777216
+grpc_max_decoding_message_size = 268435456
 
 [system]
 runtime_work_threads = 100

--- a/config/placement-center.toml
+++ b/config/placement-center.toml
@@ -22,6 +22,7 @@ nodes = { 1 = "127.0.0.1:1228" }
 local_ip = "127.0.0.1"
 grpc_port = 1228
 http_port = 1227
+grpc_max_decoding_message_size = 16777216
 
 [system]
 runtime_work_threads = 100

--- a/src/common/base/src/config/default_placement_center.rs
+++ b/src/common/base/src/config/default_placement_center.rs
@@ -36,6 +36,7 @@ pub fn default_network() -> Network {
     Network {
         local_ip: default_local_ip(),
         grpc_port: default_grpc_port(),
+        grpc_max_decoding_message_size: default_grpc_max_decoding_message_size(),
         http_port: default_http_port(),
     }
 }
@@ -49,7 +50,7 @@ pub fn default_grpc_port() -> u32 {
 }
 
 pub fn default_grpc_max_decoding_message_size() -> u32 {
-    1024 * 1024 * 16 // 16MB
+    16677216 // 16MB
 }
 
 pub fn default_http_port() -> u32 {

--- a/src/common/base/src/config/default_placement_center.rs
+++ b/src/common/base/src/config/default_placement_center.rs
@@ -50,7 +50,7 @@ pub fn default_grpc_port() -> u32 {
 }
 
 pub fn default_grpc_max_decoding_message_size() -> u32 {
-    16677216 // 16MB
+    268435456 // 256MB
 }
 
 pub fn default_http_port() -> u32 {

--- a/src/common/base/src/config/default_placement_center.rs
+++ b/src/common/base/src/config/default_placement_center.rs
@@ -48,6 +48,10 @@ pub fn default_grpc_port() -> u32 {
     1228
 }
 
+pub fn default_grpc_max_decoding_message_size() -> u32 {
+    1024 * 1024 * 16 // 16MB
+}
+
 pub fn default_http_port() -> u32 {
     1227
 }

--- a/src/common/base/src/config/placement_center.rs
+++ b/src/common/base/src/config/placement_center.rs
@@ -60,6 +60,8 @@ pub struct Network {
     pub local_ip: String,
     #[serde(default = "default_grpc_port")]
     pub grpc_port: u32,
+    #[serde(default = "default_grpc_max_decoding_message_size")]
+    pub grpc_max_decoding_message_size: u32,
     #[serde(default = "default_http_port")]
     pub http_port: u32,
 }

--- a/src/common/base/src/config/placement_center.rs
+++ b/src/common/base/src/config/placement_center.rs
@@ -21,10 +21,11 @@ use toml::{Table, Value};
 
 use super::common::{override_default_by_env, Log};
 use super::default_placement_center::{
-    default_cluster_name, default_data_path, default_grpc_port, default_heartbeat,
-    default_heartbeat_check_time_ms, default_heartbeat_timeout_ms, default_http_port,
-    default_local_ip, default_log, default_max_open_files, default_network, default_node,
-    default_node_id, default_nodes, default_rocksdb, default_runtime_work_threads, default_system,
+    default_cluster_name, default_data_path, default_grpc_max_decoding_message_size,
+    default_grpc_port, default_heartbeat, default_heartbeat_check_time_ms,
+    default_heartbeat_timeout_ms, default_http_port, default_local_ip, default_log,
+    default_max_open_files, default_network, default_node, default_node_id, default_nodes,
+    default_rocksdb, default_runtime_work_threads, default_system,
 };
 use crate::tools::{read_file, try_create_fold};
 

--- a/src/placement-center/src/server/grpc/server.rs
+++ b/src/placement-center/src/server/grpc/server.rs
@@ -42,6 +42,7 @@ use protocol::placement_center::placement_center_mqtt::mqtt_service_server::Mqtt
 use protocol::placement_center::placement_center_openraft::open_raft_service_server::OpenRaftServiceServer;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use tonic::codegen::InterceptedService;
 use tonic::{transport::Server, Request, Status};
 use tower::{Layer, Service};
 
@@ -89,11 +90,32 @@ pub async fn start_grpc_server(
         mqtt_call_manager.clone(),
         client_pool.clone(),
     );
-    let pc_svc = PlacementCenterServiceServer::with_interceptor(placement_handler, grpc_intercept);
-    let kv_svc = KvServiceServer::with_interceptor(kv_handler, grpc_intercept);
-    let mqtt_svc = MqttServiceServer::with_interceptor(mqtt_handler, grpc_intercept);
-    let engine_svc = EngineServiceServer::with_interceptor(engine_handler, grpc_intercept);
-    let openraft_svc = OpenRaftServiceServer::with_interceptor(openraft_handler, grpc_intercept);
+
+    let grpc_max_decoding_message_size = config.network.grpc_max_decoding_message_size as usize;
+    let pc_svc = InterceptedService::new(
+        PlacementCenterServiceServer::new(placement_handler)
+            .max_decoding_message_size(grpc_max_decoding_message_size),
+        grpc_intercept,
+    );
+    let kv_svc = InterceptedService::new(
+        KvServiceServer::new(kv_handler).max_decoding_message_size(grpc_max_decoding_message_size),
+        grpc_intercept,
+    );
+    let mqtt_svc = InterceptedService::new(
+        MqttServiceServer::new(mqtt_handler)
+            .max_decoding_message_size(grpc_max_decoding_message_size),
+        grpc_intercept,
+    );
+    let engine_svc = InterceptedService::new(
+        EngineServiceServer::new(engine_handler)
+            .max_decoding_message_size(grpc_max_decoding_message_size),
+        grpc_intercept,
+    );
+    let openraft_svc = InterceptedService::new(
+        OpenRaftServiceServer::new(openraft_handler)
+            .max_decoding_message_size(grpc_max_decoding_message_size),
+        grpc_intercept,
+    );
 
     let layer = tower::ServiceBuilder::new()
         .layer(BaseMiddlewareLayer::default())


### PR DESCRIPTION
## What's changed and what's your intention?

- Allow the GRPC encode size to be configurable through configuration items.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link
close #1050 [https://github.com/robustmq/robustmq/issues/1050]
