### PR TITLE
feat: add pagination, sort, filter support for session and client list query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -1347,7 +1347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2229,7 +2229,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3671,7 +3671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -3691,7 +3691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -4036,7 +4036,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4378,7 +4378,7 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 [[package]]
 name = "robustmq-proto-build"
 version = "0.1.0"
-source = "git+https://github.com/robustmq/robustmq-proto.git?branch=main#51a7d07652405f8950fe586a81ce3f10cffa1dc2"
+source = "git+https://github.com/HeartLinked/robustmq-proto.git?branch=dev_copilot_list1#4ec3419a49440283d4331460f9e4dc16a81cd8a4"
 dependencies = [
  "prost-build",
  "prost-validate-build",
@@ -4505,7 +4505,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4518,7 +4518,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4596,7 +4596,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5106,7 +5106,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.5",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6039,7 +6039,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3671,7 +3671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -4378,7 +4378,7 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 [[package]]
 name = "robustmq-proto-build"
 version = "0.1.0"
-source = "git+https://github.com/HeartLinked/robustmq-proto.git?branch=dev_copilot_list1#4ec3419a49440283d4331460f9e4dc16a81cd8a4"
+source = "git+https://github.com/robustmq/robustmq-proto.git?branch=main#51a7d07652405f8950fe586a81ce3f10cffa1dc2"
 dependencies = [
  "prost-build",
  "prost-validate-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1347,7 +1347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2229,7 +2229,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3691,7 +3691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -4036,7 +4036,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4505,7 +4505,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4518,7 +4518,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4596,7 +4596,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5106,7 +5106,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6039,7 +6039,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4378,7 +4378,7 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 [[package]]
 name = "robustmq-proto-build"
 version = "0.1.0"
-source = "git+https://github.com/robustmq/robustmq-proto.git?branch=main#51a7d07652405f8950fe586a81ce3f10cffa1dc2"
+source = "git+https://github.com/robustmq/robustmq-proto.git?branch=main#81cb5e5f9ff0fad4485039ff99b9d79f45be5566"
 dependencies = [
  "prost-build",
  "prost-validate-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ metadata-struct = { path = "src/common/metadata-struct" }
 third-driver = { path = "src/common/third-driver" }
 protocol = { path = "src/protocol" }
 robustmq-test = { path = "tests" }
-robustmq-proto-build = { git = "https://github.com/HeartLinked/robustmq-proto.git", branch = "dev_copilot_list1" }
+robustmq-proto-build = { git = "https://github.com/robustmq/robustmq-proto.git", branch = "main" }
 pprof-monitor = { path = "src/common/pprof-monitor" }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ metadata-struct = { path = "src/common/metadata-struct" }
 third-driver = { path = "src/common/third-driver" }
 protocol = { path = "src/protocol" }
 robustmq-test = { path = "tests" }
-robustmq-proto-build = { git = "https://github.com/robustmq/robustmq-proto.git", branch = "main" }
+robustmq-proto-build = { git = "https://github.com/HeartLinked/robustmq-proto.git", branch = "dev_copilot_list1" }
 pprof-monitor = { path = "src/common/pprof-monitor" }
 
 

--- a/src/mqtt-broker/src/admin/client.rs
+++ b/src/mqtt-broker/src/admin/client.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::query::{apply_filters, apply_pagination, apply_sorting};
+use crate::admin::query::{apply_filters, apply_pagination, apply_sorting, Queryable};
 use crate::handler::cache::CacheManager;
 use metadata_struct::mqtt::connection::MQTTConnection;
 use metadata_struct::mqtt::session::MqttSession;
@@ -66,5 +66,21 @@ fn merge_client_info(session: MqttSession, connection: Option<MQTTConnection>) -
         // clean session is true when session_expiry is 0 (MQTT 5.0)
         clean_session: session.session_expiry == 0,
         session_expiry_interval: session.session_expiry,
+    }
+}
+
+impl Queryable for ClientRaw {
+    fn get_field_str(&self, field: &str) -> Option<String> {
+        match field {
+            "client_id" => Some(self.client_id.clone()),
+            "username" => Some(self.username.clone()),
+            "is_online" => Some(self.is_online.to_string()),
+            "source_ip" => Some(self.source_ip.clone()),
+            "connected_at" => Some(self.connected_at.to_string()),
+            "keep_alive" => Some(self.keep_alive.to_string()),
+            "clean_session" => Some(self.clean_session.to_string()),
+            "session_expiry_interval" => Some(self.session_expiry_interval.to_string()),
+            _ => None,
+        }
     }
 }

--- a/src/mqtt-broker/src/admin/mod.rs
+++ b/src/mqtt-broker/src/admin/mod.rs
@@ -16,6 +16,7 @@ pub mod acl;
 pub mod client;
 pub mod cluster;
 pub mod connector;
+pub mod query;
 pub mod schema;
 pub mod session;
 pub mod subscribe;

--- a/src/mqtt-broker/src/admin/query.rs
+++ b/src/mqtt-broker/src/admin/query.rs
@@ -41,39 +41,6 @@ pub trait Queryable {
     fn get_field_str(&self, field: &str) -> Option<String>;
 }
 
-impl Queryable for SessionRaw {
-    fn get_field_str(&self, field: &str) -> Option<String> {
-        match field {
-            "client_id" => Some(self.client_id.clone()),
-            "session_expiry" => Some(self.session_expiry.to_string()),
-            "is_contain_last_will" => Some(self.is_contain_last_will.to_string()),
-            "last_will_delay_interval" => self.last_will_delay_interval.map(|v| v.to_string()),
-            "create_time" => Some(self.create_time.to_string()),
-            "connection_id" => self.connection_id.map(|v| v.to_string()),
-            "broker_id" => self.broker_id.map(|v| v.to_string()),
-            "reconnect_time" => self.reconnect_time.map(|v| v.to_string()),
-            "distinct_time" => self.distinct_time.map(|v| v.to_string()),
-            _ => None,
-        }
-    }
-}
-
-impl Queryable for ClientRaw {
-    fn get_field_str(&self, field: &str) -> Option<String> {
-        match field {
-            "client_id" => Some(self.client_id.clone()),
-            "username" => Some(self.username.clone()),
-            "is_online" => Some(self.is_online.to_string()),
-            "source_ip" => Some(self.source_ip.clone()),
-            "connected_at" => Some(self.connected_at.to_string()),
-            "keep_alive" => Some(self.keep_alive.to_string()),
-            "clean_session" => Some(self.clean_session.to_string()),
-            "session_expiry_interval" => Some(self.session_expiry_interval.to_string()),
-            _ => None,
-        }
-    }
-}
-
 struct FilterSpec {
     field: String,
     values: Vec<String>,

--- a/src/mqtt-broker/src/admin/query.rs
+++ b/src/mqtt-broker/src/admin/query.rs
@@ -1,0 +1,188 @@
+// Copyright 2023 RobustMQ Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use protocol::broker_mqtt::broker_mqtt_admin::{
+    ClientRaw, MatchMode, OrderDirection, QueryOptions, SessionRaw,
+};
+
+/// A common interface for resource types to support generic querying logic.
+///
+/// The `Queryable` trait provides a uniform way to retrieve a named field’s
+/// string representation, enabling shared implementations of filtering,
+/// sorting, and pagination across different data types (e.g., `SessionRaw`,
+/// `ClientRaw`, etc.). By mapping field names to `Option<String>`, each
+/// implementer can handle optional fields and custom formatting.
+///
+/// Combined with the `apply_filters`, `apply_sorting`, and `apply_pagination`
+/// functions (driven by protobuf-defined `QueryOptions`, `MatchMode`, and
+/// `OrderDirection`), this design centralizes all query-related code:
+/// - Filtering handles exact and fuzzy matching (with room for future
+///   extensions to support additional matching strategies).
+/// - **Sorting** applies a dynamic `order_by` field and ascending/descending
+///   direction.
+/// - **Pagination** returns a sublist and total count based on `limit` and
+///   `offset`.
+///
+/// This approach greatly reduces duplication in each endpoint handler and
+/// makes it trivial to add new queryable types—simply implement `Queryable`.
+pub trait Queryable {
+    /// given the field name, return the field's string representation or None
+    fn get_field_str(&self, field: &str) -> Option<String>;
+}
+
+impl Queryable for SessionRaw {
+    fn get_field_str(&self, field: &str) -> Option<String> {
+        match field {
+            "client_id" => Some(self.client_id.clone()),
+            "session_expiry" => Some(self.session_expiry.to_string()),
+            "is_contain_last_will" => Some(self.is_contain_last_will.to_string()),
+            "last_will_delay_interval" => self.last_will_delay_interval.map(|v| v.to_string()),
+            "create_time" => Some(self.create_time.to_string()),
+            "connection_id" => self.connection_id.map(|v| v.to_string()),
+            "broker_id" => self.broker_id.map(|v| v.to_string()),
+            "reconnect_time" => self.reconnect_time.map(|v| v.to_string()),
+            "distinct_time" => self.distinct_time.map(|v| v.to_string()),
+            _ => None,
+        }
+    }
+}
+
+impl Queryable for ClientRaw {
+    fn get_field_str(&self, field: &str) -> Option<String> {
+        match field {
+            "client_id" => Some(self.client_id.clone()),
+            "username" => Some(self.username.clone()),
+            "is_online" => Some(self.is_online.to_string()),
+            "source_ip" => Some(self.source_ip.clone()),
+            "connected_at" => Some(self.connected_at.to_string()),
+            "keep_alive" => Some(self.keep_alive.to_string()),
+            "clean_session" => Some(self.clean_session.to_string()),
+            "session_expiry_interval" => Some(self.session_expiry_interval.to_string()),
+            _ => None,
+        }
+    }
+}
+
+struct FilterSpec {
+    field: String,
+    values: Vec<String>,
+    mode: MatchMode,
+}
+
+pub fn apply_filters<T: Queryable>(items: Vec<T>, options: &Option<QueryOptions>) -> Vec<T> {
+    let Some(qo) = options else { return items };
+    if qo.filters.is_empty() {
+        return items;
+    }
+
+    //  turn the filter spec into a vector of FilterSpec
+    let mut specs = Vec::with_capacity(qo.filters.len());
+    for f in &qo.filters {
+        let values = f.values.iter().map(|v| v.to_lowercase()).collect();
+        let mode = if let Some(raw_i) = f.exact_match {
+            MatchMode::try_from(raw_i).unwrap_or_else(|_| MatchMode::Exact)
+        } else {
+            MatchMode::Exact
+        };
+        specs.push(FilterSpec {
+            field: f.field.clone(),
+            values,
+            mode,
+        });
+    }
+
+    items
+        .into_iter()
+        .filter(|item| {
+            // for every item, check all the filter spec
+            for spec in &specs {
+                match item.get_field_str(&spec.field) {
+                    None if spec.values.is_empty() => continue,
+                    None => return false,
+                    Some(raw) => {
+                        let raw = raw.to_lowercase();
+                        // want to match None, but got Some, no match
+                        if spec.values.is_empty() {
+                            return false;
+                        }
+                        let ok = match spec.mode {
+                            MatchMode::Exact => spec.values.iter().any(|v| &raw == v),
+                            MatchMode::Fuzzy => spec.values.iter().any(|v| raw.contains(v)),
+                        };
+                        if !ok {
+                            return false;
+                        }
+                    }
+                }
+            }
+            true
+        })
+        .collect()
+}
+
+pub fn apply_sorting<T: Queryable>(mut items: Vec<T>, options: &Option<QueryOptions>) -> Vec<T> {
+    if let Some(opts) = options {
+        if let Some(sorting) = &opts.sorting {
+            if let Some(order_by) = &sorting.order_by {
+                let direction = if let Some(raw_dir) = sorting.direction {
+                    OrderDirection::try_from(raw_dir).unwrap_or(OrderDirection::Asc)
+                } else {
+                    OrderDirection::Asc
+                };
+
+                items.sort_by(|a, b| {
+                    let oa = a.get_field_str(order_by);
+                    let ob = b.get_field_str(order_by);
+
+                    let ord = oa.cmp(&ob);
+                    if direction == OrderDirection::Desc {
+                        ord.reverse()
+                    } else {
+                        ord
+                    }
+                });
+            }
+        }
+    }
+    items
+}
+
+pub fn apply_pagination<T>(items: Vec<T>, options: &Option<QueryOptions>) -> (Vec<T>, usize) {
+    // default pagination limit: 10
+    let default_limit: u32 = 10;
+    let default_offset: u32 = 0;
+
+    let total_count = items.len();
+
+    let (limit, offset) = if let Some(qo) = options {
+        if let Some(p) = &qo.pagination {
+            (
+                p.limit.unwrap_or(default_limit),
+                p.offset.unwrap_or(default_offset),
+            )
+        } else {
+            (default_limit, default_offset)
+        }
+    } else {
+        (default_limit, default_offset)
+    };
+
+    let paginated = items
+        .into_iter()
+        .skip(offset as usize)
+        .take(limit as usize)
+        .collect::<Vec<T>>();
+
+    (paginated, total_count)
+}

--- a/src/mqtt-broker/src/admin/query.rs
+++ b/src/mqtt-broker/src/admin/query.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use protocol::broker_mqtt::broker_mqtt_admin::{
-    ClientRaw, MatchMode, OrderDirection, QueryOptions, SessionRaw,
-};
+use protocol::broker_mqtt::broker_mqtt_admin::{MatchMode, OrderDirection, QueryOptions};
 
 /// A common interface for resource types to support generic querying logic.
 ///
@@ -58,7 +56,7 @@ pub fn apply_filters<T: Queryable>(items: Vec<T>, options: &Option<QueryOptions>
     for f in &qo.filters {
         let values = f.values.iter().map(|v| v.to_lowercase()).collect();
         let mode = if let Some(raw_i) = f.exact_match {
-            MatchMode::try_from(raw_i).unwrap_or_else(|_| MatchMode::Exact)
+            MatchMode::try_from(raw_i).unwrap_or(MatchMode::Exact)
         } else {
             MatchMode::Exact
         };

--- a/src/mqtt-broker/src/admin/session.rs
+++ b/src/mqtt-broker/src/admin/session.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::admin::query::{apply_filters, apply_pagination, apply_sorting};
+use crate::admin::query::{apply_filters, apply_pagination, apply_sorting, Queryable};
 use crate::handler::cache::CacheManager;
 use protocol::broker_mqtt::broker_mqtt_admin::{ListSessionReply, ListSessionRequest, SessionRaw};
 use std::sync::Arc;
@@ -52,4 +52,21 @@ fn extract_sessions(cache_manager: &Arc<CacheManager>) -> Vec<SessionRaw> {
             }
         })
         .collect()
+}
+
+impl Queryable for SessionRaw {
+    fn get_field_str(&self, field: &str) -> Option<String> {
+        match field {
+            "client_id" => Some(self.client_id.clone()),
+            "session_expiry" => Some(self.session_expiry.to_string()),
+            "is_contain_last_will" => Some(self.is_contain_last_will.to_string()),
+            "last_will_delay_interval" => self.last_will_delay_interval.map(|v| v.to_string()),
+            "create_time" => Some(self.create_time.to_string()),
+            "connection_id" => self.connection_id.map(|v| v.to_string()),
+            "broker_id" => self.broker_id.map(|v| v.to_string()),
+            "reconnect_time" => self.reconnect_time.map(|v| v.to_string()),
+            "distinct_time" => self.distinct_time.map(|v| v.to_string()),
+            _ => None,
+        }
+    }
 }

--- a/src/mqtt-broker/src/admin/user.rs
+++ b/src/mqtt-broker/src/admin/user.rs
@@ -60,6 +60,7 @@ pub async fn list_user_by_req(
     client_pool: &Arc<ClientPool>,
 ) -> Result<Response<ListUserReply>, Status> {
     let mut reply = ListUserReply::default();
+
     let auth_driver = AuthDriver::new(cache_manager.clone(), client_pool.clone());
     match auth_driver.read_all_user().await {
         Ok(data) => {

--- a/src/mqtt-broker/src/server/grpc/admin.rs
+++ b/src/mqtt-broker/src/server/grpc/admin.rs
@@ -16,7 +16,7 @@ use crate::admin::acl::{
     create_acl_by_req, create_blacklist_by_req, delete_acl_by_req, delete_blacklist_by_req,
     list_acl_by_req, list_blacklist_by_req,
 };
-use crate::admin::client::list_client;
+use crate::admin::client::list_client_by_req;
 use crate::admin::cluster::set_cluster_config_by_req;
 use crate::admin::connector::{
     create_connector_by_req, delete_connector_by_req, list_connector_by_req,
@@ -26,7 +26,7 @@ use crate::admin::schema::{
     bind_schema_by_req, create_schema_by_req, delete_schema_by_req, list_bind_schema_by_req,
     list_schema_by_req, unbind_schema_by_req, update_schema_by_req,
 };
-use crate::admin::session::list_session;
+use crate::admin::session::list_session_by_req;
 use crate::admin::subscribe::{
     delete_auto_subscribe_rule, list_auto_subscribe_rule_by_req, set_auto_subscribe_rule,
 };
@@ -153,16 +153,16 @@ impl MqttBrokerAdminService for GrpcAdminServices {
 
     async fn mqtt_broker_list_client(
         &self,
-        _: Request<ListClientRequest>,
+        request: Request<ListClientRequest>,
     ) -> Result<Response<ListClientReply>, Status> {
-        list_client(&self.cache_manager).await
+        list_client_by_req(&self.cache_manager, request).await
     }
 
     async fn mqtt_broker_list_session(
         &self,
-        _: Request<ListSessionRequest>,
+        request: Request<ListSessionRequest>,
     ) -> Result<Response<ListSessionReply>, Status> {
-        list_session(&self.cache_manager).await
+        list_session_by_req(&self.cache_manager, request).await
     }
 
     async fn mqtt_broker_list_acl(


### PR DESCRIPTION
## What's changed and what's your intention?

-  Add unified query trait for pagination, sort, filter support for session and client list.
- The `Queryable` trait provides a uniform way to retrieve a named field’s string representation, enabling shared implementations of filtering, sorting, and pagination across different data types (e.g., `SessionRaw`,  `ClientRaw`, etc.). By mapping field names to `Option<String>`, each implementer can handle optional fields and custom formatting. This trait can be implement for all the fields used in the dashboard.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link
close #1079 
