### PR TITLE
docs: add initial troubleshooting with tokio-console docs

### DIFF
--- a/docs/en/ContributionGuide/ContributingCode/Troubleshooting.md
+++ b/docs/en/ContributionGuide/ContributingCode/Troubleshooting.md
@@ -1,0 +1,27 @@
+# Troubleshooting
+
+## `tokio-console` support and configuration
+
+`tokio-console` is a tool that is commonly used to monitor and debug async rust applications built with the tokio runtime. Support for `tokio-console` can be enabled by configuring the `tokio_console` config in the `RUSTFLAGS` environment variable. For example, the following command will launch the placement center with `tokio-console` support:
+
+```bash
+RUSTFLAGS="--cfg tokio_unstable --cfg tokio_console"  cargo run --package cmd --bin placement-center
+```
+
+### Configuring the socket address with environment variables
+
+`tokio-console` will use the [default IP](https://docs.rs/console-subscriber/latest/console_subscriber/struct.Server.html#associatedconstant.DEFAULT_IP) and [default port](https://docs.rs/console-subscriber/latest/console_subscriber/struct.Server.html#associatedconstant.DEFAULT_PORT) to listen for RPC connections. If you want to configure the socket address, you can use the the environment variable `TOKIO_CONSOLE_BIND` to specify the address. For example, the following command will launch the placement center with `tokio-console` support and bind to `127.0.0.1:5674`:
+
+```bash
+export TOKIO_CONSOLE_BIND=127.0.0.1:5674 && RUSTFLAGS="--cfg tokio_unstable --cfg tokio_console"  cargo run --package cmd --bin placement-center
+```
+
+You can then use the following command to launch the `tokio-console` client to connect to the server listening on the custom address:
+
+```bash
+tokio-console http://127.0.0.1:5674
+```
+
+### Configuring `tokio-console` with config files
+
+Support for configuring `tokio-console` with a config file is still under development. This section will be updated once the feature is implemented.

--- a/docs/zh/ContributionGuide/ContributingCode/Troubleshooting.md
+++ b/docs/zh/ContributionGuide/ContributingCode/Troubleshooting.md
@@ -1,0 +1,27 @@
+# 故障排查
+
+## `tokio-console` 的支持和配置
+
+`tokio-console` 常被用来调试使用`tokio`运行时构建的异步 Rust 应用程序。可以通过在 `RUSTFLAGS` 环境变量中配置 `tokio_console` 来启用对 `tokio-console` 的支持。例如，以下命令将启动带有 `tokio-console` 支持的 placement center：
+
+```bash
+RUSTFLAGS="--cfg tokio_unstable --cfg tokio_console"  cargo run --package cmd --bin placement-center
+```
+
+### 使用环境变量配置socket地址
+
+`tokio-console`默认使用[默认IP](https://docs.rs/console-subscriber/latest/console_subscriber/struct.Server.html#associatedconstant.DEFAULT_IP)和[默认端口](https://docs.rs/console-subscriber/latest/console_subscriber/struct.Server.html#associatedconstant.DEFAULT_PORT)来监听RPC连接。如果你想配置socket地址，可以使用环境变量`TOKIO_CONSOLE_BIND`来指定地址。例如，以下命令将启动带有 `tokio-console` 支持的 placement center，并绑定到地址 `127.0.0.1:5674`：
+
+```bash
+export TOKIO_CONSOLE_BIND=127.0.0.1:5674 && RUSTFLAGS="--cfg tokio_unstable --cfg tokio_console"  cargo run --package cmd --bin placement-center
+```
+
+以下命令将启动 `tokio-console` 客户端以连接到监听在自定义地址上的服务器：
+
+```bash
+tokio-console http://127.0.0.1:5674
+```
+
+### 通过配置文件配置 `tokio-console`
+
+对通过配置文件配置 `tokio-console` 的支持仍在开发中。此部分内容将于功能实现后更新。


### PR DESCRIPTION
## What's changed and what's your intention?

Add initial documentation explaining how to enable `tokio-console` support for troubleshooting.

Please explain IN DETAIL what the changes are in this PR and why they are needed:

n/a

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link

Closes #1129 
