### PR TITLE
fix: Fix typos errors in pre-commit and _typos.toml - close #1053

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -20,12 +20,6 @@
 # we need to ignore it.
 Identifer = "Identifer"
 
-# Ignore the unsubscribe term as it's used in the MQTT context.
-# todo fix spelling error
-UNSUBSCRIBE = "UNSUBSCRIBE"
-unsubscrible = "unsubscrible"
-SUBSCRIBLE = "SUBSCRIBLE"
-
 
 [files]
 extend-exclude = []

--- a/src/mqtt-broker/src/observability/metrics/packets.rs
+++ b/src/mqtt-broker/src/observability/metrics/packets.rs
@@ -84,15 +84,15 @@ common_base::register_gauge_metric!(
     NetworkLabel
 );
 common_base::register_gauge_metric!(
-    PACKETS_SUBSCRIBLE_RECEIVED,
-    "packets_subscrible_received",
-    "Number of packets subscrible received",
+    PACKETS_SUBSCRIBE_RECEIVED,
+    "packets_subscribe_received",
+    "Number of packets subscribe received",
     NetworkLabel
 );
 common_base::register_gauge_metric!(
-    PACKETS_UNSUBSCRIBLE_RECEIVED,
-    "packets_unsubscrible_received",
-    "Number of packets unsubscrible received",
+    PACKETS_UNSUBSCRIBE_RECEIVED,
+    "packets_unsubscribe_received",
+    "Number of packets unsubscribe received",
     NetworkLabel
 );
 common_base::register_gauge_metric!(
@@ -308,10 +308,10 @@ pub fn record_received_metrics(
         }
         MqttPacket::Auth(_, _) => common_base::gauge_metric_inc!(PACKETS_AUTH_RECEIVED, label),
         MqttPacket::Subscribe(_, _) => {
-            common_base::gauge_metric_inc!(PACKETS_SUBSCRIBLE_RECEIVED, label)
+            common_base::gauge_metric_inc!(PACKETS_SUBSCRIBE_RECEIVED, label)
         }
         MqttPacket::Unsubscribe(_, _) => {
-            common_base::gauge_metric_inc!(PACKETS_UNSUBSCRIBLE_RECEIVED, label)
+            common_base::gauge_metric_inc!(PACKETS_UNSUBSCRIBE_RECEIVED, label)
         }
         _ => unreachable!("This branch only matches for packets could not be received"),
     }

--- a/src/placement-center/src/raft/raft_node.rs
+++ b/src/placement-center/src/raft/raft_node.rs
@@ -45,7 +45,7 @@ impl Display for Node {
     }
 }
 
-pub mod typ {
+pub mod types {
     use crate::raft::typeconfig::TypeConfig;
     pub type Entry = openraft::Entry<TypeConfig>;
 }

--- a/src/placement-center/src/raft/store/state_machine_store.rs
+++ b/src/placement-center/src/raft/store/state_machine_store.rs
@@ -30,7 +30,7 @@ use crate::core::metrics::{
     metrics_raft_storage_total_ms, metrics_rocksdb_storage_err_inc,
     metrics_rocksdb_storage_total_inc, metrics_rocksdb_stroge_total_ms, RocksDBLabels,
 };
-use crate::raft::raft_node::typ;
+use crate::raft::raft_node::types;
 use crate::raft::route::AppResponseData;
 use crate::raft::typeconfig::{SnapshotData, TypeConfig};
 use crate::route::DataRoute;
@@ -205,7 +205,7 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
         entries: I,
     ) -> Result<Vec<AppResponseData>, StorageError<TypeConfig>>
     where
-        I: IntoIterator<Item = typ::Entry> + OptionalSend,
+        I: IntoIterator<Item = types::Entry> + OptionalSend,
         I::IntoIter: OptionalSend,
     {
         let entries = entries.into_iter();

--- a/src/protocol/src/mqtt/mqttv5/connect.rs
+++ b/src/protocol/src/mqtt/mqttv5/connect.rs
@@ -398,8 +398,8 @@ mod willproperties {
             len += 1 + 4;
         }
 
-        if let Some(typ) = &properties.content_type {
-            len += 1 + 2 + typ.len()
+        if let Some(content_type_value) = &properties.content_type {
+            len += 1 + 2 + content_type_value.len()
         }
 
         if let Some(topic) = &properties.response_topic {
@@ -452,9 +452,9 @@ mod willproperties {
                     cursor += 4;
                 }
                 PropertyType::ContentType => {
-                    let typ = read_mqtt_string(bytes)?;
-                    cursor += 2 + typ.len();
-                    content_type = Some(typ);
+                    let content_type_value = read_mqtt_string(bytes)?;
+                    cursor += 2 + content_type_value.len();
+                    content_type = Some(content_type_value);
                 }
                 PropertyType::ResponseTopic => {
                     let topic = read_mqtt_string(bytes)?;
@@ -506,9 +506,9 @@ mod willproperties {
             buffer.put_u32(message_expiry_interval);
         }
 
-        if let Some(typ) = &properties.content_type {
+        if let Some(content_type_value) = &properties.content_type {
             buffer.put_u8(PropertyType::ContentType as u8);
-            write_mqtt_string(buffer, typ);
+            write_mqtt_string(buffer, content_type_value);
         }
 
         if let Some(topic) = &properties.response_topic {

--- a/src/protocol/src/mqtt/mqttv5/publish.rs
+++ b/src/protocol/src/mqtt/mqttv5/publish.rs
@@ -258,9 +258,9 @@ mod properties {
                 }
 
                 PropertyType::ContentType => {
-                    let typ = read_mqtt_string(bytes)?;
-                    cursor += 2 + typ.len();
-                    content_type = Some(typ);
+                    let content_type_value = read_mqtt_string(bytes)?;
+                    cursor += 2 + content_type_value.len();
+                    content_type = Some(content_type_value);
                 }
                 _ => return Err(Error::InvalidPropertyType(prop)),
             }


### PR DESCRIPTION
## What's changed and what's your intention?

**MQTT Packet Metric Constant Typos**: 
- `PACKETS_SUBSCRIBLE_RECEIVED` → `PACKETS_SUBSCRIBE_RECEIVED` 
- `PACKETS_UNSUBSCRIBLE_RECEIVED` → `PACKETS_UNSUBSCRIBE_RECEIVED` 
**Variable/Module Naming Improvements**: 
- In MQTT v5 protocol: `typ` → `content_type_value`
- In Raft module: `mod typ` → `mod types`
**Configuration Cleanup**: 
- Updated `_typos.toml` to remove ignore rules for already-fixed typos 
## Checklist

- [x] I have written the necessary rustdoc comments. 
- [x] I have added the necessary unit tests and integration tests. 
- [x] This PR does not require documentation updates. 

## Refer to a related PR or issue link

close #1053