### PR TITLE
fix: Disable TokioConsole entry in logging config by default

### DIFF
--- a/config/log-config/mqtt-tracing.toml
+++ b/config/log-config/mqtt-tracing.toml
@@ -34,6 +34,7 @@ prefix = "mqtt-slow_sub-"
 suffix = "log"
 max_log_files = 10
 
-[tokio_console]
-kind = "TokioConsole"
-bind = "127.0.0.1:5675"
+## Uncomment the section below to enable troubleshooting with `tokio-console`.
+# [tokio_console]
+# kind = "TokioConsole"
+# bind = "127.0.0.1:5675"

--- a/config/log-config/place-tracing.toml
+++ b/config/log-config/place-tracing.toml
@@ -25,6 +25,7 @@ prefix = "place-server-"
 suffix = "log"
 max_log_files = 10
 
-[tokio_console]
-kind = "TokioConsole"
-bind = "127.0.0.1:5674"
+## Uncomment the section below to enable troubleshooting with `tokio-console`.
+# [tokio_console]
+# kind = "TokioConsole"
+# bind = "127.0.0.1:5674"


### PR DESCRIPTION
## What's changed and what's your intention?

This PR fixes a mistake introduced in the prior PR #1137 where the `TokioConsole` appender entry is enabled in the default logging config files for placement center and mqtt broker. This is a problem because this appender would panic if `tokio_unstable` cfg is not enabled, and this is not the most common use case.

Please explain IN DETAIL what the changes are in this PR and why they are needed:

Comment out the `TokioConsole` entries in the two logging config files

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link

n/a
