### PR TITLE
feat: add impl expand validate stmt for validate_req

### DIFF
--- a/src/robustmq-macro/src/lib.rs
+++ b/src/robustmq-macro/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod parse;
+mod tools;
 mod validate_req;
 
 use crate::parse::ParseItem;
@@ -57,81 +58,4 @@ pub(crate) fn origin_compile_err(mut origin: TokenStream, err: syn::Error) -> To
     let compile_error = compile_err(err);
     origin.extend(compile_error);
     origin
-}
-
-/// Injects a statement at the beginning of an `async` block inside `Box::pin(async move { ... })`.
-///
-/// This is typically used to insert statements into async code blocks expanded by [`async_trait`] macros.
-///
-/// # Arguments
-/// * `block` - The code block containing the `Box::pin(async move { ... })` expression
-/// * `inject_stmt` - The statement to be inserted
-///
-/// # Returns
-/// * `Ok(())` if injection succeeded
-/// * `Err(syn::Error)` with detailed error message if the structure doesn't match expectations
-///
-/// [`async_trait`]: https://docs.rs/async-trait
-pub(crate) fn inject_into_async_block(
-    block: &mut Box<syn::Block>,
-    inject_stmt: syn::Stmt,
-) -> syn::Result<()> {
-    // Because `#[async_trait]` will only perform ast parsing during the compilation phase.
-    // During the coding phase, the IDE is too smart and will expand our macros in advance,
-    // resulting in false positives, so here we just return Ok().
-    // Don't worry, it will be judged again when the insertion is actually executed.
-    let async_stmt = if let Some(async_stmt) = block.stmts.first_mut() {
-        async_stmt
-    } else {
-        return Ok(());
-    };
-    let pin_call = match async_stmt {
-        syn::Stmt::Expr(syn::Expr::Call(call), _) => call,
-        _ => {
-            return Ok(());
-        }
-    };
-
-    let async_expr = {
-        let pin_call_token = pin_call.clone();
-        pin_call.args.first_mut().ok_or_else(|| {
-            syn::Error::new_spanned(
-                pin_call_token,
-                r#""Box::pin()" requires at least one argument"#,
-            )
-        })?
-    };
-
-    if is_box_pin_call(&pin_call.func) {
-        if let syn::Expr::Async(syn::ExprAsync {
-            block: async_block, ..
-        }) = async_expr
-        {
-            async_block.stmts.insert(0, inject_stmt);
-            Ok(())
-        } else {
-            Err(syn::Error::new_spanned(
-                async_expr,
-                r#"expected async block inside "Box::pin()""#,
-            ))
-        }
-    } else {
-        Ok(())
-    }
-}
-
-fn is_box_pin_call(expr: &syn::Expr) -> bool {
-    if let syn::Expr::Path(syn::ExprPath { path, .. }) = expr {
-        path.segments
-            .first()
-            .map(|seg| seg.ident.eq("Box"))
-            .unwrap_or(false)
-            && path
-                .segments
-                .last()
-                .map(|seg| seg.ident.eq("pin"))
-                .unwrap_or(false)
-    } else {
-        false
-    }
 }

--- a/src/robustmq-macro/src/parse.rs
+++ b/src/robustmq-macro/src/parse.rs
@@ -36,6 +36,11 @@ impl syn::parse::Parse for ParseItem {
             input.parse::<Token![unsafe]>()?;
             lookahead = input.lookahead1();
         }
+        if lookahead.peek(Token![async]) {
+            // usually happens with asynchronous functions
+            input.parse::<Token![async]>()?;
+            lookahead = input.lookahead1();
+        }
 
         if lookahead.peek(Token![impl]) {
             let mut item_impl = input.parse::<syn::ItemImpl>()?;

--- a/src/robustmq-macro/src/tools.rs
+++ b/src/robustmq-macro/src/tools.rs
@@ -1,0 +1,165 @@
+// Copyright 2023 RobustMQ Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use syn::spanned::Spanned;
+
+/// Extracts the first non-receiver argument from a function signature.
+///
+/// This function scans the function's signature and returns the identifier and type
+/// of the first argument that is not `self`. It only supports simple identifier patterns
+/// like `arg: Type`.
+///
+/// # Errors
+///
+/// Returns a `syn::Error` if:
+/// - There are no arguments other than `self`.
+/// - The first non-`self` argument is not a simple identifier pattern.
+///
+/// # Example
+///
+/// ```rust
+/// // For a function signature like:
+/// struct Foo;
+///
+/// impl Foo{
+///     // This function will return ("value", i32)
+///     fn do_something(&self, value: i32){}
+/// }
+/// ```
+pub(crate) fn extract_first_non_self_arg(
+    sig: &syn::Signature,
+) -> syn::Result<(syn::Ident, &syn::Type)> {
+    for input in &sig.inputs {
+        match input {
+            syn::FnArg::Receiver(_) => continue,
+            syn::FnArg::Typed(pat_ty) => {
+                return if let syn::Pat::Ident(syn::PatIdent { ident, .. }) = &*pat_ty.pat {
+                    Ok((ident.clone(), &pat_ty.ty))
+                } else {
+                    Err(syn::Error::new(
+                        pat_ty.pat.span(),
+                        "expected the argument to be an identifier (e.g. `arg: Type`)",
+                    ))
+                }
+            }
+        }
+    }
+
+    Err(syn::Error::new(
+        sig.span(),
+        "expected at least one argument after `self`",
+    ))
+}
+
+/// Injects a statement at the beginning of an `async` block inside `Box::pin(async move { ... })`.
+///
+/// This is typically used to insert statements into async code blocks expanded by [`async_trait`] macros.
+///
+/// # Arguments
+/// * `block` - The code block containing the `Box::pin(async move { ... })` expression
+/// * `inject_stmt` - The statement to be inserted
+///
+/// # Returns
+/// * `Ok(())` if injection succeeded
+/// * `Err(syn::Error)` with detailed error message if the structure doesn't match expectations
+///
+/// [`async_trait`]: https://docs.rs/async-trait
+pub(crate) fn inject_into_async_block(
+    block: &mut syn::Block,
+    inject_stmt: syn::Stmt,
+) -> syn::Result<()> {
+    // Because `#[async_trait]` will only perform ast parsing during the compilation phase.
+    // During the coding phase, the IDE is too smart and will expand our macros in advance,
+    // resulting in false positives, so here we just return Ok().
+    // Don't worry, it will be judged again when the insertion is actually executed.
+    let async_stmt = if let Some(async_stmt) = block.stmts.first_mut() {
+        async_stmt
+    } else {
+        return Ok(());
+    };
+    let pin_call = match async_stmt {
+        syn::Stmt::Expr(syn::Expr::Call(call), _) => call,
+        _ => {
+            return Ok(());
+        }
+    };
+
+    let async_expr = {
+        let pin_call_token = pin_call.clone();
+        pin_call.args.first_mut().ok_or_else(|| {
+            syn::Error::new_spanned(
+                pin_call_token,
+                r#""Box::pin()" requires at least one argument"#,
+            )
+        })?
+    };
+
+    if is_box_pin_call(&pin_call.func) {
+        if let syn::Expr::Async(syn::ExprAsync {
+            block: async_block, ..
+        }) = async_expr
+        {
+            async_block.stmts.insert(0, inject_stmt);
+            Ok(())
+        } else {
+            Err(syn::Error::new_spanned(
+                async_expr,
+                r#"expected async block inside "Box::pin()""#,
+            ))
+        }
+    } else {
+        Ok(())
+    }
+}
+
+/// Checks whether the given expression is a path call to `Box::pin`.
+///
+/// This function inspects the provided `syn::Expr` to determine if it represents
+/// a path expression equivalent to `Box::pin`, such as:
+///
+/// ```rust
+/// Box::pin(async {  });
+/// ```
+///
+/// It does so by verifying that:
+/// - The expression is a `syn::Expr::Path`
+/// - The first path segment is `Box`
+/// - The last path segment is `pin`
+///
+/// This check does **not** verify the full path structure in between segments,
+/// so it may return true for paths like `my::Box::pin`.
+///
+/// # Arguments
+///
+/// * `expr` - A reference to a `syn::Expr` to analyze.
+///
+/// # Returns
+///
+/// * `true` if the expression is syntactically similar to `Box::pin(...)`
+/// * `false` otherwise
+pub(crate) fn is_box_pin_call(expr: &syn::Expr) -> bool {
+    if let syn::Expr::Path(syn::ExprPath { path, .. }) = expr {
+        path.segments
+            .first()
+            .map(|seg| seg.ident.eq("Box"))
+            .unwrap_or(false)
+            && path
+                .segments
+                .last()
+                .map(|seg| seg.ident.eq("pin"))
+                .unwrap_or(false)
+    } else {
+        false
+    }
+}

--- a/src/robustmq-macro/tests/expand.rs
+++ b/src/robustmq-macro/tests/expand.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #[test]
-#[ignore = "reason"]
 fn test_validate_req_expand() {
     macrotest::expand_args(
         "tests/validate_req/expand/*.rs",

--- a/src/robustmq-macro/tests/validate_req/expand/fn_success.expanded.rs
+++ b/src/robustmq-macro/tests/validate_req/expand/fn_success.expanded.rs
@@ -86,7 +86,6 @@ impl HeyGRPC for FooService {
             let __self = self;
             let _request = _request;
             let __ret: Result<tonic::Response<Response>, tonic::Status> = {
-                _request.get_ref().validate().unwrap();
                 Ok(tonic::Response::new(Response {}))
             };
             #[allow(unreachable_code)] __ret

--- a/src/robustmq-macro/tests/validate_req/expand/fn_success.expanded.rs
+++ b/src/robustmq-macro/tests/validate_req/expand/fn_success.expanded.rs
@@ -1,0 +1,96 @@
+use prost_validate::Validator;
+pub struct FooService;
+pub struct Request {
+    #[validate(r#type(string(r#const = "foo")))]
+    name: String,
+}
+impl ::prost_validate::Validator for Request {
+    #[allow(irrefutable_let_patterns)]
+    #[allow(unused_variables)]
+    fn validate(&self) -> prost_validate::Result<()> {
+        let name = &self.name;
+        if name != "foo" {
+            return Err(
+                ::prost_validate::Error::new(
+                    "",
+                    ::prost_validate::errors::string::Error::Const("foo".to_string()),
+                ),
+            );
+        }
+        Ok(())
+    }
+}
+pub struct Response;
+pub trait HeyGRPC {
+    #[must_use]
+    #[allow(
+        elided_named_lifetimes,
+        clippy::type_complexity,
+        clippy::type_repetition_in_bounds
+    )]
+    fn hey<'life0, 'async_trait>(
+        &'life0 self,
+        _request: tonic::Request<Request>,
+    ) -> ::core::pin::Pin<
+        Box<
+            dyn ::core::future::Future<
+                Output = Result<tonic::Response<Response>, tonic::Status>,
+            > + ::core::marker::Send + 'async_trait,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait;
+}
+impl HeyGRPC for FooService {
+    #[allow(
+        elided_named_lifetimes,
+        clippy::async_yields_async,
+        clippy::diverging_sub_expression,
+        clippy::let_unit_value,
+        clippy::needless_arbitrary_self_type,
+        clippy::no_effect_underscore_binding,
+        clippy::shadow_same,
+        clippy::type_complexity,
+        clippy::type_repetition_in_bounds,
+        clippy::used_underscore_binding
+    )]
+    fn hey<'life0, 'async_trait>(
+        &'life0 self,
+        _request: tonic::Request<Request>,
+    ) -> ::core::pin::Pin<
+        Box<
+            dyn ::core::future::Future<
+                Output = Result<tonic::Response<Response>, tonic::Status>,
+            > + ::core::marker::Send + 'async_trait,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move {
+            {
+                {
+                    let ___request__validate_ref = _request.get_ref();
+                    if let Err(e) = ___request__validate_ref.validate() {
+                        return Err(tonic::Status::invalid_argument(e.to_string()));
+                    }
+                }
+            }
+            if let ::core::option::Option::Some(__ret) = ::core::option::Option::None::<
+                Result<tonic::Response<Response>, tonic::Status>,
+            > {
+                #[allow(unreachable_code)] return __ret;
+            }
+            let __self = self;
+            let _request = _request;
+            let __ret: Result<tonic::Response<Response>, tonic::Status> = {
+                _request.get_ref().validate().unwrap();
+                Ok(tonic::Response::new(Response {}))
+            };
+            #[allow(unreachable_code)] __ret
+        })
+    }
+}
+fn main() {}

--- a/src/robustmq-macro/tests/validate_req/expand/fn_success.rs
+++ b/src/robustmq-macro/tests/validate_req/expand/fn_success.rs
@@ -39,7 +39,6 @@ impl HeyGRPC for FooService {
         &self,
         _request: tonic::Request<Request>,
     ) -> Result<tonic::Response<Response>, tonic::Status> {
-        _request.get_ref().validate().unwrap();
         Ok(tonic::Response::new(Response {}))
     }
 }

--- a/src/robustmq-macro/tests/validate_req/expand/fn_success.rs
+++ b/src/robustmq-macro/tests/validate_req/expand/fn_success.rs
@@ -25,7 +25,7 @@ pub struct Request {
 pub struct Response;
 
 #[async_trait::async_trait]
-pub trait Hey {
+pub trait HeyGRPC {
     async fn hey(
         &self,
         _request: tonic::Request<Request>,
@@ -33,7 +33,7 @@ pub trait Hey {
 }
 
 #[async_trait::async_trait]
-impl Hey for FooService {
+impl HeyGRPC for FooService {
     #[robustmq_macro::validate_req(validator = prost_validate::Validator)]
     async fn hey(
         &self,

--- a/src/robustmq-macro/tests/validate_req/expand/impl_success.expanded.rs
+++ b/src/robustmq-macro/tests/validate_req/expand/impl_success.expanded.rs
@@ -21,7 +21,7 @@ impl ::prost_validate::Validator for Request {
     }
 }
 pub struct Response;
-pub trait Hey {
+pub trait HeyGRPC {
     #[must_use]
     #[allow(
         elided_named_lifetimes,
@@ -41,8 +41,27 @@ pub trait Hey {
     where
         'life0: 'async_trait,
         Self: 'async_trait;
+    #[must_use]
+    #[allow(
+        elided_named_lifetimes,
+        clippy::type_complexity,
+        clippy::type_repetition_in_bounds
+    )]
+    fn hi<'life0, 'async_trait>(
+        &'life0 self,
+        _request: tonic::Request<Request>,
+    ) -> ::core::pin::Pin<
+        Box<
+            dyn ::core::future::Future<
+                Output = Result<tonic::Response<Response>, tonic::Status>,
+            > + ::core::marker::Send + 'async_trait,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait;
 }
-impl Hey for FooService {
+impl HeyGRPC for FooService {
     #[allow(
         elided_named_lifetimes,
         clippy::async_yields_async,
@@ -87,6 +106,54 @@ impl Hey for FooService {
             let _request = _request;
             let __ret: Result<tonic::Response<Response>, tonic::Status> = {
                 _request.get_ref().validate().unwrap();
+                Ok(tonic::Response::new(Response {}))
+            };
+            #[allow(unreachable_code)] __ret
+        })
+    }
+    #[allow(
+        elided_named_lifetimes,
+        clippy::async_yields_async,
+        clippy::diverging_sub_expression,
+        clippy::let_unit_value,
+        clippy::needless_arbitrary_self_type,
+        clippy::no_effect_underscore_binding,
+        clippy::shadow_same,
+        clippy::type_complexity,
+        clippy::type_repetition_in_bounds,
+        clippy::used_underscore_binding
+    )]
+    fn hi<'life0, 'async_trait>(
+        &'life0 self,
+        _request: tonic::Request<Request>,
+    ) -> ::core::pin::Pin<
+        Box<
+            dyn ::core::future::Future<
+                Output = Result<tonic::Response<Response>, tonic::Status>,
+            > + ::core::marker::Send + 'async_trait,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move {
+            {
+                {
+                    let ___request__validate_ref = _request.get_ref();
+                    if let Err(e) = ___request__validate_ref.validate() {
+                        return Err(tonic::Status::invalid_argument(e.to_string()));
+                    }
+                }
+            }
+            if let ::core::option::Option::Some(__ret) = ::core::option::Option::None::<
+                Result<tonic::Response<Response>, tonic::Status>,
+            > {
+                #[allow(unreachable_code)] return __ret;
+            }
+            let __self = self;
+            let _request = _request;
+            let __ret: Result<tonic::Response<Response>, tonic::Status> = {
                 Ok(tonic::Response::new(Response {}))
             };
             #[allow(unreachable_code)] __ret

--- a/src/robustmq-macro/tests/validate_req/expand/impl_success.expanded.rs
+++ b/src/robustmq-macro/tests/validate_req/expand/impl_success.expanded.rs
@@ -105,7 +105,6 @@ impl HeyGRPC for FooService {
             let __self = self;
             let _request = _request;
             let __ret: Result<tonic::Response<Response>, tonic::Status> = {
-                _request.get_ref().validate().unwrap();
                 Ok(tonic::Response::new(Response {}))
             };
             #[allow(unreachable_code)] __ret

--- a/src/robustmq-macro/tests/validate_req/expand/impl_success.rs
+++ b/src/robustmq-macro/tests/validate_req/expand/impl_success.rs
@@ -1,0 +1,59 @@
+// Copyright 2023 RobustMQ Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use prost_validate::Validator;
+
+pub struct FooService;
+
+#[derive(prost_validate::Validator)]
+pub struct Request {
+    #[validate(r#type(string(r#const = "foo")))]
+    name: String,
+}
+
+pub struct Response;
+
+#[async_trait::async_trait]
+pub trait HeyGRPC {
+    async fn hey(
+        &self,
+        _request: tonic::Request<Request>,
+    ) -> Result<tonic::Response<Response>, tonic::Status>;
+
+    async fn hi(
+        &self,
+        _request: tonic::Request<Request>,
+    ) -> Result<tonic::Response<Response>, tonic::Status>;
+}
+
+#[async_trait::async_trait]
+#[robustmq_macro::validate_req(validator = prost_validate::Validator)]
+impl HeyGRPC for FooService {
+    async fn hey(
+        &self,
+        _request: tonic::Request<Request>,
+    ) -> Result<tonic::Response<Response>, tonic::Status> {
+        _request.get_ref().validate().unwrap();
+        Ok(tonic::Response::new(Response {}))
+    }
+
+    async fn hi(
+        &self,
+        _request: tonic::Request<Request>,
+    ) -> Result<tonic::Response<Response>, tonic::Status> {
+        Ok(tonic::Response::new(Response {}))
+    }
+}
+
+fn main() {}

--- a/src/robustmq-macro/tests/validate_req/expand/impl_success.rs
+++ b/src/robustmq-macro/tests/validate_req/expand/impl_success.rs
@@ -44,7 +44,6 @@ impl HeyGRPC for FooService {
         &self,
         _request: tonic::Request<Request>,
     ) -> Result<tonic::Response<Response>, tonic::Status> {
-        _request.get_ref().validate().unwrap();
         Ok(tonic::Response::new(Response {}))
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

add impl expand validate stmt for validate_req

example:
```rust
#[async_trait::async_trait]
pub trait HeyGRPC {
    async fn hey(
        &self,
        _request: tonic::Request<Request>,
    ) -> Result<tonic::Response<Response>, tonic::Status>;

    async fn hi(
        &self,
        _request: tonic::Request<Request>,
    ) -> Result<tonic::Response<Response>, tonic::Status>;
}

#[async_trait::async_trait]
#[robustmq_macro::validate_req(validator = prost_validate::Validator)]
impl HeyGRPC for FooService {
    async fn hey(
        &self,
        _request: tonic::Request<Request>,
    ) -> Result<tonic::Response<Response>, tonic::Status> {
        Ok(tonic::Response::new(Response {}))
    }

    async fn hi(
        &self,
        _request: tonic::Request<Request>,
    ) -> Result<tonic::Response<Response>, tonic::Status> {
        Ok(tonic::Response::new(Response {}))
    }
}

// "robustmq_macro::validate_req" expand:
impl HeyGRPC for FooService {
    fn hey<'life0, 'async_trait>(
        &'life0 self,
        _request: tonic::Request<Request>,
    ) -> ::core::pin::Pin<
        Box<
            dyn ::core::future::Future<
                Output = Result<tonic::Response<Response>, tonic::Status>,
            > + ::core::marker::Send + 'async_trait,
        >,
    >
    where
        'life0: 'async_trait,
        Self: 'async_trait,
    {
        Box::pin(async move {
            {
                {
                    let ___request__validate_ref = _request.get_ref();
                    if let Err(e) = ___request__validate_ref.validate() {
                        return Err(tonic::Status::invalid_argument(e.to_string()));
                    }
                }
            }
            ......
        })
    }

    fn hi<'life0, 'async_trait>(
        &'life0 self,
        _request: tonic::Request<Request>,
    ) -> ::core::pin::Pin<
        Box<
            dyn ::core::future::Future<
                Output = Result<tonic::Response<Response>, tonic::Status>,
            > + ::core::marker::Send + 'async_trait,
        >,
    >
    where
        'life0: 'async_trait,
        Self: 'async_trait,
    {
        Box::pin(async move {
            {
                {
                    let ___request__validate_ref = _request.get_ref();
                    if let Err(e) = ___request__validate_ref.validate() {
                        return Err(tonic::Status::invalid_argument(e.to_string()));
                    }
                }
            }
            ......
        })
    }
}
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [X]  This PR does not require documentation updates.

## Refer to a related PR or issue link
Please associate a related Issue, which can help reviewers better understand your intent.
You can refer to the [GitHub Contribution Guide](https://robustmq.com/ContributionGuide/GitHub-Contribution-Guide.html)
to submit the corresponding Issue.It also has an [PR Example](https://robustmq.com/ContributionGuide/Pull-Request-Example.html) to
help you submit PR.
