### PR TITLE
docs: add sign off doc to contributor guide(en)

### DIFF
--- a/docs/en/ContributionGuide/GitHub-Contribution-Guide.md
+++ b/docs/en/ContributionGuide/GitHub-Contribution-Guide.md
@@ -73,7 +73,34 @@ ISSUE:
 
 For more details, you can refer to the [PR submission example](./Pull-Request-Example.md).
 
-## 3. Reasons for PR Submission Failure
+## 3. Sign off
+
+A signature is a simple line of text at the end of the code description that proves that you wrote the code or that you have the rights to release it as open source.
+
+You just add one line to each git commit message:
+
+```text
+Signed-off-by: your_name <your_email>
+```
+
+You can add a signature when you create a git commit with `git commit -s`.
+
+If you want to do this automatically, you can set up some aliases:
+
+```bash
+# will automatically add the signature when committing using the alias
+git config --add alias.c "commit -s"
+```
+
+Example commit message:
+
+```text
+feat: a good start!
+
+Signed-off-by: robustmq <robustmq@outlook.com>
+```
+
+## 4. Reasons for PR Submission Failure
 
 #### License Error
 
@@ -111,3 +138,21 @@ build: Changes to the build system or external dependencies
 ci: Changes to continuous integration configuration, including modifications to configuration files and scripts.
 revert: Revert
 ```
+
+### Fix DCO check failure error
+
+If your PR fails the DCO check, you need to fix the entire commit history in the PR.
+
+We recommend that you compress the commits in the PR into a single one, attach a signature according to the signing process, and then force a commit.
+
+For example, there are 3 commits in your PR:
+
+```bash
+git rebase -i HEAD^3
+(interactive squash + sign off append)
+git push origin -f
+```
+
+Note that this approach will cause multiple commit records to be compressed into one, which makes review difficult and is only used to fix DCO checks.
+
+Best practice is to include a signature in every commit.

--- a/docs/zh/ContributionGuide/GitHub-Contribution-Guide.md
+++ b/docs/zh/ContributionGuide/GitHub-Contribution-Guide.md
@@ -176,7 +176,8 @@ Signed-off-by: robustmq <robustmq@outlook.com>
 
 我们建议你可以将 PR 中的 commit 压缩为单个，并按照 [签名](#签名) 流程附带签名，然后进行强制提交。
 
-例如，您的 PR 中存在 2 个 commit:
+例如，您的 PR 中存在 3 个 commit:
+
 ```bash
 git rebase -i HEAD^3
 (interactive squash + sign off append)


### PR DESCRIPTION
## What's changed and what's your intention?

add sign off doc to contributor guide(en)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link
Please associate a related Issue, which can help reviewers better understand your intent.
You can refer to the [GitHub Contribution Guide](https://robustmq.com/ContributionGuide/GitHub-Contribution-Guide.html)
to submit the corresponding Issue.It also has an [PR Example](https://robustmq.com/ContributionGuide/Pull-Request-Example.html) to
help you submit PR.
