### PR TITLE
feat: add mqtt-broker thread num static metrics

### DIFF
--- a/.github/workflows/command-actbot.yml
+++ b/.github/workflows/command-actbot.yml
@@ -25,9 +25,10 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      actions: write
       contents: read
     steps:
       - uses: actions/checkout@v2
-      - uses: ShyunnY/actbot@v0.1.0
+      - uses: ShyunnY/actbot@v0.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/example/single-mqtt-cluster/mqtt-server/mqtt-server.toml
+++ b/example/single-mqtt-cluster/mqtt-server/mqtt-server.toml
@@ -36,6 +36,7 @@ request_queue_size = 2000
 response_queue_size = 2000
 lock_max_try_mut_times = 30
 lock_try_mut_sleep_time_ms = 50
+queue_size = 10
 
 [auth_storage]
 storage_type = "placement"


### PR DESCRIPTION
## What's changed and what's your intention?

add mqtt-broker thread num static metrics

```plain text
# HELP broker_active_thread_num The number of execution threads started by the broker.
# TYPE broker_active_thread_num gauge
broker_active_thread_num{network="tls",thread_type="handler"} 10
broker_active_thread_num{network="tcp",thread_type="accept"} 10
broker_active_thread_num{network="tls",thread_type="accept"} 10
broker_active_thread_num{network="tcp",thread_type="handler"} 10
broker_active_thread_num{network="tls",thread_type="response"} 10
broker_active_thread_num{network="tcp",thread_type="response"} 10
```

_Note: Currently, only records are added for tcp/tls server. In fact, we need to add records for quic/websocket server as well, but the current code organization structure will result in a lot of unnecessary redundant code. Therefore, this part of the implementation will be written after refactoring quic/websocket._


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [X]  This PR does not require documentation updates.

## Refer to a related PR or issue link
Please associate a related Issue, which can help reviewers better understand your intent.
You can refer to the [GitHub Contribution Guide](https://robustmq.com/ContributionGuide/GitHub-Contribution-Guide.html)
to submit the corresponding Issue.It also has an [PR Example](https://robustmq.com/ContributionGuide/Pull-Request-Example.html) to
help you submit PR.
