### PR TITLE
feat: enable FatLTO and codegen-units = 1 optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,4 +198,6 @@ overflow-checks = false
 incremental = true
 
 [profile.release]
+codegen-units = 1
+lto = true
 overflow-checks = false


### PR DESCRIPTION
## What's changed and what's your intention?

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Enable LTO and CG=1 optimizations for the Cargo Release profile for better optimizations (binary size and performance)
- I enabled only LTO and CG=1. Other options is up to the developers
- Initially, I just enabled the optimizations above directly in the Release profile - since it automatically brings LTO and CG=1 optimizations in all builds that use the Release profile without a need to tweak CI scripts or anything else. If it brings some issues for the project - we can move it to a dedicated profile - like `[profile.heavy-optimized-release]` - later. It wouldn't be a problem too.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link

https://github.com/robustmq/robustmq/issues/1203
