### PR TITLE
refactor: Use Box<CommonError> to fix the result_large_err warning in clippy.

### DIFF
--- a/src/journal-client/src/lib.rs
+++ b/src/journal-client/src/lib.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #![allow(dead_code, unused_variables)]
-#![allow(clippy::result_large_err)]
 mod async_reader;
 mod async_writer;
 mod cache;

--- a/src/journal-client/src/option.rs
+++ b/src/journal-client/src/option.rs
@@ -33,11 +33,12 @@ impl JournalClientOption {
     }
 }
 
-pub fn options_validator(option: &JournalClientOption) -> Result<(), CommonError> {
+pub fn options_validator(option: &JournalClientOption) -> Result<(), Box<CommonError>> {
     if option.addrs.is_empty() {
-        return Err(CommonError::ParameterCannotBeNull(
+        let err = Box::new(CommonError::ParameterCannotBeNull(
             "option.addrs".to_string(),
         ));
+        return Err(err);
     }
     Ok(())
 }


### PR DESCRIPTION
## What's changed and what's your intention?

We use Result<(), Box<CommError>> to substitute the Result<(), CommonError> to avoid the result-large-err warning.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [X]  This PR does not require documentation updates.

## Refer to a related PR or issue link


As the [issue](https://github.com/robustmq/robustmq/issues/1114) discussed, this PR fixes the result_large_err warning in clippy