### PR TITLE
chore: synchronize new configuration in single-cluster and remove lint allow rules

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -105,4 +105,4 @@ jobs:
       - name: cargo clippy check
         env:
           RUSTC_WRAPPER: ""
-        run: cargo clippy --all-targets --all-features --tests --benches -- -D warnings -A clippy::uninlined-format-args
+        run: cargo clippy --all-targets --all-features --tests --benches -- -D warnings

--- a/codecheck.sh
+++ b/codecheck.sh
@@ -16,5 +16,5 @@
 hawkeye format
 cargo fmt --all
 cargo fmt --all -- --check
-cargo clippy --all-targets --all-features --tests --benches -- -D warnings -A clippy::uninlined-format-args
+cargo clippy --all-targets --all-features --tests --benches -- -D warnings
 cargo-deny check licenses

--- a/example/single-mqtt-cluster/journal-server/journal-tracing.toml
+++ b/example/single-mqtt-cluster/journal-server/journal-tracing.toml
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 [stdout]
-kind = "Console"
-level = "Info"
-formatter = "Json"
+kind = "console"
+level = "info"
+formatter = "json"
 
 [server]
-kind = "RollingFile"
-level = "Info"
-rotation = "Minutely"
+kind = "rolling_file"
+level = "info"
+rotation = "minutely"
 directory = "./logs"
 prefix = "journal-server-"
 suffix = "log"

--- a/example/single-mqtt-cluster/mqtt-server/mqtt-tracing.toml
+++ b/example/single-mqtt-cluster/mqtt-server/mqtt-tracing.toml
@@ -13,29 +13,29 @@
 # limitations under the License.
 
 [stdout]
-kind = "Console"
-level = "Info"
-formatter = "Json"
+kind = "console"
+level = "info"
+formatter = "json"
 
 [server]
-kind = "RollingFile"
-level = "Info"
-rotation = "Minutely"
+kind = "rolling_file"
+level = "info"
+rotation = "minutely"
 directory = "./logs"
 prefix = "mqtt-server-"
 suffix = "log"
 max_log_files = 10
 
 [slow_sub]
-kind = "RollingFile"
-level = "Info"
-rotation = "Minutely"
+kind = "rolling_file"
+level = "info"
+rotation = "minutely"
 directory = "./logs"
 prefix = "mqtt-slow_sub-"
 suffix = "log"
 max_log_files = 10
 
 [tokio_console]
-kind = "TokioConsole"
+kind = "tokio_console"
 bind = "0.0.0.0:9999"
 grpc_enable = true

--- a/example/single-mqtt-cluster/placement-center/place-tracing.toml
+++ b/example/single-mqtt-cluster/placement-center/place-tracing.toml
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 [stdout]
-kind = "Console"
-level = "Info"
-formatter = "Json"
+kind = "console"
+level = "info"
+formatter = "json"
 
 [server]
-kind = "RollingFile"
-level = "Info"
-rotation = "Minutely"
+kind = "rolling_file"
+level = "info"
+rotation = "minutely"
 directory = "./logs"
 prefix = "place-server-"
 suffix = "log"


### PR DESCRIPTION


## What's changed and what's your intention?

chore: synchronize new configuration in single-cluster and remove lint allow rules

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [X]  This PR does not require documentation updates.

## Refer to a related PR or issue link

Remove lint allow rule according: #1259