### PR TITLE
refactor: Version inforation management optimization

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -67,6 +67,9 @@ cross_build(){
 
     mkdir -p ${package_path}/{bin,libs,config}
 
+    # Create version.ini file with version information
+    echo "${version}" > ${package_path}/config/version.ini
+    log "Created version.ini with version: ${version}"
 
     binaries="mqtt-server placement-center journal-server cli-command cli-bench"
 
@@ -159,6 +162,10 @@ build_local(){
     fi
 
     mkdir -p ${package_path}/{bin,libs,config}
+
+    # Create version.ini file with version information
+    echo "${version}" > ${package_path}/config/version.ini
+    log "Created version.ini with version: ${version}"
 
     binaries="mqtt-server placement-center journal-server cli-command cli-bench"
 

--- a/src/common/base/src/version/logo.rs
+++ b/src/common/base/src/version/logo.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub const DEFAULT_PLACEMENT_CENTER_CONFIG: &str = "./version.ini";
+pub const DEFAULT_PLACEMENT_CENTER_CONFIG: &str = "./config/version.ini";
 
 pub fn banner() {
     const B: &str = r"


### PR DESCRIPTION
## What's changed and what's your intention?

- Use `OnceLock` to cache version information
- Change the version file path from `./version.ini` to `./config/version.ini`
- Update the `build-release.sh` script to ensure the version file is created correctly during the build process

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link

#1253
