### PR TITLE
docs: Fix OpenMessaging typo in a few places

### DIFF
--- a/docs/en/Architect/Broker-Server.md
+++ b/docs/en/Architect/Broker-Server.md
@@ -1,6 +1,6 @@
 # Broker Server
 ## Overview
-Broker Server is a computation layer component, primarily responsible for the data access of various messaging protocols and the implementation of their related functions. From a design perspective, it aims to support mainstream messaging protocols such as MQTT 3.1/3.1.1/5.0, AMQP, RocketMQ Remoting/GRPC, Kafka Protocol, OpenMessing, JNS, SQS, etc. The architecture is as follows:
+Broker Server is a computation layer component, primarily responsible for the data access of various messaging protocols and the implementation of their related functions. From a design perspective, it aims to support mainstream messaging protocols such as MQTT 3.1/3.1.1/5.0, AMQP, RocketMQ Remoting/GRPC, Kafka Protocol, OpenMessaging, JNS, SQS, etc. The architecture is as follows:
 ![image](../../images/doc-image2.png)
 
 - Broker Server relies on Placement Center to complete cluster formation, such as node discovery, cluster metadata storage, etc.

--- a/docs/en/OverView/What-is-RobustMQ.md
+++ b/docs/en/OverView/What-is-RobustMQ.md
@@ -10,7 +10,7 @@ Use Rust to build a high-performance, stable, fully functional message queue tha
 
 ### 1.4 Features
 - 100% Rust: A message queuing kernel implemented entirely in Rust.
-- Multi-protocol: Support MQTT 3.1/3.1.1/5.0, AMQP, RocketMQ Remoting/GRPC, Kafka Protocol, OpenMessing, JNS, SQS and other mainstream message protocols.
+- Multi-protocol: Support MQTT 3.1/3.1.1/5.0, AMQP, RocketMQ Remoting/GRPC, Kafka Protocol, OpenMessaging, JNS, SQS and other mainstream message protocols.
 - Layered architecture: computing, storage, scheduling independent three-tier architecture, each layer has the ability of cluster deployment, rapid horizontal scaling capacity.
 - Plug-in storage: Standalone plug-in storage layer implementation, you can choose the appropriate storage layer according to your needs. It is compatible with traditional and cloud-native architectures, and supports cloud and IDC deployment patterns.
 - High cohesion architecture: It provides built-in metadata storage components, distributed Journal storage services, and has the ability to deploy quickly, easily and cohesively.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -29,7 +29,7 @@ features:
   - title: 100% Rust
     details: A message queuing kernel implemented entirely in Rust, which is the amazing language to build software with stunning performance, reliability and productivity.
   - title: Multi-protocol
-    details: Support MQTT 3.1/3.1.1/5.0, AMQP, RocketMQ Remoting/GRPC, Kafka Protocol, OpenMessing, JNS, SQS and other mainstream message protocols.
+    details: Support MQTT 3.1/3.1.1/5.0, AMQP, RocketMQ Remoting/GRPC, Kafka Protocol, OpenMessaging, JNS, SQS and other mainstream message protocols.
   - title: Layered architecture
     details: Three-tier independent architecture consists of Computing, Storage and Scheduling. Each layer has the ability of cluster deployment and rapid horizontal scaling capacity.
   - title: Plug-in storage

--- a/docs/zh/Architect/Broker-Server.md
+++ b/docs/zh/Architect/Broker-Server.md
@@ -1,6 +1,6 @@
 # Broker Server
 ## 概览
-Broker Server是计算层组件，主要完成各种不同消息协议的数据接入及其相关功能的实现。从设计角度来看，它希望支持MQTT 3.1/3.1.1/5.0、AMQP、RocketMQ Remoting/GRPC、Kafka Protocol、OpenMessing、JNS、SQS等主流消息协议。架构如下：
+Broker Server是计算层组件，主要完成各种不同消息协议的数据接入及其相关功能的实现。从设计角度来看，它希望支持MQTT 3.1/3.1.1/5.0、AMQP、RocketMQ Remoting/GRPC、Kafka Protocol、OpenMessaging、JNS、SQS等主流消息协议。架构如下：
 ![image](../../images/doc-image2.png)
 
 - Broker Server 依靠 Placement Center 完成集群组建，比如节点发现、集群元数据存储等等。

--- a/docs/zh/OverView/What-is-RobustMQ.md
+++ b/docs/zh/OverView/What-is-RobustMQ.md
@@ -14,7 +14,7 @@
 
 ### 1.4 特点
 - 100% Rust：完全基于 Rust 语言实现的消息队列引擎。
-- 多协议：支持MQTT 3.1/3.1.1/5.0、AMQP、Kafka Protocol、RocketMQ Remoting/GRPC、OpenMessing、JNS、SQS 等主流消息协议。
+- 多协议：支持MQTT 3.1/3.1.1/5.0、AMQP、Kafka Protocol、RocketMQ Remoting/GRPC、OpenMessaging、JNS、SQS 等主流消息协议。
 - 分层架构：计算、存储、调度完全独立的三层架构，职责清晰、独立。
 - Serverless：所有组件均具备分布式集群化部署，快速扩缩容的能力。
 - 插件式存储：独立插件式的存储层实现，支持独立部署和共享存储两种架构。

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -29,7 +29,7 @@ features:
   - title: 100% Rust
     details: 完全用 Rust 实现的消息队列内核，这是构建具有惊人性能、可靠性和生产力的软件的神奇语言。
   - title: 多协议
-    details: 支持 MQTT 3.1/3.1.1/5.0、AMQP、RocketMQ Remoting/GRPC、Kafka 协议、OpenMessing、JNS、SQS 等主流消息协议。
+    details: 支持 MQTT 3.1/3.1.1/5.0、AMQP、RocketMQ Remoting/GRPC、Kafka 协议、OpenMessaging、JNS、SQS 等主流消息协议。
   - title: 分层架构
     details: 三层独立架构，包括 Computing、Storage 和 Scheduling。每一层都具备集群部署能力和快速水平扩容能力。
   - title: 插件存储


### PR DESCRIPTION
Fix typos in docs