### PR TITLE
feat: add connections metrics for mqtt-broker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ jn-1.log
 pc-1.log
 config/log-config/mqtt-tracing.toml
 config/log-config/place-tracing.toml
+.cargo

--- a/src/common/base/src/metrics/gauge.rs
+++ b/src/common/base/src/metrics/gauge.rs
@@ -100,6 +100,25 @@ macro_rules! gauge_metric_get {
     }};
 }
 
+#[macro_export]
+macro_rules! gauge_metrics_set {
+    ($family:ident,$label:ident,$value:expr) => {
+        let family = $family.clone();
+        let mut found = false;
+        {
+            let family_r = family.read().unwrap();
+            if let Some(gauge) = family_r.get(&$label) {
+                gauge.set($value);
+                found = true;
+            };
+        }
+        if !found {
+            let family_w = family.write().unwrap();
+            family_w.get_or_create(&$label).set($value);
+        }
+    };
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/common/base/src/metrics/mod.rs
+++ b/src/common/base/src/metrics/mod.rs
@@ -55,3 +55,20 @@ pub async fn register_prometheus_export(port: u32) {
 pub async fn route_metrics() -> String {
     dump_metrics()
 }
+
+/// `NoLabelSet` is an empty label set type, used to build **unlabeled metrics**
+/// Implemented `EncodeLabelSet` so that it can be correctly encoded as `{}` (empty labels) by Prometheus
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Default)]
+pub struct NoLabelSet;
+
+mod impl_encode_label_set {
+    use crate::metrics::NoLabelSet;
+    use prometheus_client::encoding::{EncodeLabelSet, LabelSetEncoder};
+    use std::fmt::Error;
+
+    impl EncodeLabelSet for NoLabelSet {
+        fn encode(&self, _: LabelSetEncoder) -> Result<(), Error> {
+            Ok(())
+        }
+    }
+}

--- a/src/mqtt-broker/src/observability/metrics/server.rs
+++ b/src/mqtt-broker/src/observability/metrics/server.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::server::common::connection::NetworkConnectionType;
+use common_base::metrics::NoLabelSet;
 use common_base::tools::now_mills;
 use prometheus_client::encoding::EncodeLabelSet;
 
@@ -95,6 +96,13 @@ common_base::register_gauge_metric!(
     "broker_active_thread_num",
     "The number of execution active threads started by the broker",
     BrokerThreadLabel
+);
+
+common_base::register_gauge_metric!(
+    BROKER_CONNECTIONS_NUM,
+    "broker_connections_num",
+    "The number of active connections by the broker",
+    NoLabelSet
 );
 
 pub fn metrics_request_total_ms(network_connection: &NetworkConnectionType, ms: f64) {
@@ -188,4 +196,8 @@ pub fn record_broker_thread_num(
         thread_type: "response".to_string(),
     };
     common_base::gauge_metric_inc_by!(BROKER_ACTIVE_THREAD_NUM, accept_label, response as i64);
+}
+
+pub fn record_broker_connections_num(value: i64) {
+    common_base::gauge_metrics_set!(BROKER_CONNECTIONS_NUM, NoLabelSet, value);
 }


### PR DESCRIPTION
## What's changed and what's your intention?

add connections metrics for mqtt-broker

simple example:
```plain text
# HELP broker.connections.num The number of active connections by the broker.
# TYPE broker.connections.num gauge
broker.connections.num{connection_type="Tcp"} 1

......
```
