### PR TITLE
feat: add connections max metrics for mqtt-broker

### DIFF
--- a/src/mqtt-broker/src/common/metrics_cache.rs
+++ b/src/mqtt-broker/src/common/metrics_cache.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::common::types::ResultMqttBrokerError;
-use crate::observability::metrics::server::record_broker_connections_num;
+use crate::observability::metrics::server::{record_broker_connections_max, record_broker_connections_num};
 use crate::{
     common::tool::loop_select, handler::cache::CacheManager,
     server::common::connection_manager::ConnectionManager, subscribe::manager::SubscribeManager,
@@ -121,6 +121,7 @@ impl MetricsCacheManager {
     pub fn export_metrics(&self) {
         if let Some(connection_num) = self.latest_by_time(&self.connection_num) {
             record_broker_connections_num(connection_num as i64);
+            record_broker_connections_max(connection_num as i64);
         }
     }
 

--- a/src/mqtt-broker/src/observability/metrics/server.rs
+++ b/src/mqtt-broker/src/observability/metrics/server.rs
@@ -105,6 +105,13 @@ common_base::register_gauge_metric!(
     NoLabelSet
 );
 
+common_base::register_gauge_metric!(
+    BROKER_CONNECTIONS_MAX,
+    "broker_connections_max",
+    "The number of max active connections by the broker",
+    NoLabelSet
+);
+
 pub fn metrics_request_total_ms(network_connection: &NetworkConnectionType, ms: f64) {
     let label = NetworkLabel {
         network: network_connection.to_string(),
@@ -200,4 +207,13 @@ pub fn record_broker_thread_num(
 
 pub fn record_broker_connections_num(value: i64) {
     common_base::gauge_metrics_set!(BROKER_CONNECTIONS_NUM, NoLabelSet, value);
+}
+
+pub fn record_broker_connections_max(value: i64) {
+    let mut current_val = 0i64;
+    common_base::gauge_metric_get!(BROKER_CONNECTIONS_MAX, NoLabelSet, current_val);
+
+    if current_val < value {
+        common_base::gauge_metrics_set!(BROKER_CONNECTIONS_MAX, NoLabelSet, value);
+    }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

feat: add connections max metrics for mqtt-broker

example:
```
# HELP broker_connections_num The number of active connections by the broker.
# TYPE broker_connections_num gauge
broker_connections_num{} 1
# HELP broker_connections_max The number of max active connections by the broker.
# TYPE broker_connections_max gauge
broker_connections_max{} 2
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [X]  This PR does not require documentation updates.

## Refer to a related PR or issue link

<!--
Please associate a related Issue, which can help reviewers better understand your intent.
You can refer to the [GitHub Contribution Guide](https://robustmq.com/ContributionGuide/GitHub-Contribution-Guide.html)
to submit the corresponding Issue.It also has an [PR Example](https://robustmq.com/ContributionGuide/Pull-Request-Example.html) to
help you submit PR.
-->
