### PR TITLE
chore: cleanup redundancy format indicator check

### DIFF
--- a/src/mqtt-broker/src/handler/validator.rs
+++ b/src/mqtt-broker/src/handler/validator.rs
@@ -236,34 +236,6 @@ pub async fn publish_validator(
         }
     }
 
-    if let Some(properties) = publish_properties {
-        if let Some(payload_format) = properties.payload_format_indicator {
-            if payload_format == 1
-                && std::str::from_utf8(publish.payload.to_vec().as_slice()).is_err()
-            {
-                if is_puback {
-                    return Some(build_puback(
-                        protocol,
-                        connection,
-                        publish.p_kid,
-                        PubAckReason::PayloadFormatInvalid,
-                        Some(MqttBrokerError::PayloadFormatInvalid.to_string()),
-                        Vec::new(),
-                    ));
-                } else {
-                    return Some(build_pubrec(
-                        protocol,
-                        connection,
-                        publish.p_kid,
-                        PubRecReason::PayloadFormatInvalid,
-                        Some(MqttBrokerError::PayloadFormatInvalid.to_string()),
-                        Vec::new(),
-                    ));
-                }
-            }
-        }
-    }
-
     if is_qos_message(publish.qos)
         && connection.get_recv_qos_message() >= cluster.mqtt_protocol_config.receive_max as isize
     {
@@ -295,7 +267,7 @@ pub async fn publish_validator(
                 connection,
                 publish.p_kid,
                 PubAckReason::PayloadFormatInvalid,
-                None,
+                Some(MqttBrokerError::PayloadFormatInvalid.to_string()),
                 Vec::new(),
             ));
         } else {
@@ -304,7 +276,7 @@ pub async fn publish_validator(
                 connection,
                 publish.p_kid,
                 PubRecReason::PayloadFormatInvalid,
-                None,
+                Some(MqttBrokerError::PayloadFormatInvalid.to_string()),
                 Vec::new(),
             ));
         }


### PR DESCRIPTION
## What's changed and what's your intention?

This check
https://github.com/robustmq/robustmq/blob/5c9639fd424194ad19dc581f2962894db729e624/src/mqtt-broker/src/handler/validator.rs#L291-L311
link to 
https://github.com/robustmq/robustmq/blob/5c0a1f92074597343f88adafcd09b35adb64d061/src/mqtt-broker/src/handler/content_type.rs#L33-L43
and 
https://github.com/robustmq/robustmq/blob/5c9639fd424194ad19dc581f2962894db729e624/src/mqtt-broker/src/handler/validator.rs#L239-L265
is the same format indicator check

Expect should check only once

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link

<!--
Please associate a related Issue, which can help reviewers better understand your intent.
You can refer to the [GitHub Contribution Guide](https://robustmq.com/ContributionGuide/GitHub-Contribution-Guide.html)
to submit the corresponding Issue.It also has an [PR Example](https://robustmq.com/ContributionGuide/Pull-Request-Example.html) to
help you submit PR.
-->
