### PR TITLE
docs:install protoc and zstd

### DIFF
--- a/docs/en/QuickGuide/Build-and-Package.md
+++ b/docs/en/QuickGuide/Build-and-Package.md
@@ -47,6 +47,28 @@ sudo apt-get install curl jq git tar  # Ubuntu/Debian
 brew install curl jq git  # macOS
 ```
 
+install `protoc`
+
+```bash
+# Ubuntu(has been verified)
+PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+curl -LO $PB_REL/download/v26.1/protoc-26.1-linux-x86_64.zip
+# Replace the local version
+unzip protoc-26.1-linux-x86_64.zip -d $HOME/.local
+```
+
+resolve: `failed to run custom build command for zstd-sysv2.0.15+zstd.1.5.7`
+
+```bash
+# resolve: failed to run custom build command for zstd-sysv2.0.15+zstd.1.5.7
+# Ubuntu(has been verified)
+sudo apt install build-essential clang pkg-config libssl-dev
+# Fedora/RHEL
+sudo dnf install clang pkg-config zstd-devel # Fedora/RHEL
+# macOS
+brew install zstd pkg-config 
+```
+
 ### Optional Dependencies
 
 #### Cross-platform Compilation Toolchain

--- a/docs/zh/QuickGuide/Build-and-Package.md
+++ b/docs/zh/QuickGuide/Build-and-Package.md
@@ -47,6 +47,28 @@ sudo apt-get install curl jq git tar  # Ubuntu/Debian
 brew install curl jq git  # macOS
 ```
 
+安装 `protoc`
+
+```bash
+# Ubuntu(已验证)
+PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+curl -LO $PB_REL/download/v26.1/protoc-26.1-linux-x86_64.zip
+# 替换本机版本
+unzip protoc-26.1-linux-x86_64.zip -d $HOME/.local
+```
+
+解决: `failed to run custom build command for zstd-sysv2.0.15+zstd.1.5.7`
+
+```bash
+# 解决: failed to run custom build command for zstd-sysv2.0.15+zstd.1.5.7
+# Ubuntu(已验证)
+sudo apt install build-essential clang pkg-config libssl-dev
+# Fedora/RHEL
+sudo dnf install clang pkg-config zstd-devel # Fedora/RHEL
+# macOS
+brew install zstd pkg-config 
+```
+
 ### 可选依赖
 
 #### 跨平台编译工具链


### PR DESCRIPTION
## What's changed and what's your intention?

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link

Supplement the dryness that needs to be installed in the Quick Start documentation

- install protoc
- Resolve  `failed to run custom build command for zstd-sysv2.0.15+zstd.1.5.7`
