### PR TITLE
fix(nix): export `LD_LIBRARY_PATH` environment variable for nix devshells

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,12 @@
         packages = [ rustToolchain ] ++ devTools;
 
         LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+        LD_LIBRARY_PATH =
+          with pkgs;
+          lib.concatStringsSep ":" [
+            (lib.makeLibraryPath [ openssl ])
+            "${pkgs.stdenv.cc.cc.lib}/lib"
+          ];
 
         shellHook = ''
           echo "Entered RobustMQ development shell. 🚀"


### PR DESCRIPTION
## What's changed and what's your intention?

export `LD_LIBRARY_PATH` environment variable in nix devshells. so we run or debug the built executable normally.

- before patched, the `ldd ./target/debug/broker-server` will output:

  ```text
  linux-vdso.so.1 (0x00007ffff7fc4000)
  libssl.so.3 => not found
  libcrypto.so.3 => not found
  libstdc++.so.6 => not found
  libgcc_s.so.1 => /nix/store/f6famnry0piih1d3hh6y73fxx05jxsa8-xgcc-14.3.0-libgcc/lib/libgcc_s.so.1 (0x00007ffff7f90000)
  libm.so.6 => /nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib/libm.so.6 (0x00007ffff7ea8000)
  libc.so.6 => /nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib/libc.so.6 (0x00007fffef800000)
  /nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib/ld-linux-x86-64.so.2 => /nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib64/ld-linux-x86-64.so.2 (0x00007ffff7fc6000)
  ```

- after:

   ```text
   linux-vdso.so.1 (0x00007ffff7fc4000)
   libssl.so.3 => /nix/store/xzhbzgxyzw8vpkx0pxvwsh64v4536isz-openssl-3.5.1/lib/libssl.so.3 (0x00007ffff7ea9000)
   libcrypto.so.3 => /nix/store/xzhbzgxyzw8vpkx0pxvwsh64v4536isz-openssl-3.5.1/lib/libcrypto.so.3 (0x00007fffef400000)
   libstdc++.so.6 => /nix/store/ysdkxvcvy2sy36sqigkyqanixm76z2xh-gcc-14.3.0-lib/lib/libstdc++.so.6 (0x00007fffef000000)
   libgcc_s.so.1 => /nix/store/ysdkxvcvy2sy36sqigkyqanixm76z2xh-gcc-14.3.0-lib/lib/libgcc_s.so.1 (0x00007ffff7e7b000)
   libm.so.6 => /nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib/libm.so.6 (0x00007fffefb18000)
   libc.so.6 => /nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib/libc.so.6 (0x00007fffeec00000)
   /nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib/ld-linux-x86-64.so.2 => /nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib64/ld-linux-x86-64.so.2 (0x00007ffff7fc6000)
   libdl.so.2 => /nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib/libdl.so.2 (0x00007ffff7e74000)
   libpthread.so.0 => /nix/store/8p33is69mjdw3bi1wmi8v2zpsxir8nwd-glibc-2.40-66/lib/libpthread.so.0 (0x00007ffff7e6f000)
   ```
   and we can run or debug it.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link

https://github.com/robustmq/robustmq/issues/1458

