### PR TITLE
fix(cli): resolve short option conflict in CreateConnectorArgs.

### DIFF
--- a/src/cli-command/src/mqtt/params.rs
+++ b/src/cli-command/src/mqtt/params.rs
@@ -382,13 +382,13 @@ pub enum ConnectorActionType {
 #[derive(clap::Args, Debug)]
 #[command(next_line_help = true)]
 pub struct CreateConnectorArgs {
-    #[arg(short, long, required = true)]
+    #[arg(short = 'n', long, required = true)]
     pub connector_name: String,
-    #[arg(short, long, required = true)]
+    #[arg(short = 't', long, required = true)]
     pub connector_type: String,
-    #[arg(short, long, required = true)]
+    #[arg(short = 'c', long, required = true)]
     pub config: String,
-    #[arg(short, long, required = true)]
+    #[arg(short = 'p', long, required = true)]
     pub topic_name: String,
 }
 


### PR DESCRIPTION
Fix Command create: Short option names must be unique for each argument, but '-c' is in use by both 'connector_name' and 'connector_type'