### PR TITLE
feat(server): add index route to AdminServer

### DIFF
--- a/src/admin-server/src/server.rs
+++ b/src/admin-server/src/server.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::cluster::index;
 use crate::mqtt::topic::{topic_delete, topic_rewrite_delete};
 use crate::{
     cluster::{cluster_config_get, cluster_config_set, cluster_info},
@@ -41,6 +42,7 @@ use crate::{
 };
 use axum::response::Html;
 use axum::response::IntoResponse;
+use axum::routing::get;
 use axum::{
     extract::{ConnectInfo, Request},
     http::{HeaderMap, Method, Uri},
@@ -53,11 +55,9 @@ use common_metrics::http::record_http_request;
 use reqwest::StatusCode;
 use std::path::PathBuf;
 use std::{net::SocketAddr, sync::Arc, time::Instant};
-use axum::routing::get;
 use tokio::fs;
 use tower_http::{cors::CorsLayer, services::ServeDir};
 use tracing::{debug, info, warn};
-use crate::cluster::index;
 
 pub struct AdminServer {}
 


### PR DESCRIPTION
## What's changed and what's your intention?

Added a new GET route for the root path (`"/"`) in the `AdminServer` router, handled by the `index` function.

Reference link: https://robustmq.com/zh/Api/COMMON#%E6%9C%8D%E5%8A%A1%E7%89%88%E6%9C%AC%E6%9F%A5%E8%AF%A2

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link

<!--
Please associate a related Issue, which can help reviewers better understand your intent.
You can refer to the [GitHub Contribution Guide](https://robustmq.com/ContributionGuide/GitHub-Contribution-Guide.html)
to submit the corresponding Issue.It also has an [PR Example](https://robustmq.com/ContributionGuide/Pull-Request-Example.html) to
help you submit PR.
-->
