### PR TITLE
feat(config): add default broker IP for BrokerConfig

### DIFF
--- a/src/common/base/src/tools.rs
+++ b/src/common/base/src/tools.rs
@@ -223,7 +223,10 @@ mod tests {
 
     #[test]
     fn get_local_ip_test() {
-        println!("{}", get_local_ip());
+        let ip_string = get_local_ip();
+        println!("{}", ip_string);
+        let parse_ip: std::net::IpAddr = ip_string.parse().unwrap();
+        assert!(parse_ip.is_ipv4() || parse_ip.is_ipv6());
     }
 
     #[test]

--- a/src/common/config/src/config.rs
+++ b/src/common/config/src/config.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 use super::default::{
-    default_broker_id, default_cluster_name, default_flapping_detect, default_grpc_port,
-    default_http_port, default_journal_runtime, default_journal_server, default_journal_storage,
-    default_message_storage, default_meta_addrs, default_mqtt_auth_config, default_mqtt_keep_alive,
-    default_mqtt_offline_message, default_mqtt_protocol_config, default_mqtt_runtime,
-    default_mqtt_schema, default_mqtt_security, default_mqtt_server,
+    default_broker_id, default_broker_ip, default_cluster_name, default_flapping_detect,
+    default_grpc_port, default_http_port, default_journal_runtime, default_journal_server,
+    default_journal_storage, default_message_storage, default_meta_addrs, default_mqtt_auth_config,
+    default_mqtt_keep_alive, default_mqtt_offline_message, default_mqtt_protocol_config,
+    default_mqtt_runtime, default_mqtt_schema, default_mqtt_security, default_mqtt_server,
     default_mqtt_slow_subscribe_config, default_mqtt_system_monitor, default_network,
     default_place_runtime, default_rocksdb, default_roles, default_runtime,
 };
@@ -39,7 +39,7 @@ pub struct BrokerConfig {
     #[serde(default = "default_broker_id")]
     pub broker_id: u64,
 
-    #[serde(default)]
+    #[serde(default = "default_broker_ip")]
     pub broker_ip: Option<String>,
 
     #[serde(default = "default_roles")]

--- a/src/common/config/src/default.rs
+++ b/src/common/config/src/default.rs
@@ -22,6 +22,7 @@ use crate::config::{
 use crate::storage::{StorageAdapterConfig, StorageAdapterType};
 use common_base::enum_type::delay_type::DelayType;
 use common_base::runtime::get_runtime_worker_threads;
+use common_base::tools::get_local_ip;
 use toml::Table;
 
 pub fn default_roles() -> Vec<String> {
@@ -38,6 +39,10 @@ pub fn default_broker_id() -> u64 {
 
 pub fn default_grpc_port() -> u32 {
     1228
+}
+
+pub fn default_broker_ip() -> Option<String> {
+    Some(get_local_ip())
 }
 
 pub fn default_http_port() -> u32 {


### PR DESCRIPTION
## What's changed and what's your intention?
```
{
"cluster_name": "broker-server",
"broker_id": 1,
"broker_ip": null,
}
```
By default, the local IP is used as the broker IP.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link

<!--
Please associate a related Issue, which can help reviewers better understand your intent.
You can refer to the [GitHub Contribution Guide](https://robustmq.com/ContributionGuide/GitHub-Contribution-Guide.html)
to submit the corresponding Issue.It also has an [PR Example](https://robustmq.com/ContributionGuide/Pull-Request-Example.html) to
help you submit PR.
-->
