### PR TITLE
refactor(config): replace Vec<u8> with Bytes for internal data transmission

### DIFF
--- a/src/common/metadata-struct/src/resource_config.rs
+++ b/src/common/metadata-struct/src/resource_config.rs
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+
+use crate::adapter::serde_bytes_wrapper;
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct ClusterResourceConfig {
     pub cluster_name: String,
     pub resource: String,
-    pub config: Vec<u8>,
+    #[serde(with = "serde_bytes_wrapper")]
+    pub config: Bytes,
 }
 
 impl ClusterResourceConfig {

--- a/src/meta-service/src/server/services/common/inner.rs
+++ b/src/meta-service/src/server/services/common/inner.rs
@@ -99,7 +99,7 @@ pub async fn set_resource_config_by_req(
     let config = ClusterResourceConfig {
         cluster_name: req.cluster_name.clone(),
         resource: req.resources.join("/"),
-        config: req.config.clone(),
+        config: req.config.clone().into(),
     };
 
     update_cache_by_set_resource_config(&req.cluster_name, call_manager, client_pool, config)

--- a/src/mqtt-broker/src/handler/dynamic_config.rs
+++ b/src/mqtt-broker/src/handler/dynamic_config.rs
@@ -16,6 +16,7 @@ use crate::common::types::ResultMqttBrokerError;
 use crate::handler::cache::MQTTCacheManager;
 use crate::handler::error::MqttBrokerError;
 use broker_core::cluster::ClusterStorage;
+use bytes::Bytes;
 use common_config::broker::broker_config;
 use common_config::config::{
     BrokerConfig, MqttFlappingDetect, MqttOfflineMessage, MqttProtocolConfig, MqttSchema,
@@ -162,7 +163,7 @@ pub async fn build_cluster_config(
 pub async fn update_cluster_dynamic_config(
     cache_manager: &Arc<MQTTCacheManager>,
     resource_type: ClusterDynamicConfig,
-    config: Vec<u8>,
+    config: Bytes,
 ) -> ResultMqttBrokerError {
     match resource_type {
         ClusterDynamicConfig::MqttSlowSubscribeConfig => {


### PR DESCRIPTION
## What's changed and what's your intention?

<!--
_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
- Modify `ClusterResourceConfig` to use `Bytes` for the `config` field.
- Introduce `serde_bytes_wrapper` to ensure correct serialization/deserialization behavior for `Bytes` fields, maintaining compatibility with existing storage formats.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link

<!--
Please associate a related Issue, which can help reviewers better understand your intent.
You can refer to the [GitHub Contribution Guide](https://robustmq.com/ContributionGuide/GitHub-Contribution-Guide.html)
to submit the corresponding Issue.It also has an [PR Example](https://robustmq.com/ContributionGuide/Pull-Request-Example.html) to
help you submit PR.
-->
Part of #1583 