### PR TITLE
refactor: replace `lazy_static` with `std::sync::LazyLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,7 +1399,6 @@ dependencies = [
  "console-subscriber",
  "crc32fast",
  "governor",
- "lazy_static",
  "local-ip-address",
  "opendal",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,6 @@ apache-avro = "0.17.0"
 # ====================
 anyhow = "1.0.98"
 thiserror = "1.0"
-lazy_static = "1.4"
 bytes = { version = "1", features = ["serde"] }
 uuid = { version = "1.7.0", features = ["v4"] }
 dashmap = { version = "6.1.0", features = ["serde"] }

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -20,7 +20,6 @@ license.workspace = true
 
 [dependencies]
 tokio.workspace = true
-lazy_static.workspace = true
 prometheus.workspace = true
 thiserror.workspace = true
 axum.workspace = true

--- a/src/common/base/src/runtime.rs
+++ b/src/common/base/src/runtime.rs
@@ -13,28 +13,31 @@
 // limitations under the License.
 
 use std::sync::atomic::AtomicU32;
+use std::sync::LazyLock;
 
-use lazy_static::lazy_static;
 use prometheus::{register_int_gauge_vec, IntGaugeVec};
 use tokio::runtime::{Builder, Runtime};
 
 static GLOBAL_RUNTIME_ID: AtomicU32 = AtomicU32::new(0);
 pub const THREAD_NAME_LABEL: &str = "thread_name";
 
-lazy_static! {
-    static ref METRIC_RUNTIME_THREADS_ALIVE: IntGaugeVec = register_int_gauge_vec!(
+static METRIC_RUNTIME_THREADS_ALIVE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
         "runtime_threads_alive",
         "runtime threads alive",
         &[THREAD_NAME_LABEL]
     )
-    .unwrap();
-    static ref METRIC_RUNTIME_THREADS_IDLE: IntGaugeVec = register_int_gauge_vec!(
+    .unwrap()
+});
+
+static METRIC_RUNTIME_THREADS_IDLE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
         "runtime_threads_idle",
         "runtime threads idle",
         &[THREAD_NAME_LABEL]
     )
-    .unwrap();
-}
+    .unwrap()
+});
 
 struct RuntimeBuilder {
     runtime_name: String,


### PR DESCRIPTION
## What's changed and what's your intention?

<!--
_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->
Since the Rust version 1.80+, we can use `std::sync::LazyLock` to replace `lazy_static`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link

<!--
Please associate a related Issue, which can help reviewers better understand your intent.
You can refer to the [GitHub Contribution Guide](https://robustmq.com/ContributionGuide/GitHub-Contribution-Guide.html)
to submit the corresponding Issue.It also has an [PR Example](https://robustmq.com/ContributionGuide/Pull-Request-Example.html) to
help you submit PR.
-->
Part of #1465