### PR TITLE
refactor: use parking_lot::Mutex instead of tokio::sync::Mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7614,6 +7614,7 @@ dependencies = [
  "grpc-clients",
  "metadata-struct",
  "network-server",
+ "parking_lot",
  "prost",
  "protocol",
  "rkyv 0.8.13",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ sysinfo = "0.29.10"
 local-ip-address = "0.6.1"
 num_cpus = "1.16"
 chrono-tz = "0.10.3"
+parking_lot = "0.12.5"
 
 # ====================
 # Testing

--- a/src/storage-engine/Cargo.toml
+++ b/src/storage-engine/Cargo.toml
@@ -46,3 +46,4 @@ axum.workspace = true
 broker-core.workspace = true
 twox-hash.workspace = true
 rkyv.workspace = true
+parking_lot.workspace = true


### PR DESCRIPTION
## What's changed and what's your intention?

<!--
_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link
https://github.com/robustmq/robustmq/issues/1653

Release the lock before the .await call.

<!--
Please associate a related Issue, which can help reviewers better understand your intent.
You can refer to the [GitHub Contribution Guide](https://robustmq.com/ContributionGuide/GitHub-Contribution-Guide.html)
to submit the corresponding Issue.It also has an [PR Example](https://robustmq.com/ContributionGuide/Pull-Request-Example.html) to
help you submit PR.
-->
