### PR TITLE
fix: clean up expired retain messages from storage

### DIFF
--- a/src/mqtt-broker/src/core/retain.rs
+++ b/src/mqtt-broker/src/core/retain.rs
@@ -134,20 +134,14 @@ pub async fn try_send_retain_message(ctx: SendRetainContext<'_>) -> Result<(), M
 
             if retain_message.expired_at > 0 && now_second() >= retain_message.expired_at {
                 // Clean up expired retain message from storage and update metrics
-                if let Err(e) = storage
-                    .delete_retain_message(ctx.tenant, &topic_name)
-                    .await
-                {
+                if let Err(e) = storage.delete_retain_message(ctx.tenant, &topic_name).await {
                     warn!(
                         "Failed to delete expired retain message: topic={}, error={}",
                         topic_name, e
                     );
                 } else {
                     record_mqtt_retained_dec();
-                    debug!(
-                        "Expired retain message cleaned up: topic={}",
-                        topic_name
-                    );
+                    debug!("Expired retain message cleaned up: topic={}", topic_name);
                 }
                 continue;
             }

--- a/src/mqtt-broker/src/core/retain.rs
+++ b/src/mqtt-broker/src/core/retain.rs
@@ -133,6 +133,22 @@ pub async fn try_send_retain_message(ctx: SendRetainContext<'_>) -> Result<(), M
             };
 
             if retain_message.expired_at > 0 && now_second() >= retain_message.expired_at {
+                // Clean up expired retain message from storage and update metrics
+                if let Err(e) = storage
+                    .delete_retain_message(ctx.tenant, &topic_name)
+                    .await
+                {
+                    warn!(
+                        "Failed to delete expired retain message: topic={}, error={}",
+                        topic_name, e
+                    );
+                } else {
+                    record_mqtt_retained_dec();
+                    debug!(
+                        "Expired retain message cleaned up: topic={}",
+                        topic_name
+                    );
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- Add expiry check in `try_send_retain_message` to delete expired retain messages from storage instead of delivering stale data
- When a retain message has passed its `message_expiry_interval`, it is removed from the cache and storage before reaching the subscriber

Fixes #1694

## Test plan
- Retain messages with expired intervals are cleaned up on access
- Non-expired retain messages continue to be delivered normally