### PR TITLE
refactor: Use request host for MCP resource discovery

### DIFF
--- a/src/admin-server/src/mcp/mod.rs
+++ b/src/admin-server/src/mcp/mod.rs
@@ -21,7 +21,7 @@ use crate::state::HttpState;
 use async_nats::Client;
 use axum::{
     extract::State,
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     routing::{get, post},
     Json, Router,
 };
@@ -58,9 +58,18 @@ pub fn mcp_route() -> Router<Arc<HttpState>> {
 
 /// Declare that /mcp requires no OAuth authentication.
 /// MCP clients check this endpoint to determine auth requirements.
-async fn oauth_protected_resource() -> Json<Value> {
+async fn oauth_protected_resource(headers: HeaderMap) -> Json<Value> {
+    let host = headers
+        .get("host")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("localhost:8080");
+    let proto = headers
+        .get("x-forwarded-proto")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("http");
+
     Json(json!({
-        "resource": "http://localhost:8080/mcp",
+        "resource": format!("{proto}://{host}/mcp"),
         "bearer_methods_supported": [],
         "resource_documentation": "https://github.com/robustmq/robustmq"
     }))


### PR DESCRIPTION
## Summary
- derive the MCP OAuth protected resource URL from the incoming Host header
- respect X-Forwarded-Proto when present
- avoid advertising a hardcoded localhost:8080 resource when the admin HTTP port is configured differently

## Validation
- cargo fmt --package admin-server
- env CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=cc RUSTFLAGS='--cfg tokio_unstable' cargo check -p admin-server

## Context
This fixes MCP client discovery for deployments where http_port is not 8080, such as a local RobustMQ instance running on 8086 because another service owns 8080.