### PR TITLE
fix(healthy): probe QUIC readiness over UDP instead of TCP

### DIFF
--- a/src/common/base/src/port.rs
+++ b/src/common/base/src/port.rs
@@ -12,9 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::net::TcpStream;
+use std::net::{TcpStream, UdpSocket};
 
 /// Check whether a local TCP port is currently listening.
 pub fn is_local_port_listening(port: u32) -> bool {
     TcpStream::connect(format!("127.0.0.1:{port}")).is_ok()
+}
+
+/// Check whether a local UDP port is currently bound (e.g. a QUIC listener).
+///
+/// UDP is connectionless, so — unlike TCP — we cannot detect a listener by
+/// connecting (a UDP "connect" only sets the default peer and always
+/// succeeds). Instead we try to bind the port ourselves: if the bind fails
+/// the address is already in use, which we treat as "listening". A plain
+/// bind without `SO_REUSEADDR`/`SO_REUSEPORT` still conflicts even when the
+/// existing listener set those options, so the check stays reliable. If the
+/// bind succeeds nothing is using the port, so we drop the socket and report
+/// not listening.
+pub fn is_local_udp_port_listening(port: u32) -> bool {
+    UdpSocket::bind(format!("0.0.0.0:{port}")).is_err()
 }

--- a/src/common/healthy/src/ready.rs
+++ b/src/common/healthy/src/ready.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_base::{
-    port::is_local_port_listening,
+    port::{is_local_port_listening, is_local_udp_port_listening},
     role::{is_broker_node, is_engine_node},
 };
 use common_config::broker::broker_config;
@@ -32,7 +32,9 @@ pub fn healthy_ready_check() -> bool {
             || !is_local_port_listening(config.mqtt_server.tls_port)
             || !is_local_port_listening(config.mqtt_server.websocket_port)
             || !is_local_port_listening(config.mqtt_server.websockets_port)
-            || !is_local_port_listening(config.mqtt_server.quic_port))
+            // QUIC listens on UDP, so it must be probed with a UDP bind check
+            // rather than a TCP connect (which would always fail here).
+            || !is_local_udp_port_listening(config.mqtt_server.quic_port))
     {
         return false;
     }


### PR DESCRIPTION
The readiness check used is_local_port_listening (a TCP connect) for the MQTT QUIC port. QUIC binds a UDP socket, so the TCP probe could never succeed and broker-role nodes always reported not_ready.

Add is_local_udp_port_listening, which detects a bound UDP port via a bind attempt (EADDRINUSE means the port is in use), and use it for the QUIC port in healthy_ready_check.

## What's changed and what's your intention?

<!--
_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
-->

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

By submitting this pull request, you agree to the terms of the [Apache License 2.0](https://github.com/robustmq/robustmq/blob/main/LICENSE), the [LICENSE](https://github.com/robustmq/robustmq/blob/main/LICENSING.md), and the [Contributor License Agreement (CLA)](https://github.com/robustmq/robustmq/blob/main/CLA.md).

## Refer to a related PR or issue link

<!--
Please associate a related Issue, which can help reviewers better understand your intent.
You can refer to the [GitHub Contribution Guide](https://robustmq.com/ContributionGuide/GitHub-Contribution-Guide.html)
to submit the corresponding Issue.It also has an [PR Example](https://robustmq.com/ContributionGuide/Pull-Request-Example.html) to
help you submit PR.
-->
