### PR TITLE
feat(chaos-test): add stable 3env launcher and faster packaging

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,8 +16,7 @@
 # This file optimizes build performance and reduces disk space usage
 
 [build]
-# Parallel jobs - use all CPU cores for maximum speed
-jobs = 12              # Reduced from 14 to leave resources for system (adjust if needed)
+# Let Cargo choose the local CPU parallelism. Override with CARGO_BUILD_JOBS if needed.
 incremental = true     # Enable incremental compilation
 
 # Optimize for faster compilation during development
@@ -74,9 +73,9 @@ rustflags = [
 git-fetch-with-cli = true
 
 # Registry settings
-[registry]
+[registries.crates-io]
 # Use sparse registry protocol for faster index updates (Rust 1.68+)
-default = "sparse"
+protocol = "sparse"
 
 # Term settings - better progress output
 [term]
@@ -95,8 +94,7 @@ frequency = 'never'  # Don't generate reports (reduces disk I/O)
 # detection which incorrectly fails on Apple Clang 17 when CARGO_ENCODED_RUSTFLAGS
 # contains --cfg flags that clang doesn't understand as C compiler arguments.
 AWS_LC_SYS_CMAKE_BUILDER = "1"
-# Set test threads based on CPU cores (can be overridden per test)
-RUST_TEST_THREADS = "14"
+# Let the Rust test harness choose local CPU parallelism. Override with RUST_TEST_THREADS if needed.
 # Reduce test output verbosity
 RUST_TEST_NOCAPTURE = "0"
 # Use faster allocator for tests (if available)

--- a/.cargo/config.toml.recommended
+++ b/.cargo/config.toml.recommended
@@ -80,6 +80,6 @@ RUST_TEST_NOCAPTURE = "0"
 # Source replacement (optional - uncomment if using mirrors)
 # [source.crates-io]
 # replace-with = "ustc"
-# 
+#
 # [source.ustc]
 # registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"

--- a/.cargo/config.toml.recommended
+++ b/.cargo/config.toml.recommended
@@ -16,8 +16,7 @@
 # This file optimizes build performance and reduces disk space usage
 
 [build]
-# Parallel jobs - use all CPU cores for maximum speed
-jobs = 14              # Your CPU core count (adjust if different)
+# Let Cargo choose the local CPU parallelism. Override with CARGO_BUILD_JOBS if needed.
 incremental = true     # Enable incremental compilation
 
 # Optimize for faster compilation during development
@@ -55,9 +54,9 @@ git-fetch-with-cli = true
 multiplexing = true
 
 # Registry settings
-[registry]
+[registries.crates-io]
 # Use sparse registry protocol for faster index updates (Rust 1.68+)
-default = "sparse"
+protocol = "sparse"
 
 # Term settings - better progress output
 [term]
@@ -72,8 +71,7 @@ frequency = 'never'  # Don't generate reports (reduces disk I/O)
 
 # Test execution settings
 [env]
-# Set test threads based on CPU cores (can be overridden per test)
-RUST_TEST_THREADS = "14"
+# Let the Rust test harness choose local CPU parallelism. Override with RUST_TEST_THREADS if needed.
 # Reduce test output verbosity
 RUST_TEST_NOCAPTURE = "0"
 # Use faster allocator for tests (if available)
@@ -85,4 +83,3 @@ RUST_TEST_NOCAPTURE = "0"
 # 
 # [source.ustc]
 # registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -303,7 +303,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -345,7 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aef82843a0ec9f8b19567445ad2421ceeb1d711514384bdd3d49fe37102ee13"
 dependencies = [
  "bigdecimal",
- "digest",
+ "digest 0.10.7",
  "libflate",
  "log",
  "num-bigint",
@@ -1368,7 +1368,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1392,6 +1392,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1865,7 +1874,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -2050,12 +2059,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "cms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der",
  "spki",
  "x509-cert",
@@ -2227,7 +2242,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "third-driver",
  "tokio",
  "tracing",
@@ -2370,6 +2385,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -2611,6 +2632,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,6 +2662,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,7 +2679,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.1",
  "subtle",
@@ -3124,11 +3163,11 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "num-traits",
  "rand 0.9.2",
  "regex",
- "sha2",
+ "sha2 0.10.9",
  "unicode-segmentation",
  "uuid",
 ]
@@ -3494,7 +3533,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "flagset",
  "pem-rfc7468",
@@ -3667,10 +3706,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -3701,7 +3752,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3800,7 +3851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -3826,7 +3877,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "subtle",
  "zeroize",
@@ -3871,7 +3922,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -3971,7 +4022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4984,7 +5035,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -4993,7 +5044,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5078,6 +5138,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -5165,7 +5234,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5511,7 +5580,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5574,7 +5643,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5693,7 +5762,7 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -5702,7 +5771,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
 ]
@@ -6771,7 +6840,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6984,9 +7063,9 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "lazy_static",
- "md-5",
+ "md-5 0.10.6",
  "pbkdf2 0.11.0",
  "percent-encoding",
  "rand 0.8.5",
@@ -6997,7 +7076,7 @@ dependencies = [
  "serde_bytes",
  "serde_with 1.14.0",
  "sha-1",
- "sha2",
+ "sha2 0.10.9",
  "socket2 0.4.10",
  "stringprep",
  "strsim 0.10.0",
@@ -7090,7 +7169,7 @@ dependencies = [
  "grep",
  "grpc-clients",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "ipnet",
  "jsonwebtoken",
  "lapin",
@@ -7122,7 +7201,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "sqlx",
  "storage-adapter",
  "storage-engine",
@@ -7283,7 +7362,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "subprocess",
  "thiserror 1.0.69",
@@ -7313,7 +7392,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "uuid",
 ]
@@ -7572,7 +7651,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7732,7 +7811,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -7741,7 +7820,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -8004,7 +8083,7 @@ dependencies = [
  "http-body",
  "jiff",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "percent-encoding",
  "quick-xml 0.38.4",
  "reqsign",
@@ -8026,7 +8105,7 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "ed25519-dalek",
- "hmac",
+ "hmac 0.12.1",
  "http",
  "itertools 0.10.5",
  "log",
@@ -8041,7 +8120,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_plain",
  "serde_with 3.16.1",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 1.0.69",
  "url",
@@ -8186,7 +8265,7 @@ checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
 dependencies = [
  "flate2",
  "pkg-config",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "ureq",
 ]
@@ -8227,13 +8306,13 @@ dependencies = [
  "der",
  "des",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "pkcs12",
  "pkcs5",
  "rand 0.9.2",
  "rc2",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "x509-parser",
 ]
@@ -8247,7 +8326,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8259,7 +8338,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8390,7 +8469,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -8399,8 +8478,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -8474,7 +8553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8641,9 +8720,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695b3df3d3cc1015f12d70235e35b6b79befc5fa7a9b95b951eab1dd07c9efc2"
 dependencies = [
  "cms",
- "const-oid",
+ "const-oid 0.9.6",
  "der",
- "digest",
+ "digest 0.10.7",
  "spki",
  "x509-cert",
  "zeroize",
@@ -8660,7 +8739,7 @@ dependencies = [
  "der",
  "pbkdf2 0.12.2",
  "scrypt",
- "sha2",
+ "sha2 0.10.9",
  "spki",
 ]
 
@@ -8764,27 +8843,27 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.10"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac",
- "md-5",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
  "memchr",
- "rand 0.9.2",
- "sha2",
+ "rand 0.10.0",
+ "sha2 0.11.0",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -9043,7 +9122,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -9063,7 +9142,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -9552,7 +9631,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.38",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9590,7 +9669,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -10101,7 +10180,7 @@ dependencies = [
  "form_urlencoded",
  "getrandom 0.2.17",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "http",
  "log",
@@ -10113,7 +10192,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
 ]
 
@@ -10221,7 +10300,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -10410,8 +10489,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -10585,7 +10664,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10700,7 +10779,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10854,7 +10933,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2 0.12.2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -11226,7 +11305,7 @@ checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -11237,7 +11316,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -11248,7 +11327,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -11294,7 +11384,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -11406,7 +11496,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11418,7 +11508,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11457,7 +11547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11578,7 +11668,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -11615,7 +11705,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -11636,7 +11726,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -11646,10 +11736,10 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
@@ -11657,7 +11747,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -11684,17 +11774,17 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -12206,10 +12296,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12461,9 +12551,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -12478,7 +12568,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.10.0",
  "socket2 0.6.3",
  "tokio",
  "tokio-util",
@@ -13105,9 +13195,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -13681,7 +13771,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -14200,7 +14290,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der",
  "spki",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -401,6 +401,15 @@ overflow-checks = false # No runtime overhead
 opt-level = 3           # Maximum optimization
 strip = true            # Strip symbols to reduce binary size
 
+[profile.release-fast]
+# Local packaging profile - faster builds than release, without changing release artifacts.
+inherits = "release"
+lto = false
+codegen-units = 16
+incremental = true
+opt-level = 2
+strip = false
+
 [profile.test]
 opt-level = 0                # No optimization for faster test compilation
 debug = 1                    # Minimal debug info (line tables only)

--- a/chaos-test/config/robustmq-3env/node1/logger.toml
+++ b/chaos-test/config/robustmq-3env/node1/logger.toml
@@ -1,0 +1,66 @@
+[stdout]
+kind = "console"
+targets = [
+    { path = "", level = "info" },
+    { path = "openraft", level = "info" },
+]
+
+[server]
+kind = "rolling_file"
+targets = [
+    { path = "", level = "info" },
+    { path = "openraft", level = "info" },
+]
+rotation = "daily"
+directory = "./data/broker-1/logs"
+prefix = "server"
+suffix = "log"
+max_log_files = 50
+
+[http_request]
+kind = "rolling_file"
+targets = [{ path = "admin_server::server", level = "info" }]
+rotation = "daily"
+directory = "./data/broker-1/logs"
+prefix = "http_request"
+suffix = "log"
+max_log_files = 50
+
+[raft]
+kind = "rolling_file"
+targets = [
+    { path = "openraft", level = "info" },
+    { path = "openraft::raft::responder", level = "error" },
+]
+rotation = "daily"
+directory = "./data/broker-1/logs"
+prefix = "raft"
+suffix = "log"
+max_log_files = 50
+
+[tokio_console]
+grpc_web = true
+kind = "tokio_console"
+bind = "127.0.0.1:5674"
+
+[meta]
+kind = "rolling_file"
+targets = [{ path = "meta_service", level = "info" }]
+rotation = "daily"
+directory = "./data/broker-1/logs"
+prefix = "meta"
+suffix = "log"
+max_log_files = 50
+
+[openraft_except_engine]
+kind = "rolling_file"
+targets = [
+    { path = "openraft", level = "info" },
+    { path = "openraft::engine", level = "off" },
+    { path = "openraft::raft::responder", level = "error" },
+]
+rotation = "daily"
+directory = "./data/broker-1/logs"
+prefix = "openraft-except-engine"
+suffix = "log"
+max_log_files = 10

--- a/chaos-test/config/robustmq-3env/node1/logger.toml
+++ b/chaos-test/config/robustmq-3env/node1/logger.toml
@@ -1,3 +1,17 @@
+# Copyright 2023 RobustMQ Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [stdout]
 kind = "console"
 targets = [

--- a/chaos-test/config/robustmq-3env/node1/server.toml
+++ b/chaos-test/config/robustmq-3env/node1/server.toml
@@ -1,3 +1,17 @@
+# Copyright 2023 RobustMQ Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cluster_name = "robustmq-3env"
 broker_id = 1
 broker_ip = "127.0.0.1"

--- a/chaos-test/config/robustmq-3env/node1/server.toml
+++ b/chaos-test/config/robustmq-3env/node1/server.toml
@@ -1,0 +1,93 @@
+cluster_name = "robustmq-3env"
+broker_id = 1
+broker_ip = "127.0.0.1"
+roles = ["meta", "broker", "engine"]
+grpc_port = 1228
+http_port = 58080
+meta_addrs = { 1 = "127.0.0.1:1228", 2 = "127.0.0.1:2228", 3 = "127.0.0.1:3228" }
+data_path = "./data/broker-1/data"
+
+[log]
+log_config = "./config/logger.toml"
+log_path = "./data/broker-1/logs"
+
+[network]
+accept_thread_num = 1
+handler_thread_num = 64
+queue_size = 5000
+keep_alive_enable = false
+
+[meta_runtime]
+heartbeat_timeout_ms = 30000
+heartbeat_check_time_ms = 1000
+raft_write_timeout_sec = 30
+offset_raft_group_num = 1
+data_raft_group_num = 1
+
+[mqtt_keep_alive]
+enable = true
+default_time = 180
+max_time = 3600
+default_timeout = 2
+
+[message_storage]
+storage_type = "EngineRocksDB"
+
+[mqtt_system_topic]
+interval_ms = 60000
+
+[mqtt_offline_message]
+enable = true
+expire_ms = 3600000
+max_messages_num = 100000
+
+[storage_offset]
+enable_cache = true
+
+[storage_runtime]
+tcp_port = 1779
+max_segment_size = 1073741824
+data_path = ["./data/broker-1/engine"]
+io_thread_num = 4
+
+[runtime]
+tls_cert = "./config/certs/cert.pem"
+tls_key = "./config/certs/key.pem"
+server_worker_threads = 16
+meta_worker_threads = 16
+broker_worker_threads = 16
+
+[mqtt_runtime]
+default_user = "admin"
+default_password = "robustmq"
+durable_sessions_enable = false
+secret_free_login = false
+is_self_protection_status = false
+
+[grpc_client]
+channels_per_address = 4
+
+[mqtt_server]
+tcp_port = 1883
+tls_port = 1885
+websocket_port = 8183
+websockets_port = 8185
+quic_port = 9183
+
+[nats_runtime]
+tcp_port = 4222
+tls_port = 4223
+ws_port  = 4080
+wss_port = 4443
+
+[kafka_runtime]
+tcp_port = 9092
+
+[amqp_runtime]
+tcp_port = 5672
+
+[admin]
+username = "admin"
+password = "admin"
+jwt_secret = "robustmq-change-me-in-production"
+token_ttl_hours = 8

--- a/chaos-test/config/robustmq-3env/node2/logger.toml
+++ b/chaos-test/config/robustmq-3env/node2/logger.toml
@@ -1,0 +1,66 @@
+[stdout]
+kind = "console"
+targets = [
+    { path = "", level = "info" },
+    { path = "openraft", level = "info" },
+]
+
+[server]
+kind = "rolling_file"
+targets = [
+    { path = "", level = "info" },
+    { path = "openraft", level = "info" },
+]
+rotation = "daily"
+directory = "./data/broker-2/logs"
+prefix = "server"
+suffix = "log"
+max_log_files = 50
+
+[http_request]
+kind = "rolling_file"
+targets = [{ path = "admin_server::server", level = "info" }]
+rotation = "daily"
+directory = "./data/broker-2/logs"
+prefix = "http_request"
+suffix = "log"
+max_log_files = 50
+
+[raft]
+kind = "rolling_file"
+targets = [
+    { path = "openraft", level = "info" },
+    { path = "openraft::raft::responder", level = "error" },
+]
+rotation = "daily"
+directory = "./data/broker-2/logs"
+prefix = "raft"
+suffix = "log"
+max_log_files = 50
+
+[tokio_console]
+grpc_web = true
+kind = "tokio_console"
+bind = "127.0.0.1:5675"
+
+[meta]
+kind = "rolling_file"
+targets = [{ path = "meta_service", level = "info" }]
+rotation = "daily"
+directory = "./data/broker-2/logs"
+prefix = "meta"
+suffix = "log"
+max_log_files = 50
+
+[openraft_except_engine]
+kind = "rolling_file"
+targets = [
+    { path = "openraft", level = "info" },
+    { path = "openraft::engine", level = "off" },
+    { path = "openraft::raft::responder", level = "error" },
+]
+rotation = "daily"
+directory = "./data/broker-2/logs"
+prefix = "openraft-except-engine"
+suffix = "log"
+max_log_files = 10

--- a/chaos-test/config/robustmq-3env/node2/logger.toml
+++ b/chaos-test/config/robustmq-3env/node2/logger.toml
@@ -1,3 +1,17 @@
+# Copyright 2023 RobustMQ Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [stdout]
 kind = "console"
 targets = [

--- a/chaos-test/config/robustmq-3env/node2/server.toml
+++ b/chaos-test/config/robustmq-3env/node2/server.toml
@@ -1,0 +1,93 @@
+cluster_name = "robustmq-3env"
+broker_id = 2
+broker_ip = "127.0.0.1"
+roles = ["meta", "broker", "engine"]
+grpc_port = 2228
+http_port = 58082
+meta_addrs = { 1 = "127.0.0.1:1228", 2 = "127.0.0.1:2228", 3 = "127.0.0.1:3228" }
+data_path = "./data/broker-2/data"
+
+[log]
+log_config = "./config/logger.toml"
+log_path = "./data/broker-2/logs"
+
+[network]
+accept_thread_num = 1
+handler_thread_num = 64
+queue_size = 5000
+keep_alive_enable = false
+
+[meta_runtime]
+heartbeat_timeout_ms = 30000
+heartbeat_check_time_ms = 1000
+raft_write_timeout_sec = 30
+offset_raft_group_num = 1
+data_raft_group_num = 1
+
+[mqtt_keep_alive]
+enable = true
+default_time = 180
+max_time = 3600
+default_timeout = 2
+
+[message_storage]
+storage_type = "EngineRocksDB"
+
+[mqtt_system_topic]
+interval_ms = 60000
+
+[mqtt_offline_message]
+enable = true
+expire_ms = 3600000
+max_messages_num = 100000
+
+[storage_offset]
+enable_cache = true
+
+[storage_runtime]
+tcp_port = 2779
+max_segment_size = 1073741824
+data_path = ["./data/broker-2/engine"]
+io_thread_num = 4
+
+[runtime]
+tls_cert = "./config/certs/cert.pem"
+tls_key = "./config/certs/key.pem"
+server_worker_threads = 16
+meta_worker_threads = 16
+broker_worker_threads = 16
+
+[mqtt_runtime]
+default_user = "admin"
+default_password = "robustmq"
+durable_sessions_enable = false
+secret_free_login = false
+is_self_protection_status = false
+
+[grpc_client]
+channels_per_address = 4
+
+[mqtt_server]
+tcp_port = 2883
+tls_port = 2885
+websocket_port = 8283
+websockets_port = 8285
+quic_port = 9283
+
+[nats_runtime]
+tcp_port = 5222
+tls_port = 5223
+ws_port  = 5080
+wss_port = 5443
+
+[kafka_runtime]
+tcp_port = 9192
+
+[amqp_runtime]
+tcp_port = 5772
+
+[admin]
+username = "admin"
+password = "admin"
+jwt_secret = "robustmq-change-me-in-production"
+token_ttl_hours = 8

--- a/chaos-test/config/robustmq-3env/node2/server.toml
+++ b/chaos-test/config/robustmq-3env/node2/server.toml
@@ -1,3 +1,17 @@
+# Copyright 2023 RobustMQ Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cluster_name = "robustmq-3env"
 broker_id = 2
 broker_ip = "127.0.0.1"

--- a/chaos-test/config/robustmq-3env/node3/logger.toml
+++ b/chaos-test/config/robustmq-3env/node3/logger.toml
@@ -1,0 +1,66 @@
+[stdout]
+kind = "console"
+targets = [
+    { path = "", level = "info" },
+    { path = "openraft", level = "info" },
+]
+
+[server]
+kind = "rolling_file"
+targets = [
+    { path = "", level = "info" },
+    { path = "openraft", level = "info" },
+]
+rotation = "daily"
+directory = "./data/broker-3/logs"
+prefix = "server"
+suffix = "log"
+max_log_files = 50
+
+[http_request]
+kind = "rolling_file"
+targets = [{ path = "admin_server::server", level = "info" }]
+rotation = "daily"
+directory = "./data/broker-3/logs"
+prefix = "http_request"
+suffix = "log"
+max_log_files = 50
+
+[raft]
+kind = "rolling_file"
+targets = [
+    { path = "openraft", level = "info" },
+    { path = "openraft::raft::responder", level = "error" },
+]
+rotation = "daily"
+directory = "./data/broker-3/logs"
+prefix = "raft"
+suffix = "log"
+max_log_files = 50
+
+[tokio_console]
+grpc_web = true
+kind = "tokio_console"
+bind = "127.0.0.1:5676"
+
+[meta]
+kind = "rolling_file"
+targets = [{ path = "meta_service", level = "info" }]
+rotation = "daily"
+directory = "./data/broker-3/logs"
+prefix = "meta"
+suffix = "log"
+max_log_files = 50
+
+[openraft_except_engine]
+kind = "rolling_file"
+targets = [
+    { path = "openraft", level = "info" },
+    { path = "openraft::engine", level = "off" },
+    { path = "openraft::raft::responder", level = "error" },
+]
+rotation = "daily"
+directory = "./data/broker-3/logs"
+prefix = "openraft-except-engine"
+suffix = "log"
+max_log_files = 10

--- a/chaos-test/config/robustmq-3env/node3/logger.toml
+++ b/chaos-test/config/robustmq-3env/node3/logger.toml
@@ -1,3 +1,17 @@
+# Copyright 2023 RobustMQ Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [stdout]
 kind = "console"
 targets = [

--- a/chaos-test/config/robustmq-3env/node3/server.toml
+++ b/chaos-test/config/robustmq-3env/node3/server.toml
@@ -1,3 +1,17 @@
+# Copyright 2023 RobustMQ Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cluster_name = "robustmq-3env"
 broker_id = 3
 broker_ip = "127.0.0.1"

--- a/chaos-test/config/robustmq-3env/node3/server.toml
+++ b/chaos-test/config/robustmq-3env/node3/server.toml
@@ -1,0 +1,93 @@
+cluster_name = "robustmq-3env"
+broker_id = 3
+broker_ip = "127.0.0.1"
+roles = ["meta", "broker", "engine"]
+grpc_port = 3228
+http_port = 58083
+meta_addrs = { 1 = "127.0.0.1:1228", 2 = "127.0.0.1:2228", 3 = "127.0.0.1:3228" }
+data_path = "./data/broker-3/data"
+
+[log]
+log_config = "./config/logger.toml"
+log_path = "./data/broker-3/logs"
+
+[network]
+accept_thread_num = 1
+handler_thread_num = 64
+queue_size = 5000
+keep_alive_enable = false
+
+[meta_runtime]
+heartbeat_timeout_ms = 30000
+heartbeat_check_time_ms = 1000
+raft_write_timeout_sec = 30
+offset_raft_group_num = 1
+data_raft_group_num = 1
+
+[mqtt_keep_alive]
+enable = true
+default_time = 180
+max_time = 3600
+default_timeout = 2
+
+[message_storage]
+storage_type = "EngineRocksDB"
+
+[mqtt_system_topic]
+interval_ms = 60000
+
+[mqtt_offline_message]
+enable = true
+expire_ms = 3600000
+max_messages_num = 100000
+
+[storage_offset]
+enable_cache = true
+
+[storage_runtime]
+tcp_port = 3779
+max_segment_size = 1073741824
+data_path = ["./data/broker-3/engine"]
+io_thread_num = 4
+
+[runtime]
+tls_cert = "./config/certs/cert.pem"
+tls_key = "./config/certs/key.pem"
+server_worker_threads = 16
+meta_worker_threads = 16
+broker_worker_threads = 16
+
+[mqtt_runtime]
+default_user = "admin"
+default_password = "robustmq"
+durable_sessions_enable = false
+secret_free_login = false
+is_self_protection_status = false
+
+[grpc_client]
+channels_per_address = 4
+
+[mqtt_server]
+tcp_port = 3883
+tls_port = 3885
+websocket_port = 8383
+websockets_port = 8385
+quic_port = 9383
+
+[nats_runtime]
+tcp_port = 6222
+tls_port = 6223
+ws_port  = 6080
+wss_port = 6443
+
+[kafka_runtime]
+tcp_port = 9292
+
+[amqp_runtime]
+tcp_port = 5872
+
+[admin]
+username = "admin"
+password = "admin"
+jwt_secret = "robustmq-change-me-in-production"
+token_ttl_hours = 8

--- a/chaos-test/robustmq-3env.sh
+++ b/chaos-test/robustmq-3env.sh
@@ -61,6 +61,7 @@ Environment:
   ROBUSTMQ_3ENV_BUILD_FRONTEND=true  Pass --with-frontend to scripts/build.sh
   ROBUSTMQ_3ENV_OVERWRITE=true  Allow prepare to overwrite unmarked runtime roots
   ROBUSTMQ_3ENV_CONFIG_DIR=/path/dir  Use config dir with node1-node3/server.toml and logger.toml
+  ROBUSTMQ_3ENV_READY_TIMEOUT=90  Seconds to wait for each node to become ready
 EOF
 }
 
@@ -530,6 +531,53 @@ launch_node() {
     printf '%s\n' "$pid"
 }
 
+node_process_log_path() {
+    local index="$1"
+    local root="${RUNTIME_ROOTS[$index]}"
+    local broker_id
+
+    broker_id="$(broker_id_for_node "$index")"
+    printf '%s/data/broker-%s/logs/process.log\n' "$root" "$broker_id"
+}
+
+node_process_log_size() {
+    local index="$1"
+    local log_file
+
+    log_file="$(node_process_log_path "$index")"
+    if [ -f "$log_file" ]; then
+        stat -c '%s' "$log_file"
+    else
+        printf '0\n'
+    fi
+}
+
+print_node_log_tail() {
+    local index="$1"
+    local log_file
+
+    log_file="$(node_process_log_path "$index")"
+    warn "Last log lines for ${NODES[$index]}: $log_file"
+    if [ -f "$log_file" ]; then
+        tail -n 80 "$log_file" >&2 || true
+    else
+        warn "Log file not found: $log_file"
+    fi
+}
+
+detect_startup_fatal() {
+    local index="$1"
+    local log_offset="${2:-0}"
+    local log_file
+
+    log_file="$(node_process_log_path "$index")"
+    [ -f "$log_file" ] || return 1
+
+    tail -c +"$((log_offset + 1))" "$log_file" 2>/dev/null | grep -E \
+        "NodeCallManager global sender is not initialized|Failed to initialize inner topics|Timeout waiting for topic|thread '.*' panicked|panicked at|Address already in use|Permission denied" \
+        >/dev/null 2>&1
+}
+
 wait_for_port() {
     local port="$1"
     local label="$2"
@@ -545,6 +593,45 @@ wait_for_port() {
     done
 
     error "Timed out waiting for $label on port $port after ${max_wait}s"
+}
+
+wait_for_node_ready() {
+    local index="$1"
+    local pid="$2"
+    local log_offset="$3"
+    local node="${NODES[$index]}"
+    local max_wait="${ROBUSTMQ_3ENV_READY_TIMEOUT:-90}"
+    local elapsed=0
+    local grpc_port http_port mqtt_port
+
+    grpc_port="$(server_port_for_node "$index" grpc_port)"
+    http_port="$(server_port_for_node "$index" http_port)"
+    mqtt_port="$(section_port_for_node "$index" mqtt_server tcp_port)"
+
+    while [ "$elapsed" -lt "$max_wait" ]; do
+        if ! pid_running "$pid"; then
+            print_node_log_tail "$index"
+            error "$node exited before becoming ready; config=${RUNTIME_ROOTS[$index]}/config/server.toml"
+        fi
+
+        if detect_startup_fatal "$index" "$log_offset"; then
+            print_node_log_tail "$index"
+            error "$node reported a fatal startup error; config=${RUNTIME_ROOTS[$index]}/config/server.toml"
+        fi
+
+        if port_is_listening "$grpc_port" \
+            && port_is_listening "$http_port" \
+            && port_is_listening "$mqtt_port"; then
+            info "$node ready: grpc=$grpc_port http=$http_port mqtt=$mqtt_port"
+            return 0
+        fi
+
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+
+    print_node_log_tail "$index"
+    error "Timed out waiting for $node readiness after ${max_wait}s; grpc=$grpc_port http=$http_port mqtt=$mqtt_port config=${RUNTIME_ROOTS[$index]}/config/server.toml"
 }
 
 port_state() {
@@ -609,17 +696,12 @@ start() {
     local i
     for i in "${!NODES[@]}"; do
         local pid
+        local log_offset
+        log_offset="$(node_process_log_size "$i")"
         pid="$(launch_node "$i")"
         append_state "$i" "$pid"
         info "Started ${NODES[$i]} pid=$pid"
-    done
-
-    for i in "${!NODES[@]}"; do
-        local mqtt_port http_port
-        mqtt_port="$(section_port_for_node "$i" mqtt_server tcp_port)"
-        http_port="$(server_port_for_node "$i" http_port)"
-        wait_for_port "$mqtt_port" "${NODES[$i]} MQTT"
-        wait_for_port "$http_port" "${NODES[$i]} HTTP"
+        wait_for_node_ready "$i" "$pid" "$log_offset"
     done
 
     START_ROLLBACK_ACTIVE=false

--- a/chaos-test/robustmq-3env.sh
+++ b/chaos-test/robustmq-3env.sh
@@ -1,0 +1,755 @@
+#!/usr/bin/env bash
+# Copyright 2023 RobustMQ Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info() { echo -e "${GREEN}[3env]${NC} $*"; }
+warn() { echo -e "${YELLOW}[warn]${NC}  $*" >&2; }
+error() {
+    echo -e "${RED}[error]${NC} $*" >&2
+    exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+STATE_DIR="${SCRIPT_DIR}/.robustmq-3env"
+STATE_FILE="${STATE_DIR}/state.tsv"
+PACKAGE_FILE="${STATE_DIR}/package.path"
+MANAGED_MARKER=".robustmq-3env-managed"
+CONFIG_SOURCE_DIR="${ROBUSTMQ_3ENV_CONFIG_DIR:-${SCRIPT_DIR}/config/robustmq-3env}"
+
+NODES=("node1" "node2" "node3")
+RUNTIME_ROOTS=("/home/node1/robustmq" "/home/node2/robustmq" "/home/node3/robustmq")
+START_ROLLBACK_ACTIVE=false
+
+usage() {
+    cat <<EOF
+Usage:
+  bash chaos-test/robustmq-3env.sh <command>
+
+Commands:
+  build     Build/package RobustMQ once, or use ROBUSTMQ_3ENV_PACKAGE
+  prepare   Create/reuse node1-node3 users and prepare /home/nodeX/robustmq
+  start     Start three RobustMQ nodes as node1-node3
+  status    Show process state recorded by this script
+  stop      Stop only processes started by this script
+  restart   Stop then start
+  clean     Remove generated runtime directories and state, but keep users
+  all       Run build, prepare, start, status
+  help      Show this help
+
+Environment:
+  ROBUSTMQ_3ENV_PACKAGE=/path/file.tar.gz  Use an existing robustmq-*.tar.gz package
+  ROBUSTMQ_3ENV_BUILD_FRONTEND=true  Pass --with-frontend to scripts/build.sh
+  ROBUSTMQ_3ENV_OVERWRITE=true  Allow prepare to overwrite unmarked runtime roots
+  ROBUSTMQ_3ENV_CONFIG_DIR=/path/dir  Use config dir with node1-node3/server.toml and logger.toml
+EOF
+}
+
+require_root() {
+    if [ "$(id -u)" -ne 0 ]; then
+        error "This command must run as root because it manages users and /home/nodeX runtime directories."
+    fi
+}
+
+ensure_state_dir() {
+    mkdir -p "$STATE_DIR"
+}
+
+package_path() {
+    if [ -n "${ROBUSTMQ_3ENV_PACKAGE:-}" ]; then
+        printf '%s\n' "$ROBUSTMQ_3ENV_PACKAGE"
+        return 0
+    fi
+    if [ -f "$PACKAGE_FILE" ]; then
+        cat "$PACKAGE_FILE"
+        return 0
+    fi
+    discover_package
+}
+
+build_package() {
+    ensure_state_dir
+
+    if [ -n "${ROBUSTMQ_3ENV_PACKAGE:-}" ]; then
+        [ -f "$ROBUSTMQ_3ENV_PACKAGE" ] || error "ROBUSTMQ_3ENV_PACKAGE does not exist: $ROBUSTMQ_3ENV_PACKAGE"
+        case "$ROBUSTMQ_3ENV_PACKAGE" in
+            *.tar.gz) ;;
+            *) error "ROBUSTMQ_3ENV_PACKAGE must point to a .tar.gz package: $ROBUSTMQ_3ENV_PACKAGE" ;;
+        esac
+        printf '%s\n' "$ROBUSTMQ_3ENV_PACKAGE" > "$PACKAGE_FILE"
+        info "Using existing package: $ROBUSTMQ_3ENV_PACKAGE"
+        return 0
+    fi
+
+    local args=()
+    if [ "${ROBUSTMQ_3ENV_BUILD_FRONTEND:-false}" = "true" ]; then
+        args+=(--with-frontend)
+    fi
+
+    info "Building RobustMQ package with scripts/build.sh ${args[*]:-}"
+    (cd "$PROJECT_ROOT" && bash scripts/build.sh "${args[@]}")
+
+    local package
+    package="$(discover_package)"
+    printf '%s\n' "$package" > "$PACKAGE_FILE"
+    info "Package ready: $package"
+}
+
+discover_package() {
+    local package
+    package="$(find "$PROJECT_ROOT/build" -maxdepth 1 -type f -name 'robustmq-*.tar.gz' -printf '%T@ %p\n' 2>/dev/null | sort -nr | awk 'NR == 1 {print $2}')"
+    [ -n "$package" ] || error "No build/robustmq-*.tar.gz package found. Run: bash chaos-test/robustmq-3env.sh build"
+    printf '%s\n' "$package"
+}
+
+ensure_user_exists() {
+    local user="$1"
+
+    if id "$user" >/dev/null 2>&1; then
+        info "User exists: $user"
+        return 0
+    fi
+
+    info "Creating user: $user"
+    useradd --create-home --shell /bin/bash "$user"
+}
+
+prepare_node_root() {
+    local user="$1"
+    local root="$2"
+    local home_dir
+
+    home_dir="$(dirname "$root")"
+    if [ -e "$root" ]; then
+        refuse_if_runtime_root_running "$root"
+
+        if [ -f "$root/$MANAGED_MARKER" ]; then
+            rm -rf "$root"
+        elif [ "${ROBUSTMQ_3ENV_OVERWRITE:-false}" = "true" ]; then
+            warn "Overwriting unmarked runtime root because ROBUSTMQ_3ENV_OVERWRITE=true: $root"
+            rm -rf "$root"
+        elif [ -z "$(find "$root" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
+            rm -rf "$root"
+        else
+            error "$root already exists and is not marked as managed by this script. Move it away or set ROBUSTMQ_3ENV_OVERWRITE=true explicitly."
+        fi
+    fi
+
+    mkdir -p "$home_dir" "$root"
+    touch "$root/$MANAGED_MARKER"
+    chown -R "$user:$user" "$root"
+}
+
+extract_package_to_node() {
+    local package="$1"
+    local user="$2"
+    local root="$3"
+
+    tar -xzf "$package" -C "$root" --strip-components=1
+
+    [ -x "$root/libs/broker-server" ] || error "broker-server not found or not executable under $root/libs"
+    touch "$root/$MANAGED_MARKER"
+    chown -R "$user:$user" "$root"
+}
+
+source_config_path() {
+    local index="$1"
+    local file="$2"
+
+    printf '%s/%s/%s\n' "$CONFIG_SOURCE_DIR" "${NODES[$index]}" "$file"
+}
+
+runtime_server_config_path() {
+    local index="$1"
+
+    printf '%s/config/server.toml\n' "${RUNTIME_ROOTS[$index]}"
+}
+
+runtime_logger_config_path() {
+    local index="$1"
+
+    printf '%s/config/logger.toml\n' "${RUNTIME_ROOTS[$index]}"
+}
+
+require_source_configs() {
+    local index="$1"
+    local server_config logger_config
+
+    server_config="$(source_config_path "$index" server.toml)"
+    logger_config="$(source_config_path "$index" logger.toml)"
+
+    [ -f "$server_config" ] || error "Missing source config: $server_config"
+    [ -f "$logger_config" ] || error "Missing source config: $logger_config"
+}
+
+require_runtime_configs() {
+    local index="$1"
+    local server_config logger_config
+
+    server_config="$(runtime_server_config_path "$index")"
+    logger_config="$(runtime_logger_config_path "$index")"
+
+    [ -f "$server_config" ] || error "Missing runtime config: $server_config. Run prepare before start."
+    [ -f "$logger_config" ] || error "Missing runtime config: $logger_config. Run prepare before start."
+}
+
+copy_node_config() {
+    local index="$1"
+    local root="${RUNTIME_ROOTS[$index]}"
+
+    require_source_configs "$index"
+    cp "$(source_config_path "$index" server.toml)" "$root/config/server.toml"
+    cp "$(source_config_path "$index" logger.toml)" "$root/config/logger.toml"
+}
+
+toml_scalar() {
+    local file="$1"
+    local section="$2"
+    local key="$3"
+
+    awk -v target_section="$section" -v target_key="$key" '
+        function trim(value) {
+            gsub(/^[ \t\r\n]+|[ \t\r\n]+$/, "", value)
+            return value
+        }
+
+        /^[ \t]*($|#)/ {
+            next
+        }
+
+        /^[ \t]*\[/ {
+            current = $0
+            sub(/^[ \t]*\[/, "", current)
+            sub(/\][ \t]*$/, "", current)
+            current = trim(current)
+            next
+        }
+
+        {
+            if (target_section == "" && current != "") {
+                next
+            }
+            if (target_section != "" && current != target_section) {
+                next
+            }
+
+            split($0, parts, "=")
+            if (trim(parts[1]) != target_key) {
+                next
+            }
+
+            sub(/^[^=]*=/, "", $0)
+            value = trim($0)
+            sub(/[ \t]*#.*/, "", value)
+            value = trim(value)
+            sub(/^"/, "", value)
+            sub(/"$/, "", value)
+            print value
+            found = 1
+            exit
+        }
+
+        END {
+            if (!found) {
+                exit 1
+            }
+        }
+    ' "$file"
+}
+
+broker_id_for_node() {
+    local index="$1"
+
+    toml_scalar "$(runtime_server_config_path "$index")" "" broker_id
+}
+
+server_port_for_node() {
+    local index="$1"
+    local key="$2"
+
+    toml_scalar "$(runtime_server_config_path "$index")" "" "$key"
+}
+
+section_port_for_node() {
+    local index="$1"
+    local section="$2"
+    local key="$3"
+
+    toml_scalar "$(runtime_server_config_path "$index")" "$section" "$key"
+}
+
+tokio_console_port_for_node() {
+    local index="$1"
+    local bind
+
+    bind="$(toml_scalar "$(runtime_logger_config_path "$index")" tokio_console bind)"
+    printf '%s\n' "${bind##*:}"
+}
+
+ports_for_node() {
+    local index="$1"
+    local grpc http storage mqtt mqtt_tls mqtt_ws mqtt_wss mqtt_quic
+    local nats nats_tls nats_ws nats_wss kafka amqp tokio_console
+
+    require_runtime_configs "$index"
+    grpc="$(server_port_for_node "$index" grpc_port)"
+    http="$(server_port_for_node "$index" http_port)"
+    storage="$(section_port_for_node "$index" storage_runtime tcp_port)"
+    mqtt="$(section_port_for_node "$index" mqtt_server tcp_port)"
+    mqtt_tls="$(section_port_for_node "$index" mqtt_server tls_port)"
+    mqtt_ws="$(section_port_for_node "$index" mqtt_server websocket_port)"
+    mqtt_wss="$(section_port_for_node "$index" mqtt_server websockets_port)"
+    mqtt_quic="$(section_port_for_node "$index" mqtt_server quic_port)"
+    nats="$(section_port_for_node "$index" nats_runtime tcp_port)"
+    nats_tls="$(section_port_for_node "$index" nats_runtime tls_port)"
+    nats_ws="$(section_port_for_node "$index" nats_runtime ws_port)"
+    nats_wss="$(section_port_for_node "$index" nats_runtime wss_port)"
+    kafka="$(section_port_for_node "$index" kafka_runtime tcp_port)"
+    amqp="$(section_port_for_node "$index" amqp_runtime tcp_port)"
+    tokio_console="$(tokio_console_port_for_node "$index")"
+
+    printf '%s\n' \
+        "$grpc" "$http" "$storage" \
+        "$mqtt" "$mqtt_tls" "$mqtt_ws" "$mqtt_wss" "$mqtt_quic" \
+        "$nats" "$nats_tls" "$nats_ws" "$nats_wss" \
+        "$kafka" "$amqp" "$tokio_console"
+}
+
+state_ports_for_node() {
+    local index="$1"
+    local grpc http storage mqtt nats kafka amqp tokio_console
+
+    require_runtime_configs "$index"
+    grpc="$(server_port_for_node "$index" grpc_port)"
+    http="$(server_port_for_node "$index" http_port)"
+    storage="$(section_port_for_node "$index" storage_runtime tcp_port)"
+    mqtt="$(section_port_for_node "$index" mqtt_server tcp_port)"
+    nats="$(section_port_for_node "$index" nats_runtime tcp_port)"
+    kafka="$(section_port_for_node "$index" kafka_runtime tcp_port)"
+    amqp="$(section_port_for_node "$index" amqp_runtime tcp_port)"
+    tokio_console="$(tokio_console_port_for_node "$index")"
+
+    printf 'grpc=%s,http=%s,storage=%s,mqtt=%s,nats=%s,kafka=%s,amqp=%s,tokio_console=%s\n' \
+        "$grpc" "$http" "$storage" "$mqtt" "$nats" "$kafka" "$amqp" "$tokio_console"
+}
+
+prepare_node() {
+    local index="$1"
+    local user="${NODES[$index]}"
+    local root="${RUNTIME_ROOTS[$index]}"
+    local package="$2"
+
+    ensure_user_exists "$user"
+    prepare_node_root "$user" "$root"
+    extract_package_to_node "$package" "$user" "$root"
+    copy_node_config "$index"
+
+    local broker_id
+    broker_id="$(broker_id_for_node "$index")"
+
+    mkdir -p \
+        "$root/data/broker-${broker_id}/logs" \
+        "$root/data/broker-${broker_id}/data" \
+        "$root/data/broker-${broker_id}/engine"
+    chown -R "$user:$user" "$root"
+    info "Prepared $user at $root"
+}
+
+prepare() {
+    require_root
+    ensure_state_dir
+
+    local package
+    package="$(package_path)"
+    [ -f "$package" ] || error "Package does not exist: $package"
+
+    local i
+    for i in "${!NODES[@]}"; do
+        prepare_node "$i" "$package"
+    done
+}
+
+all_ports() {
+    local i
+    for i in "${!NODES[@]}"; do
+        ports_for_node "$i"
+    done
+}
+
+validate_runtime_configs() {
+    local i
+
+    for i in "${!NODES[@]}"; do
+        ports_for_node "$i" >/dev/null
+        broker_id_for_node "$i" >/dev/null
+    done
+}
+
+port_is_listening() {
+    local port="$1"
+
+    if command -v ss >/dev/null 2>&1; then
+        ss -H -ltn "sport = :$port" 2>/dev/null | grep -q .
+        return $?
+    fi
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+        return $?
+    fi
+    if command -v netstat >/dev/null 2>&1; then
+        netstat -ltn 2>/dev/null | grep -Eq "[.:]$port[[:space:]]"
+        return $?
+    fi
+    if command -v nc >/dev/null 2>&1; then
+        nc -z 127.0.0.1 "$port" >/dev/null 2>&1
+        return $?
+    fi
+
+    error "Cannot check ports because none of ss, lsof, netstat, or nc is available."
+}
+
+preflight_ports() {
+    local conflicts=()
+    local port
+
+    for port in $(all_ports | sort -n | uniq); do
+        if port_is_listening "$port"; then
+            conflicts+=("$port")
+        fi
+    done
+
+    if [ "${#conflicts[@]}" -gt 0 ]; then
+        error "Port(s) already in use: ${conflicts[*]}"
+    fi
+}
+
+node_index() {
+    local node="$1"
+    local i
+
+    for i in "${!NODES[@]}"; do
+        if [ "${NODES[$i]}" = "$node" ]; then
+            printf '%s\n' "$i"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+cmdline_matches_config() {
+    local pid="$1"
+    local config="$2"
+
+    [ -r "/proc/$pid/cmdline" ] || return 1
+    tr '\0' ' ' < "/proc/$pid/cmdline" | grep -F -- "$config" >/dev/null 2>&1
+}
+
+pid_running() {
+    local pid="$1"
+    [ -n "$pid" ] && kill -0 "$pid" >/dev/null 2>&1
+}
+
+node_running_for_config() {
+    local config="$1"
+    local pid
+
+    if [ -f "$STATE_FILE" ]; then
+        while IFS=$'\t' read -r _node _user pid recorded_config _ports; do
+            [ "$recorded_config" = "$config" ] || continue
+            if pid_running "$pid" && cmdline_matches_config "$pid" "$config"; then
+                return 0
+            fi
+        done < "$STATE_FILE"
+    fi
+
+    ps -eo pid=,args= | grep -F -- "broker-server" | grep -F -- "$config" | grep -v grep >/dev/null 2>&1
+}
+
+refuse_if_runtime_root_running() {
+    local root="$1"
+    local config="$root/config/server.toml"
+
+    if node_running_for_config "$config"; then
+        error "$root has a running broker-server for config $config. Stop it before overwriting or cleaning this runtime root."
+    fi
+}
+
+assert_not_running() {
+    local i
+    for i in "${!NODES[@]}"; do
+        local config="${RUNTIME_ROOTS[$i]}/config/server.toml"
+        if node_running_for_config "$config"; then
+            error "${NODES[$i]} is already running for config $config"
+        fi
+    done
+}
+
+launch_node() {
+    local index="$1"
+    local user="${NODES[$index]}"
+    local root="${RUNTIME_ROOTS[$index]}"
+    local config="$root/config/server.toml"
+    local broker_id stdout_log pid_file
+
+    [ -x "$root/libs/broker-server" ] || error "Missing broker-server binary: $root/libs/broker-server"
+    [ -f "$config" ] || error "Missing config: $config"
+    broker_id="$(broker_id_for_node "$index")"
+    stdout_log="$root/data/broker-${broker_id}/logs/process.log"
+    pid_file="$root/data/broker-${broker_id}/broker.pid"
+
+    command -v setsid >/dev/null 2>&1 || error "setsid is required to start broker-server outside the parent process group."
+
+    runuser -u "$user" -- bash -c "cd '$root' || exit 1; nohup setsid ./libs/broker-server --conf '$config' </dev/null >> '$stdout_log' 2>&1 & echo \$! > '$pid_file'; disown" >/dev/null
+
+    local pid
+    pid="$(cat "$pid_file")"
+    sleep 1
+    if ! pid_running "$pid"; then
+        error "Failed to start ${NODES[$index]}; check $stdout_log"
+    fi
+    printf '%s\n' "$pid"
+}
+
+wait_for_port() {
+    local port="$1"
+    local label="$2"
+    local max_wait="${ROBUSTMQ_3ENV_READY_TIMEOUT:-90}"
+    local elapsed=0
+
+    while [ "$elapsed" -lt "$max_wait" ]; do
+        if port_is_listening "$port"; then
+            return 0
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+
+    error "Timed out waiting for $label on port $port after ${max_wait}s"
+}
+
+port_state() {
+    local port="$1"
+
+    if port_is_listening "$port"; then
+        printf 'listening'
+    else
+        printf 'closed'
+    fi
+}
+
+state_port_value() {
+    local ports="$1"
+    local key="$2"
+
+    tr ',' '\n' <<< "$ports" | awk -F= -v target="$key" '$1 == target {print $2; found = 1; exit} END {if (!found) exit 1}'
+}
+
+write_state_header() {
+    ensure_state_dir
+    : > "$STATE_FILE"
+}
+
+append_state() {
+    local index="$1"
+    local pid="$2"
+    local ports
+
+    ports="$(state_ports_for_node "$index")"
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "${NODES[$index]}" \
+        "${NODES[$index]}" \
+        "$pid" \
+        "${RUNTIME_ROOTS[$index]}/config/server.toml" \
+        "$ports" >> "$STATE_FILE"
+}
+
+start_rollback_on_exit() {
+    local exit_code=$?
+
+    trap - EXIT
+    if [ "${START_ROLLBACK_ACTIVE:-false}" = "true" ] && [ -s "$STATE_FILE" ]; then
+        warn "Start failed; stopping nodes launched by this attempt"
+        START_ROLLBACK_ACTIVE=false
+        stop || true
+    fi
+
+    exit "$exit_code"
+}
+
+start() {
+    require_root
+    assert_not_running
+    validate_runtime_configs
+    preflight_ports
+    write_state_header
+
+    START_ROLLBACK_ACTIVE=true
+    trap start_rollback_on_exit EXIT
+
+    local i
+    for i in "${!NODES[@]}"; do
+        local pid
+        pid="$(launch_node "$i")"
+        append_state "$i" "$pid"
+        info "Started ${NODES[$i]} pid=$pid"
+    done
+
+    for i in "${!NODES[@]}"; do
+        local mqtt_port http_port
+        mqtt_port="$(section_port_for_node "$i" mqtt_server tcp_port)"
+        http_port="$(server_port_for_node "$i" http_port)"
+        wait_for_port "$mqtt_port" "${NODES[$i]} MQTT"
+        wait_for_port "$http_port" "${NODES[$i]} HTTP"
+    done
+
+    START_ROLLBACK_ACTIVE=false
+    trap - EXIT
+}
+
+status() {
+    if [ ! -f "$STATE_FILE" ]; then
+        warn "No state file found: $STATE_FILE"
+        return 1
+    fi
+
+    local node user pid config ports state index mqtt_state http_state mqtt_port http_port
+    while IFS=$'\t' read -r node user pid config ports; do
+        [ -n "$node" ] || continue
+        if pid_running "$pid" && cmdline_matches_config "$pid" "$config"; then
+            state="running"
+        else
+            state="stopped"
+        fi
+
+        if index="$(node_index "$node")"; then
+            mqtt_port="$(state_port_value "$ports" mqtt || true)"
+            http_port="$(state_port_value "$ports" http || true)"
+            if [ -n "$mqtt_port" ]; then
+                mqtt_state="$(port_state "$mqtt_port")"
+            else
+                mqtt_state="unknown"
+            fi
+            if [ -n "$http_port" ]; then
+                http_state="$(port_state "$http_port")"
+            else
+                http_state="unknown"
+            fi
+        else
+            mqtt_state="unknown"
+            http_state="unknown"
+        fi
+
+        printf '%s\t%s\tpid=%s\t%s\tconfig=%s\t%s\tmqtt_status=%s\thttp_status=%s\n' \
+            "$node" "$user" "$pid" "$state" "$config" "$ports" "$mqtt_state" "$http_state"
+    done < "$STATE_FILE"
+
+    return 0
+}
+
+stop() {
+    require_root
+
+    if [ ! -f "$STATE_FILE" ]; then
+        warn "No state file found: $STATE_FILE"
+        return 0
+    fi
+
+    local node user pid config ports
+    while IFS=$'\t' read -r node user pid config ports; do
+        [ -n "$node" ] || continue
+        if pid_running "$pid" && cmdline_matches_config "$pid" "$config"; then
+            info "Stopping $node pid=$pid"
+            kill "$pid" >/dev/null 2>&1 || true
+        else
+            warn "Skip $node pid=$pid because it is not running or config path does not match"
+        fi
+    done < "$STATE_FILE"
+
+    sleep 2
+
+    while IFS=$'\t' read -r node user pid config ports; do
+        [ -n "$node" ] || continue
+        if pid_running "$pid" && cmdline_matches_config "$pid" "$config"; then
+            warn "Force stopping $node pid=$pid"
+            kill -9 "$pid" >/dev/null 2>&1 || true
+        fi
+    done < "$STATE_FILE"
+}
+
+clean() {
+    require_root
+    stop || true
+
+    local root
+    for root in "${RUNTIME_ROOTS[@]}"; do
+        case "$root" in
+            /home/node1/robustmq|/home/node2/robustmq|/home/node3/robustmq)
+                if [ -f "$root/$MANAGED_MARKER" ]; then
+                    refuse_if_runtime_root_running "$root"
+                    rm -rf "$root"
+                    info "Removed $root"
+                elif [ -e "$root" ]; then
+                    warn "Skip unmarked runtime root: $root"
+                else
+                    info "Runtime root already absent: $root"
+                fi
+                ;;
+            *)
+                error "Refusing to remove unexpected runtime root: $root"
+                ;;
+        esac
+    done
+
+    rm -rf "$STATE_DIR"
+    info "Removed $STATE_DIR"
+}
+
+restart() {
+    stop || true
+    start
+}
+
+all() {
+    build_package
+    prepare
+    start
+    status
+}
+
+main() {
+    local cmd="${1:-help}"
+    case "$cmd" in
+        build) build_package ;;
+        prepare) prepare ;;
+        start) start ;;
+        status) status ;;
+        stop) stop ;;
+        restart) restart ;;
+        clean) clean ;;
+        all) all ;;
+        help|-h|--help) usage ;;
+        *) usage; error "Unknown command: $cmd" ;;
+    esac
+}
+
+main "$@"

--- a/chaos-test/tests/test_3env.sh
+++ b/chaos-test/tests/test_3env.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Copyright 2023 RobustMQ Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="${PROJECT_ROOT}/chaos-test/robustmq-3env.sh"
+
+fail() {
+    echo "[test_3env] FAIL: $*" >&2
+    exit 1
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+
+    if ! grep -Fq -- "$needle" <<< "$haystack"; then
+        fail "expected output to contain: $needle"
+    fi
+}
+
+test_script_has_valid_bash_syntax() {
+    bash -n "$SCRIPT"
+}
+
+test_help_command_lists_supported_actions() {
+    local output
+    output="$(bash "$SCRIPT" help)"
+
+    assert_contains "$output" "build"
+    assert_contains "$output" "prepare"
+    assert_contains "$output" "start"
+    assert_contains "$output" "status"
+    assert_contains "$output" "stop"
+    assert_contains "$output" "restart"
+    assert_contains "$output" "clean"
+    assert_contains "$output" "all"
+}
+
+test_config_sources_live_outside_the_script() {
+    local node
+    for node in node1 node2 node3; do
+        [ -f "${PROJECT_ROOT}/chaos-test/config/robustmq-3env/${node}/server.toml" ] || fail "missing server template for $node"
+        [ -f "${PROJECT_ROOT}/chaos-test/config/robustmq-3env/${node}/logger.toml" ] || fail "missing logger template for $node"
+    done
+
+    assert_contains "$(grep -F 'CONFIG_SOURCE_DIR' "$SCRIPT")" "ROBUSTMQ_3ENV_CONFIG_DIR"
+    assert_contains "$(grep -F 'copy_node_config' "$SCRIPT")" "copy_node_config"
+}
+
+test_status_without_state_reports_missing_state() {
+    local state_dir="${PROJECT_ROOT}/chaos-test/.robustmq-3env"
+    local backup_dir=""
+    local output
+
+    if [ -d "$state_dir" ]; then
+        backup_dir="$(mktemp -d)"
+        mv "$state_dir" "$backup_dir/.robustmq-3env"
+    fi
+
+    set +e
+    output="$(bash "$SCRIPT" status 2>&1)"
+    local code=$?
+    set -e
+
+    if [ -n "$backup_dir" ]; then
+        mv "$backup_dir/.robustmq-3env" "$state_dir"
+        rmdir "$backup_dir"
+    fi
+
+    [ "$code" -ne 0 ] || fail "status without state should return non-zero"
+    assert_contains "$output" "No state file found"
+}
+
+main() {
+    test_script_has_valid_bash_syntax
+    test_help_command_lists_supported_actions
+    test_config_sources_live_outside_the_script
+    test_status_without_state_reports_missing_state
+    echo "[test_3env] PASS"
+}
+
+main "$@"

--- a/chaos-test/tests/test_3env.sh
+++ b/chaos-test/tests/test_3env.sh
@@ -85,11 +85,42 @@ test_status_without_state_reports_missing_state() {
     assert_contains "$output" "No state file found"
 }
 
+test_start_uses_per_node_ready_gate() {
+    assert_contains "$(grep -F 'wait_for_node_ready' "$SCRIPT")" "wait_for_node_ready"
+    assert_contains "$(grep -F 'detect_startup_fatal' "$SCRIPT")" "detect_startup_fatal"
+    assert_contains "$(grep -F 'print_node_log_tail' "$SCRIPT")" "print_node_log_tail"
+
+    local launch_line ready_line
+    launch_line="$(grep -n 'pid="$(launch_node "$i")"' "$SCRIPT" | head -1 | cut -d: -f1)"
+    ready_line="$(grep -n 'wait_for_node_ready "$i" "$pid"' "$SCRIPT" | head -1 | cut -d: -f1)"
+
+    [ -n "$launch_line" ] || fail "start should launch nodes inside the node loop"
+    [ -n "$ready_line" ] || fail "start should wait for each node immediately after launch"
+    [ "$launch_line" -lt "$ready_line" ] || fail "start should wait after launch"
+}
+
+test_startup_fatal_scan_ignores_historical_log_lines() {
+    assert_contains "$(grep -F 'node_process_log_size' "$SCRIPT")" "node_process_log_size"
+    assert_contains "$(grep -F 'log_offset="$(node_process_log_size "$i")"' "$SCRIPT")" 'log_offset="$(node_process_log_size "$i")"'
+    assert_contains "$(grep -F 'wait_for_node_ready "$i" "$pid" "$log_offset"' "$SCRIPT")" 'wait_for_node_ready "$i" "$pid" "$log_offset"'
+    assert_contains "$(grep -F 'tail -c +"$((log_offset + 1))"' "$SCRIPT")" 'tail -c +"$((log_offset + 1))"'
+
+    local offset_line launch_line ready_line
+    offset_line="$(grep -n 'log_offset="$(node_process_log_size "$i")"' "$SCRIPT" | head -1 | cut -d: -f1)"
+    launch_line="$(grep -n 'pid="$(launch_node "$i")"' "$SCRIPT" | head -1 | cut -d: -f1)"
+    ready_line="$(grep -n 'wait_for_node_ready "$i" "$pid" "$log_offset"' "$SCRIPT" | head -1 | cut -d: -f1)"
+
+    [ "$offset_line" -lt "$launch_line" ] || fail "start should record log offset before launching the node"
+    [ "$launch_line" -lt "$ready_line" ] || fail "start should pass the launch-time log offset into readiness checks"
+}
+
 main() {
     test_script_has_valid_bash_syntax
     test_help_command_lists_supported_actions
     test_config_sources_live_outside_the_script
     test_status_without_state_reports_missing_state
+    test_start_uses_per_node_ready_gate
+    test_startup_fatal_scan_ignores_historical_log_lines
     echo "[test_3env] PASS"
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,6 +23,8 @@
 # Examples:
 #   ./build.sh                    # Build for current platform
 #   ./build.sh --version v0.1.0  # Build with specific version
+#   ./build.sh --fast            # Build a faster local package
+#   ./build.sh --diagnose-cache  # Show build cache settings
 #   ./build.sh --with-frontend   # Build with frontend
 
 set -euo pipefail
@@ -44,6 +46,9 @@ PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 VERSION="${VERSION:-}"
 BUILD_FRONTEND="${BUILD_FRONTEND:-false}"
 OUTPUT_DIR="${OUTPUT_DIR:-${PROJECT_ROOT}/build}"
+BUILD_PROFILE="${BUILD_PROFILE:-release}"
+USE_SCCACHE="${USE_SCCACHE:-auto}"
+DIAGNOSE_CACHE="false"
 
 # Helper functions
 log_info() {
@@ -75,6 +80,10 @@ show_help() {
     echo -e "${BOLD}OPTIONS:${NC}"
     echo "    -h, --help              Show this help message"
     echo "    -v, --version VERSION   Build version (default: auto-detect from Cargo.toml)"
+    echo "    --fast                  Use the release-fast profile for faster local packaging"
+    echo "    --profile PROFILE       Cargo build profile (default: release)"
+    echo "    --sccache auto|on|off   Use sccache when available (default: auto)"
+    echo "    --diagnose-cache        Print build cache settings and exit"
     echo "    --with-frontend         Build with frontend"
     echo "    --clean                 Clean build directory before building"
     echo
@@ -85,12 +94,19 @@ show_help() {
     echo "    # Build with specific version"
     echo "    $0 --version v0.1.30"
     echo
+    echo "    # Faster local package build"
+    echo "    $0 --fast"
+    echo
+    echo "    # Inspect local cache settings"
+    echo "    $0 --diagnose-cache"
+    echo
     echo "    # Build with frontend"
     echo "    $0 --with-frontend"
     echo
     echo
     echo -e "${BOLD}NOTES:${NC}"
     echo "    - Always builds for current platform only"
+    echo "    - Default release builds keep full optimization and LTO"
     echo "    - Output directory: $OUTPUT_DIR"
 }
 
@@ -181,6 +197,101 @@ get_rust_target() {
     esac
 }
 
+get_host_rust_target() {
+    rustc -vV | awk '/^host:/ { print $2 }'
+}
+
+get_profile_target_dir() {
+    local profile="$1"
+    case "$profile" in
+        "dev") echo "debug" ;;
+        "release") echo "release" ;;
+        *) echo "$profile" ;;
+    esac
+}
+
+get_target_dir() {
+    local rust_target="$1"
+    local build_profile="$2"
+    local host_target="$3"
+    local target_base="${CARGO_TARGET_DIR:-$PROJECT_ROOT/target}"
+    local target_profile_dir
+    target_profile_dir="$(get_profile_target_dir "$build_profile")"
+
+    if [[ "$target_base" != /* ]]; then
+        target_base="$PROJECT_ROOT/$target_base"
+    fi
+
+    if [[ "$rust_target" == "$host_target" ]]; then
+        echo "$target_base/$target_profile_dir"
+    else
+        echo "$target_base/$rust_target/$target_profile_dir"
+    fi
+}
+
+configure_rustc_wrapper() {
+    case "$USE_SCCACHE" in
+        auto)
+            if [[ -z "${RUSTC_WRAPPER:-}" ]] && command -v sccache >/dev/null 2>&1; then
+                export RUSTC_WRAPPER="sccache"
+                log_info "Using sccache via RUSTC_WRAPPER"
+            fi
+            ;;
+        on)
+            if [[ -n "${RUSTC_WRAPPER:-}" ]]; then
+                log_info "Using existing RUSTC_WRAPPER: $RUSTC_WRAPPER"
+            elif command -v sccache >/dev/null 2>&1; then
+                export RUSTC_WRAPPER="sccache"
+                log_info "Using sccache via RUSTC_WRAPPER"
+            else
+                log_error "--sccache on requested, but sccache was not found in PATH"
+                return 1
+            fi
+            ;;
+        off)
+            ;;
+        *)
+            log_error "Invalid --sccache value: $USE_SCCACHE"
+            return 1
+            ;;
+    esac
+}
+
+show_cache_diagnostics() {
+    local platform="$1"
+    local rust_target="$2"
+    local host_target="$3"
+    local target_dir
+    target_dir="$(get_target_dir "$rust_target" "$BUILD_PROFILE" "$host_target")"
+
+    log_step "Build cache diagnostics"
+    log_info "Platform: $platform"
+    log_info "Rust Target: $rust_target"
+    log_info "Host Rust Target: $host_target"
+    log_info "Build Profile: $BUILD_PROFILE"
+    log_info "Target Directory: $target_dir"
+    log_info "CARGO_TARGET_DIR: ${CARGO_TARGET_DIR:-<unset>}"
+    log_info "CARGO_BUILD_JOBS: ${CARGO_BUILD_JOBS:-<auto>}"
+    log_info "CARGO_INCREMENTAL: ${CARGO_INCREMENTAL:-<profile/default>}"
+    log_info "RUSTFLAGS: ${RUSTFLAGS:-<unset>}"
+    log_info "RUSTC_WRAPPER: ${RUSTC_WRAPPER:-<unset>}"
+    log_info "RUSTC_WORKSPACE_WRAPPER: ${RUSTC_WORKSPACE_WRAPPER:-<unset>}"
+
+    if command -v sccache >/dev/null 2>&1; then
+        log_info "sccache: $(command -v sccache)"
+        sccache --show-stats || true
+    else
+        log_warning "sccache not found; compiler artifact caching is disabled"
+    fi
+
+    if [ -d "$PROJECT_ROOT/target" ]; then
+        du -sh "$PROJECT_ROOT/target" 2>/dev/null || true
+    fi
+    if [ -d "$target_dir" ]; then
+        du -sh "$target_dir" 2>/dev/null || true
+    fi
+}
+
 check_dependencies() {
     if ! command -v cargo >/dev/null 2>&1; then
         log_error "cargo not found. Please install Rust."
@@ -203,6 +314,8 @@ check_dependencies() {
         echo
         return 1
     fi
+
+    configure_rustc_wrapper
 
     if [ "$BUILD_FRONTEND" = "true" ]; then
         if ! command -v pnpm >/dev/null 2>&1; then
@@ -295,34 +408,36 @@ build_server() {
     local version="$1"
     local platform="$2"
     local rust_target="$3"
+    local build_profile="$4"
+    local host_target="$5"
 
     log_step "Building server for $platform"
 
-    # Install target if not available
-    if ! rustup target list --installed | grep -q "$rust_target"; then
+    # Install cross target if not available. The host target is already available.
+    if [[ "$rust_target" != "$host_target" ]] && ! rustup target list --installed | grep -q "$rust_target"; then
         log_info "Installing Rust target: $rust_target"
         rustup target add "$rust_target"
     fi
 
     # Build server binaries
-    log_info "Building server binaries..."
+    log_info "Building server binaries with profile: $build_profile"
 
-    local cargo_cmd="cargo build --release --target $rust_target"
+    local cargo_args=(
+        build
+        --profile "$build_profile"
+        --bin broker-server
+        --bin cli-command
+        --bin cli-bench
+    )
 
-    # Build main server
-    if ! $cargo_cmd --bin broker-server; then
-        log_error "Failed to build broker-server"
-        return 1
+    if [[ "$rust_target" != "$host_target" ]]; then
+        cargo_args+=(--target "$rust_target")
+    else
+        log_info "Using host target cache: target/$(get_profile_target_dir "$build_profile")"
     fi
 
-    # Build CLI tools
-    if ! $cargo_cmd --bin cli-command; then
-        log_error "Failed to build cli-command"
-        return 1
-    fi
-
-    if ! $cargo_cmd --bin cli-bench; then
-        log_error "Failed to build cli-bench"
+    if ! cargo "${cargo_args[@]}"; then
+        log_error "Failed to build server binaries"
         return 1
     fi
 
@@ -333,12 +448,15 @@ create_package() {
     local version="$1"
     local platform="$2"
     local rust_target="$3"
+    local build_profile="$4"
+    local host_target="$5"
 
     log_step "Creating package for $platform"
 
     local package_name="robustmq-$version-$platform"
     local package_dir="$OUTPUT_DIR/$package_name"
-    local target_dir="$PROJECT_ROOT/target/$rust_target/release"
+    local target_dir
+    target_dir="$(get_target_dir "$rust_target" "$build_profile" "$host_target")"
 
     # Create package directory structure
     mkdir -p "$package_dir"/{bin,libs,config,dist}
@@ -425,6 +543,7 @@ Package: robustmq-server
 Version: $version
 Platform: $platform
 Target: $rust_target
+Build Profile: $build_profile
 Build Date: $(TZ='Asia/Shanghai' date '+%Y-%m-%d %H:%M:%S CST')
 Binaries: ${found_binaries[*]}
 Frontend Web UI: $frontend_status
@@ -453,6 +572,8 @@ EOF
 
 
 main() {
+    cd "$PROJECT_ROOT"
+
     # Parse command line arguments
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -466,6 +587,30 @@ main() {
                 ;;
             --with-frontend)
                 BUILD_FRONTEND="true"
+                shift
+                ;;
+            --fast)
+                BUILD_PROFILE="release-fast"
+                shift
+                ;;
+            --profile)
+                if [[ $# -lt 2 || -z "$2" ]]; then
+                    log_error "--profile requires a Cargo profile name"
+                    exit 1
+                fi
+                BUILD_PROFILE="$2"
+                shift 2
+                ;;
+            --sccache)
+                if [[ $# -lt 2 || -z "$2" ]]; then
+                    log_error "--sccache requires one of: auto, on, off"
+                    exit 1
+                fi
+                USE_SCCACHE="$2"
+                shift 2
+                ;;
+            --diagnose-cache)
+                DIAGNOSE_CACHE="true"
                 shift
                 ;;
             --clean)
@@ -499,6 +644,11 @@ main() {
     if [ $? -ne 0 ]; then
         exit 1
     fi
+    local host_target=$(get_host_rust_target)
+    if [ -z "$host_target" ]; then
+        log_error "Could not detect host Rust target"
+        exit 1
+    fi
 
     # Show configuration
     echo -e "${BOLD}${BLUE}🚀 RobustMQ Build Script (Simplified)${NC}"
@@ -506,9 +656,18 @@ main() {
     log_info "Version: $VERSION"
     log_info "Platform: $platform"
     log_info "Rust Target: $rust_target"
+    log_info "Host Rust Target: $host_target"
+    log_info "Build Profile: $BUILD_PROFILE"
+    log_info "sccache Mode: $USE_SCCACHE"
     log_info "Build Frontend: $BUILD_FRONTEND"
     log_info "Output Directory: $OUTPUT_DIR"
     echo
+
+    if [ "$DIAGNOSE_CACHE" = "true" ]; then
+        configure_rustc_wrapper
+        show_cache_diagnostics "$platform" "$rust_target" "$host_target"
+        exit 0
+    fi
 
     # Check dependencies
     log_step "Checking dependencies..."
@@ -526,13 +685,13 @@ main() {
     fi
 
     # Build server
-    build_server "$VERSION" "$platform" "$rust_target"
+    build_server "$VERSION" "$platform" "$rust_target" "$BUILD_PROFILE" "$host_target"
     if [ $? -ne 0 ]; then
         exit 1
     fi
 
     # Create package
-    create_package "$VERSION" "$platform" "$rust_target"
+    create_package "$VERSION" "$platform" "$rust_target" "$BUILD_PROFILE" "$host_target"
     if [ $? -ne 0 ]; then
         exit 1
     fi


### PR DESCRIPTION

  ## What's changed and what's your intention?

  This PR improves local RobustMQ development in two areas: it makes
  packaging faster for iterative builds, and it makes the 3-node
  chaos-test launcher stable enough for repeated use on a single machine.

  ### Build speed
  - Adds a `release-fast` packaging profile and a `--fast` flag for
    local builds.
  - Reuses the host target cache and integrates optional `sccache`.
  - Adds `--profile`, `--sccache`, and `--diagnose-cache` options to
    `scripts/build.sh`.
  - Removes fixed Cargo/test parallelism from `.cargo/config.toml` and
    `.cargo/config.toml.recommended`.
  - Keeps the normal release packaging path unchanged.

  ### 3-node launcher
  - Adds `chaos-test/robustmq-3env.sh`, a standalone root-only launcher
    for `node1`, `node2`, and `node3`.
  - Supports `build`, `prepare`, `start`, `status`, `stop`, `restart`,
    `clean`, and `all`.
  - Uses per-node runtime roots, per-node config templates, and a
    launcher-owned state file.
  - Stops and cleans only processes started by this script, so unrelated
    broker processes are not affected.

  ### Startup stability
  - Starts nodes sequentially instead of launching all three at once.
  - Waits for each node to become ready before starting the next one.
  - Detects fatal startup errors only from the current launch attempt, so
    stale lines in `process.log` do not cause false failures.
  - Prints the node log tail and rolls back only the nodes launched in
    the current attempt when startup fails.

  ### Limitations
  - This launcher is intentionally scoped to one local 3-node deployment.
  - It requires root because it manages users and `/home/nodeX` runtime
    roots.

  ### Validation
  - `git diff --check`
  - `bash -n chaos-test/robustmq-3env.sh`
  - `bash -n chaos-test/tests/test_3env.sh`
  - `bash chaos-test/tests/test_3env.sh`
  - `./scripts/build.sh --fast`
  - Three consecutive real `prepare -> start -> status -> stop -> clean`
    runs
  - Verified startup still succeeds when historical fatal lines already
    exist in `process.log`

  ## Checklist

  - [x] I have written the necessary rustdoc comments. (N/A: this PR does
    not modify Rust source files.)
  - [x] I have added the necessary unit tests and integration tests.
  - [x] This PR does not require documentation updates.

  ## Refer to a related PR or issue link

  None
