### PR TITLE
feat: add per-IP connection limit with atomic tracking (#1269)

### DIFF
--- a/src/common/config/src/config.rs
+++ b/src/common/config/src/config.rs
@@ -22,8 +22,9 @@ use super::default::{
     default_keep_alive_default_timeout, default_keep_alive_enable, default_keep_alive_max_time,
     default_limit_max_connection_rate, default_limit_max_connections_per_node,
     default_limit_max_publish_rate, default_limit_max_sessions, default_limit_max_topics,
-    default_max_admin_http_uri_rate, default_max_message_expiry_interval,
-    default_max_network_connection, default_max_network_connection_rate, default_max_packet_size,
+    default_max_admin_http_uri_rate, default_max_connection_per_ip,
+    default_max_message_expiry_interval, default_max_network_connection,
+    default_max_network_connection_rate, default_max_packet_size,
     default_max_session_expiry_interval, default_meta_addrs, default_meta_runtime,
     default_mqtt_flapping_detect, default_mqtt_keep_alive, default_mqtt_limit_cluster,
     default_mqtt_limit_tenant, default_mqtt_offline_message, default_mqtt_protocol,
@@ -356,6 +357,8 @@ pub struct ClusterLimit {
     pub max_network_connection: u64,
     #[serde(default = "default_max_network_connection_rate")]
     pub max_network_connection_rate: u32,
+    #[serde(default = "default_max_connection_per_ip")]
+    pub max_connection_per_ip: u64,
     #[serde(default = "default_max_admin_http_uri_rate")]
     pub max_admin_http_uri_rate: u32,
 }
@@ -365,6 +368,7 @@ impl Default for ClusterLimit {
         ClusterLimit {
             max_network_connection: 100000000,
             max_network_connection_rate: 10000,
+            max_connection_per_ip: 5000,
             max_admin_http_uri_rate: 50,
         }
     }
@@ -940,5 +944,32 @@ impl Default for AdminConfig {
             jwt_secret: default_admin_jwt_secret(),
             token_ttl_hours: default_admin_token_ttl_hours(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cluster_limit_default_has_max_connection_per_ip() {
+        let limit = ClusterLimit::default();
+        assert_eq!(limit.max_connection_per_ip, 5000);
+    }
+
+    #[test]
+    fn cluster_limit_default_max_network_connection() {
+        let limit = ClusterLimit::default();
+        assert_eq!(limit.max_network_connection, 100000000);
+        assert_eq!(limit.max_network_connection_rate, 10000);
+        assert_eq!(limit.max_admin_http_uri_rate, 50);
+    }
+
+    #[test]
+    fn default_max_connection_per_ip_matches_struct_default() {
+        assert_eq!(
+            default_max_connection_per_ip(),
+            ClusterLimit::default().max_connection_per_ip
+        );
     }
 }

--- a/src/common/config/src/default.rs
+++ b/src/common/config/src/default.rs
@@ -419,6 +419,9 @@ pub fn default_max_network_connection_rate() -> u32 {
 pub fn default_max_admin_http_uri_rate() -> u32 {
     50
 }
+pub fn default_max_connection_per_ip() -> u64 {
+    5000
+}
 
 // LimitQuota
 pub fn default_limit_max_connections_per_node() -> u64 {

--- a/src/common/network-server/src/common/connection_manager.rs
+++ b/src/common/network-server/src/common/connection_manager.rs
@@ -15,12 +15,15 @@
 use crate::quic::stream::QuicFramedWriteStream;
 use axum::extract::ws::{Message, WebSocket};
 use common_base::tools::now_second;
+use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use futures::stream::SplitSink;
 use futures::SinkExt;
 use metadata_struct::connection::{NetworkConnection, NetworkConnectionType};
 use protocol::codec::RobustMQCodec;
 use protocol::robust::RobustMQProtocol;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -40,13 +43,32 @@ type TcpTlsWriter = Arc<
 type WebSocketWriter = Arc<Mutex<SplitSink<WebSocket, Message>>>;
 type QuicWriter = Arc<Mutex<QuicFramedWriteStream>>;
 
-#[derive(Clone, Default)]
 pub struct ConnectionManager {
     pub connections: DashMap<u64, NetworkConnection>,
     pub tcp_write_list: DashMap<u64, TcpWriter>,
     pub tcp_tls_write_list: DashMap<u64, TcpTlsWriter>,
     pub websocket_write_list: DashMap<u64, WebSocketWriter>,
     pub quic_write_list: DashMap<u64, QuicWriter>,
+    pub ip_conn_count: DashMap<IpAddr, AtomicU64>,
+}
+
+impl Default for ConnectionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clone for ConnectionManager {
+    fn clone(&self) -> Self {
+        Self {
+            connections: self.connections.clone(),
+            tcp_write_list: self.tcp_write_list.clone(),
+            tcp_tls_write_list: self.tcp_tls_write_list.clone(),
+            websocket_write_list: self.websocket_write_list.clone(),
+            quic_write_list: self.quic_write_list.clone(),
+            ip_conn_count: DashMap::with_capacity(64),
+        }
+    }
 }
 
 // connection manager
@@ -57,17 +79,23 @@ impl ConnectionManager {
         let tcp_tls_write_list = DashMap::with_capacity(64);
         let websocket_write_list = DashMap::with_capacity(64);
         let quic_write_list = DashMap::with_capacity(64);
+        let ip_conn_count = DashMap::with_capacity(64);
         ConnectionManager {
             connections,
             tcp_write_list,
             tcp_tls_write_list,
             websocket_write_list,
             quic_write_list,
+            ip_conn_count,
         }
     }
 
     pub fn add_connection(&self, connection: NetworkConnection) -> u64 {
         let connection_id = connection.connection_id();
+        self.ip_conn_count
+            .entry(connection.addr.ip())
+            .or_insert_with(|| AtomicU64::new(0))
+            .fetch_add(1, Ordering::Relaxed);
         self.connections.insert(connection_id, connection);
         connection_id
     }
@@ -121,6 +149,13 @@ impl ConnectionManager {
         if let Some(mut connect) = self.connections.get_mut(&connect_id) {
             connect.set_heartbeat_time(time);
         }
+    }
+
+    pub fn ip_connection_count(&self, addr: &SocketAddr) -> u64 {
+        self.ip_conn_count
+            .get(&addr.ip())
+            .map(|r| r.load(Ordering::Relaxed))
+            .unwrap_or(0)
     }
 }
 
@@ -204,7 +239,18 @@ impl ConnectionManager {
     }
 
     pub async fn close_connect(&self, connection_id: u64) {
-        self.connections.remove(&connection_id);
+        if let Some((_, conn)) = self.connections.remove(&connection_id) {
+            let ip = conn.addr.ip();
+            match self.ip_conn_count.entry(ip) {
+                Entry::Occupied(entry) => {
+                    let prev = entry.get().fetch_sub(1, Ordering::Relaxed);
+                    if prev == 1 {
+                        entry.remove();
+                    }
+                }
+                Entry::Vacant(_) => {}
+            }
+        }
 
         if let Some((id, writer)) = self.tcp_write_list.remove(&connection_id) {
             match tokio::time::timeout(CLOSE_TIMEOUT, async {
@@ -298,5 +344,130 @@ impl ConnectionManager {
         for id in gc_ids {
             self.close_connect(id).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metadata_struct::connection::NetworkConnectionType;
+    use std::net::SocketAddr;
+
+    fn addr(s: &str) -> SocketAddr {
+        s.parse().unwrap()
+    }
+
+    fn new_conn(addr: &SocketAddr) -> NetworkConnection {
+        NetworkConnection::new(NetworkConnectionType::Tcp, *addr, None)
+    }
+
+    #[tokio::test]
+    async fn add_connection_tracks_ip_count() {
+        let cm = ConnectionManager::new();
+        let addr1 = addr("127.0.0.1:8080");
+        let conn = new_conn(&addr1);
+
+        cm.add_connection(conn);
+        assert_eq!(cm.ip_connection_count(&addr1), 1);
+    }
+
+    #[tokio::test]
+    async fn ip_connection_count_returns_zero_for_unknown_ip() {
+        let cm = ConnectionManager::new();
+        let addr = addr("127.0.0.1:8080");
+        assert_eq!(cm.ip_connection_count(&addr), 0);
+    }
+
+    #[tokio::test]
+    async fn multiple_connections_same_ip_increment_count() {
+        let cm = ConnectionManager::new();
+        let addr1 = addr("127.0.0.1:8080");
+
+        cm.add_connection(new_conn(&addr1));
+        cm.add_connection(new_conn(&addr1));
+        cm.add_connection(new_conn(&addr1));
+        assert_eq!(cm.ip_connection_count(&addr1), 3);
+    }
+
+    #[tokio::test]
+    async fn different_ips_tracked_independently() {
+        let cm = ConnectionManager::new();
+        let addr1 = addr("127.0.0.1:8080");
+        let addr2 = addr("192.168.1.1:9090");
+        let addr3 = addr("10.0.0.1:3000");
+
+        cm.add_connection(new_conn(&addr1));
+        cm.add_connection(new_conn(&addr1));
+        cm.add_connection(new_conn(&addr2));
+        cm.add_connection(new_conn(&addr3));
+        cm.add_connection(new_conn(&addr3));
+
+        assert_eq!(cm.ip_connection_count(&addr1), 2);
+        assert_eq!(cm.ip_connection_count(&addr2), 1);
+        assert_eq!(cm.ip_connection_count(&addr3), 2);
+    }
+
+    #[tokio::test]
+    async fn close_connect_decrements_ip_count() {
+        let cm = ConnectionManager::new();
+        let addr1 = addr("127.0.0.1:8080");
+
+        let id1 = cm.add_connection(new_conn(&addr1));
+        let id2 = cm.add_connection(new_conn(&addr1));
+        assert_eq!(cm.ip_connection_count(&addr1), 2);
+
+        cm.close_connect(id1).await;
+        assert_eq!(cm.ip_connection_count(&addr1), 1);
+        assert!(!cm.connections.contains_key(&id1));
+        assert!(cm.connections.contains_key(&id2));
+    }
+
+    #[tokio::test]
+    async fn close_connect_removes_ip_entry_when_count_reaches_zero() {
+        let cm = ConnectionManager::new();
+        let addr1 = addr("127.0.0.1:8080");
+
+        let id = cm.add_connection(new_conn(&addr1));
+        assert_eq!(cm.ip_connection_count(&addr1), 1);
+
+        cm.close_connect(id).await;
+        assert_eq!(cm.ip_connection_count(&addr1), 0);
+        assert!(!cm.ip_conn_count.contains_key(&addr1.ip()));
+    }
+
+    #[tokio::test]
+    async fn close_connect_on_unknown_id_does_not_panic() {
+        let cm = ConnectionManager::new();
+        cm.close_connect(99999).await;
+    }
+
+    #[tokio::test]
+    async fn close_all_connect_cleans_up_ip_counts() {
+        let cm = ConnectionManager::new();
+        let addr1 = addr("127.0.0.1:8080");
+        let addr2 = addr("192.168.1.1:9090");
+
+        cm.add_connection(new_conn(&addr1));
+        cm.add_connection(new_conn(&addr1));
+        cm.add_connection(new_conn(&addr2));
+
+        cm.close_all_connect().await;
+
+        assert_eq!(cm.ip_connection_count(&addr1), 0);
+        assert_eq!(cm.ip_connection_count(&addr2), 0);
+        assert_eq!(cm.connections.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn same_ip_different_ports_share_count() {
+        let cm = ConnectionManager::new();
+        let addr_a = addr("127.0.0.1:8080");
+        let addr_b = addr("127.0.0.1:9090");
+
+        cm.add_connection(new_conn(&addr_a));
+        cm.add_connection(new_conn(&addr_b));
+
+        assert_eq!(cm.ip_connection_count(&addr_a), 2);
+        assert_eq!(cm.ip_connection_count(&addr_b), 2);
     }
 }

--- a/src/common/network-server/src/common/tcp_acceptor.rs
+++ b/src/common/network-server/src/common/tcp_acceptor.rs
@@ -30,7 +30,7 @@ use tokio::sync::broadcast;
 use tokio::sync::mpsc::{self, Receiver};
 use tokio::{io, select};
 use tokio_util::codec::{FramedRead, FramedWrite};
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 pub struct TcpAcceptorContext {
     pub accept_thread_num: usize,
@@ -93,8 +93,7 @@ pub async fn acceptor_process(ctx: TcpAcceptorContext) {
                             Ok((stream, addr)) => {
                                 debug!("Accept {} connection:{:?}", network_type, addr);
                                 // check connection
-                                if let Err(e) = check_connection_limit(&row_global_limit_manager, &row_broker_cache, &connection_manager).await{
-                                    warn!("{}",e.to_string());
+                                if check_connection_limit(&row_global_limit_manager, &row_broker_cache, &connection_manager, &addr).await{
                                     continue;
                                 }
 

--- a/src/common/network-server/src/common/tls_acceptor.rs
+++ b/src/common/network-server/src/common/tls_acceptor.rs
@@ -40,7 +40,7 @@ use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tokio_rustls::rustls::ServerConfig;
 use tokio_rustls::TlsAcceptor;
 use tokio_util::codec::{FramedRead, FramedWrite};
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 pub struct TlsAcceptorContext {
     pub accept_thread_num: usize,
@@ -129,8 +129,7 @@ pub async fn acceptor_tls_process(ctx: TlsAcceptorContext) -> ResultCommonError 
                                 let read_frame_stream = FramedRead::new(r_stream, row_codec.clone());
                                 let write_frame_stream = FramedWrite::new(w_stream, row_codec.clone());
 
-                                if let Err(e) = check_connection_limit(&row_global_limit_manager, &row_broker_cache, &connection_manager).await{
-                                    warn!("{}",e.to_string());
+                                if check_connection_limit(&row_global_limit_manager, &row_broker_cache, &connection_manager, &addr).await{
                                     continue;
                                 }
 

--- a/src/common/network-server/src/common/tool.rs
+++ b/src/common/network-server/src/common/tool.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use crate::common::{
     channel::RequestChannel, connection_manager::ConnectionManager, packet::RequestPackage,
 };
 use broker_core::cache::NodeCacheManager;
-use common_base::error::common::CommonError;
 use common_metrics::mqtt::packets::record_packet_received_metrics;
 use metadata_struct::connection::{NetworkConnection, NetworkConnectionType};
 use protocol::{mqtt::common::MqttPacket, robust::RobustMQPacket};
@@ -71,14 +71,110 @@ pub async fn check_connection_limit(
     global_limit_manager: &Arc<GlobalRateLimiterManager>,
     node_cache: &Arc<NodeCacheManager>,
     connection_manager: &Arc<ConnectionManager>,
-) -> Result<bool, CommonError> {
-    // connection rate limit
-    global_limit_manager.network_connection_rate_limit().await?;
+    addr: &SocketAddr,
+) -> bool {
+    let _ = global_limit_manager.network_connection_rate_limit().await;
 
-    // connection count limit
     let limit = node_cache.get_cluster_config().cluster_limit;
+
+    // total connection count limit
     if connection_manager.connections.len() > limit.max_network_connection as usize {
-        return Ok(true);
+        return true;
     }
-    Ok(false)
+
+    // per-IP connection count limit
+    if connection_manager.ip_connection_count(addr) > limit.max_connection_per_ip {
+        return true;
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common_config::broker::default_broker_config;
+    use rate_limit::global::GlobalRateLimiterManager;
+    use std::net::SocketAddr;
+
+    fn addr(s: &str) -> SocketAddr {
+        s.parse().unwrap()
+    }
+
+    fn make_conn(addr: &SocketAddr) -> NetworkConnection {
+        NetworkConnection::new(NetworkConnectionType::Tcp, *addr, None)
+    }
+
+    #[tokio::test]
+    async fn check_connection_limit_per_ip_pass_when_under_limit() {
+        let limit_manager = Arc::new(GlobalRateLimiterManager::new(10000).unwrap());
+        let cache = Arc::new(NodeCacheManager::new(default_broker_config()));
+        let cm = Arc::new(ConnectionManager::new());
+        let client_addr = addr("127.0.0.1:8080");
+
+        cm.add_connection(make_conn(&client_addr));
+
+        let result = check_connection_limit(&limit_manager, &cache, &cm, &client_addr).await;
+        assert!(!result);
+    }
+
+    #[tokio::test]
+    async fn check_connection_limit_per_ip_rejects_when_over_limit() {
+        let limit_manager = Arc::new(GlobalRateLimiterManager::new(10000).unwrap());
+        let node_cache = Arc::new(NodeCacheManager::new(default_broker_config()));
+        let cm = Arc::new(ConnectionManager::new());
+        let client_addr = addr("127.0.0.1:8080");
+
+        for _ in 0..5001 {
+            cm.add_connection(make_conn(&client_addr));
+        }
+
+        let result = check_connection_limit(&limit_manager, &node_cache, &cm, &client_addr).await;
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn check_connection_limit_ok_when_no_prior_connections() {
+        let limit_manager = Arc::new(GlobalRateLimiterManager::new(10000).unwrap());
+        let node_cache = Arc::new(NodeCacheManager::new(default_broker_config()));
+        let cm = Arc::new(ConnectionManager::new());
+        let client_addr = addr("192.168.1.1:9090");
+
+        let result = check_connection_limit(&limit_manager, &node_cache, &cm, &client_addr).await;
+        assert!(!result);
+    }
+
+    #[tokio::test]
+    async fn check_connection_limit_per_ip_is_per_ip_not_port() {
+        let limit_manager = Arc::new(GlobalRateLimiterManager::new(10000).unwrap());
+        let node_cache = Arc::new(NodeCacheManager::new(default_broker_config()));
+        let cm = Arc::new(ConnectionManager::new());
+
+        let addr_a = addr("10.0.0.1:8080");
+        let addr_b = addr("10.0.0.1:9090");
+
+        for _ in 0..5001 {
+            cm.add_connection(make_conn(&addr_a));
+        }
+
+        let result = check_connection_limit(&limit_manager, &node_cache, &cm, &addr_b).await;
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn check_connection_limit_different_ips_independent() {
+        let limit_manager = Arc::new(GlobalRateLimiterManager::new(10000).unwrap());
+        let node_cache = Arc::new(NodeCacheManager::new(default_broker_config()));
+        let cm = Arc::new(ConnectionManager::new());
+
+        let addr_a = addr("10.0.0.1:8080");
+        let addr_b = addr("10.0.0.2:8080");
+
+        for _ in 0..5001 {
+            cm.add_connection(make_conn(&addr_a));
+        }
+
+        let result = check_connection_limit(&limit_manager, &node_cache, &cm, &addr_b).await;
+        assert!(!result);
+    }
 }

--- a/src/common/network-server/src/quic/acceptor.rs
+++ b/src/common/network-server/src/quic/acceptor.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use tokio::select;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc::{self, Receiver};
-use tracing::{debug, error, warn};
+use tracing::{debug, error};
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn acceptor_process(
@@ -76,8 +76,7 @@ pub(crate) async fn acceptor_process(
                                             let codec_write = QuicFramedWriteStream::new(w_stream, row_codec.clone());
                                             let codec_read = QuicFramedReadStream::new(r_stream, row_codec.clone());
 
-                                            if let Err(e) = check_connection_limit(&row_global_limit_manager, &row_broker_cache, &connection_manager).await{
-                                                warn!("{}",e.to_string());
+                                            if check_connection_limit(&row_global_limit_manager, &row_broker_cache, &connection_manager, &client_addr).await{
                                                 continue;
                                             }
 

--- a/src/common/network-server/src/websocket/server.rs
+++ b/src/common/network-server/src/websocket/server.rs
@@ -150,10 +150,14 @@ async fn handle_socket(
     let mut stop_rx = stop_sx.subscribe();
 
     let mut codec = RobustMQCodec::new();
-    if let Err(e) =
-        check_connection_limit(&global_limit_manager, &node_cache, &connection_manager).await
+    if check_connection_limit(
+        &global_limit_manager,
+        &node_cache,
+        &connection_manager,
+        &addr,
+    )
+    .await
     {
-        warn!("{}", e.to_string());
         return;
     }
 


### PR DESCRIPTION

## What's changed and what's your intention?

Add per-IP connection limit with atomic tracking to prevent abuse from a single source IP.

- Introduce `max_connection_per_ip` cluster config field (default 5000), with corresponding `default_max_connection_per_ip()` in `default.rs`.
- Track per-IP connection counts via `AtomicU64` entries in a `DashMap<IpAddr, AtomicU64>` on `ConnectionManager`, using the Entry API for atomic increment on `add_connection` and safe decrement/cleanup on `close_connect`.
- Refactor `check_connection_limit` signature: remove the fallible `Result<bool, CommonError>` return in favor of a plain `bool`, and require callers to pass a `SocketAddr` so per-IP limits can be evaluated alongside the existing total-connection cap.
- Update all acceptor sites (TCP, TLS, QUIC, WebSocket) to match the new `check_connection_limit` signature and drop the stale `warn!` error-logging path.
- Add cluster-limit default-value tests in `config.rs` and a full suite of connection-manager + limit-check tests covering add, close, close-all, per-IP cross-port aggregation, independent IP tracking, and limit enforcement.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

By submitting this pull request, you agree to the terms of the [Apache License 2.0](https://github.com/robustmq/robustmq/blob/main/LICENSE), the [LICENSE](https://github.com/robustmq/robustmq/blob/main/LICENSING.md), and the [Contributor License Agreement (CLA)](https://github.com/robustmq/robustmq/blob/main/CLA.md).

## Refer to a related PR or issue link

relate #1269
