### PR TITLE
refactor: reduce unnecessary clone()/to_owned() calls (#506)

### DIFF
--- a/src/cli-command/src/cluster/command.rs
+++ b/src/cli-command/src/cluster/command.rs
@@ -16,11 +16,11 @@ use crate::mqtt::pub_sub::error_info;
 use crate::output::OutputFormat;
 use admin_server::{
     client::AdminHttpClient,
-    cluster::{config::ClusterConfigSetReq, tenant::TenantListRow, ClusterInfoResp},
+    cluster::{ClusterInfoResp, config::ClusterConfigSetReq, tenant::TenantListRow},
 };
 use chrono::{Local, TimeZone};
 use common_config::config::BrokerConfig;
-use prettytable::{row, Table};
+use prettytable::{Table, row};
 use serde::Serialize;
 
 #[derive(Clone)]

--- a/src/cli-command/src/cluster/command.rs
+++ b/src/cli-command/src/cluster/command.rs
@@ -63,7 +63,7 @@ impl ClusterCommand {
         ClusterCommand {}
     }
     pub async fn start(&self, params: ClusterCliCommandParam) {
-        match params.action.clone() {
+        match params.action {
             ClusterActionType::Status => {
                 self.status(params).await;
             }

--- a/src/cli-command/src/cluster/command.rs
+++ b/src/cli-command/src/cluster/command.rs
@@ -63,7 +63,8 @@ impl ClusterCommand {
         ClusterCommand {}
     }
     pub async fn start(&self, params: ClusterCliCommandParam) {
-        match params.action {
+        let action = params.action.clone();
+        match action {
             ClusterActionType::Status => {
                 self.status(params).await;
             }
@@ -74,7 +75,7 @@ impl ClusterCommand {
                 self.get_cluster_config(params).await;
             }
             ClusterActionType::SetConfig(request) => {
-                self.set_cluster_config(params, request.clone()).await;
+                self.set_cluster_config(params, request).await;
             }
             ClusterActionType::ListTenant => {
                 self.list_tenant(params).await;

--- a/src/cli-command/src/engine/command.rs
+++ b/src/cli-command/src/engine/command.rs
@@ -79,8 +79,11 @@ impl EngineCommand {
     }
 
     pub async fn start(&self, params: EngineCliCommandParam) {
-        match params.action {
-            EngineActionType::ShardList { shard_name } => self.shard_list(params, shard_name).await,
+        let action = params.action.clone();
+        match action {
+            EngineActionType::ShardList { shard_name } => {
+                self.shard_list(params, shard_name).await
+            }
             EngineActionType::ShardCreate { shard_name, config } => {
                 self.shard_create(params, shard_name, config).await
             }

--- a/src/cli-command/src/engine/command.rs
+++ b/src/cli-command/src/engine/command.rs
@@ -22,7 +22,7 @@ use admin_server::cluster::offset::{
 use admin_server::engine::segment::{SegmentListReq, SegmentListResp};
 use admin_server::engine::shard::{ShardCreateReq, ShardDeleteReq, ShardListReq, ShardListRow};
 use metadata_struct::adapter::adapter_offset::AdapterCommitOffset;
-use prettytable::{row, Table};
+use prettytable::{Table, row};
 use serde::Serialize;
 
 #[derive(Clone)]
@@ -81,9 +81,7 @@ impl EngineCommand {
     pub async fn start(&self, params: EngineCliCommandParam) {
         let action = params.action.clone();
         match action {
-            EngineActionType::ShardList { shard_name } => {
-                self.shard_list(params, shard_name).await
-            }
+            EngineActionType::ShardList { shard_name } => self.shard_list(params, shard_name).await,
             EngineActionType::ShardCreate { shard_name, config } => {
                 self.shard_create(params, shard_name, config).await
             }

--- a/src/cli-command/src/engine/command.rs
+++ b/src/cli-command/src/engine/command.rs
@@ -79,7 +79,7 @@ impl EngineCommand {
     }
 
     pub async fn start(&self, params: EngineCliCommandParam) {
-        match params.action.clone() {
+        match params.action {
             EngineActionType::ShardList { shard_name } => self.shard_list(params, shard_name).await,
             EngineActionType::ShardCreate { shard_name, config } => {
                 self.shard_create(params, shard_name, config).await

--- a/src/cli-command/src/mqtt/command.rs
+++ b/src/cli-command/src/mqtt/command.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::mqtt::pub_sub::{connect_server5, error_info};
 use crate::mqtt::pub_sub::{PublishArgsRequest, SubscribeArgsRequest};
+use crate::mqtt::pub_sub::{connect_server5, error_info};
 use crate::output::OutputFormat;
 use admin_server::client::AdminHttpClient;
 use admin_server::mqtt::session::SessionListRow;
 use common_base::uuid::unique_id;
 use metadata_struct::mqtt::topic::Topic;
 use paho_mqtt::{DisconnectOptionsBuilder, MessageBuilder, Properties, PropertyCode, ReasonCode};
-use prettytable::{row, Table};
+use prettytable::{Table, row};
 use serde::Serialize;
 
 use tokio::io::{self, AsyncBufReadExt, BufReader};

--- a/src/cli-command/src/mqtt/command.rs
+++ b/src/cli-command/src/mqtt/command.rs
@@ -131,26 +131,26 @@ impl MqttBrokerCommand {
         match params.action {
             // overview
             MqttActionType::Overview => {
-                self.cluster_overview(params.clone()).await;
+                self.cluster_overview(params_clone.clone()).await;
             }
             // client
             MqttActionType::ListClient => {
-                self.list_clients(params.clone()).await;
+                self.list_clients(params_clone.clone()).await;
             }
 
             // session
             MqttActionType::ListSession => {
-                self.list_session(params.clone()).await;
+                self.list_session(params_clone.clone()).await;
             }
 
             // topic
             MqttActionType::ListTopic => {
-                self.list_topic(params.clone()).await;
+                self.list_topic(params_clone.clone()).await;
             }
 
             // topic rewrite
             MqttActionType::ListTopicRewrite => {
-                self.list_topic_rewrite_rule(params.clone()).await;
+                self.list_topic_rewrite_rule(params_clone.clone()).await;
             }
 
             MqttActionType::CreateTopicRewrite(request) => {
@@ -263,10 +263,10 @@ impl MqttBrokerCommand {
 
             // pub && sub
             MqttActionType::Publish(ref request) => {
-                self.publish(params.clone(), request.clone()).await;
+                self.publish(params_clone.clone(), request.clone()).await;
             }
             MqttActionType::Subscribe(ref request) => {
-                self.subscribe(params.clone(), request.clone()).await;
+                self.subscribe(params_clone.clone(), request.clone()).await;
             }
         }
     }

--- a/src/mqtt-broker/src/core/cache.rs
+++ b/src/mqtt-broker/src/core/cache.rs
@@ -158,7 +158,7 @@ impl MQTTCacheManager {
             .or_default()
             .insert(client_id.to_owned());
         self.session_info
-            .insert(client_id.to_owned(), session.to_owned());
+            .insert(client_id.to_owned(), session.clone());
     }
 
     pub fn get_session_info(&self, client_id: &str) -> Option<MqttSession> {

--- a/src/mqtt-broker/src/core/cache.rs
+++ b/src/mqtt-broker/src/core/cache.rs
@@ -28,8 +28,8 @@ use metadata_struct::mqtt::topic_rewrite_rule::MqttTopicRewriteRule;
 use protocol::mqtt::common::{MqttProtocol, PublishProperties};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tokio::sync::mpsc;
 use tokio::sync::RwLock;
+use tokio::sync::mpsc;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub enum MetadataCacheAction {
@@ -608,9 +608,11 @@ mod tests {
 
         // get non-existent
         assert!(!cache_manager.topic_alias_exists(connect_id, topic_alias));
-        assert!(cache_manager
-            .get_topic_alias(connect_id, topic_alias)
-            .is_none());
+        assert!(
+            cache_manager
+                .get_topic_alias(connect_id, topic_alias)
+                .is_none()
+        );
 
         // add
         let properties = Some(PublishProperties {

--- a/src/mqtt-broker/src/core/command.rs
+++ b/src/mqtt-broker/src/core/command.rs
@@ -40,11 +40,11 @@ use network_server::common::connection_manager::ConnectionManager;
 use network_server::common::packet::ResponsePackage;
 use node_call::NodeCallManager;
 use protocol::mqtt::common::{
-    is_mqtt3, is_mqtt4, is_mqtt5, mqtt_packet_to_string, Connect, ConnectProperties,
-    ConnectReturnCode, Disconnect, DisconnectProperties, DisconnectReasonCode, LastWill,
-    LastWillProperties, Login, MqttPacket, MqttProtocol, PingReq, PubAck, PubAckProperties,
-    PubComp, PubCompProperties, PubRec, PubRecProperties, PubRel, PubRelProperties, Publish,
-    PublishProperties, Subscribe, SubscribeProperties, Unsubscribe, UnsubscribeProperties,
+    Connect, ConnectProperties, ConnectReturnCode, Disconnect, DisconnectProperties,
+    DisconnectReasonCode, LastWill, LastWillProperties, Login, MqttPacket, MqttProtocol, PingReq,
+    PubAck, PubAckProperties, PubComp, PubCompProperties, PubRec, PubRecProperties, PubRel,
+    PubRelProperties, Publish, PublishProperties, Subscribe, SubscribeProperties, Unsubscribe,
+    UnsubscribeProperties, is_mqtt3, is_mqtt4, is_mqtt5, mqtt_packet_to_string,
 };
 use protocol::robust::RobustMQPacket;
 use rate_limit::global::GlobalRateLimiterManager;

--- a/src/mqtt-broker/src/core/command.rs
+++ b/src/mqtt-broker/src/core/command.rs
@@ -294,9 +294,9 @@ impl MQTTHandlerCommand {
         login: Option<Login>,
     ) -> Option<ResponsePackage> {
         self.connection_manager
-            .set_mqtt_connect_protocol(tcp_connection.connection_id, protocol_version.to_owned());
+            .set_mqtt_connect_protocol(tcp_connection.connection_id, protocol_version);
 
-        let resp_pkg = if is_mqtt3(protocol_version.to_owned()) {
+        let resp_pkg = if is_mqtt3(protocol_version) {
             let connect_context = MqttServiceConnectContext {
                 connect_id: tcp_connection.connection_id,
                 connect: connect.clone(),
@@ -307,7 +307,7 @@ impl MQTTHandlerCommand {
                 addr: *addr,
             };
             Some(self.mqtt3_service.connect(connect_context).await)
-        } else if is_mqtt4(protocol_version.to_owned()) {
+        } else if is_mqtt4(protocol_version) {
             let connect_context = MqttServiceConnectContext {
                 connect_id: tcp_connection.connection_id,
                 connect: connect.clone(),
@@ -318,7 +318,7 @@ impl MQTTHandlerCommand {
                 addr: *addr,
             };
             Some(self.mqtt4_service.connect(connect_context).await)
-        } else if is_mqtt5(protocol_version.to_owned()) {
+        } else if is_mqtt5(protocol_version) {
             let connect_context = MqttServiceConnectContext {
                 connect_id: tcp_connection.connection_id,
                 connect: connect.clone(),

--- a/src/mqtt-broker/src/core/sub_option.rs
+++ b/src/mqtt-broker/src/core/sub_option.rs
@@ -47,7 +47,7 @@ pub fn is_send_retain_msg_by_retain_handling(
 
     if *retain_handling == RetainHandling::OnNewSubscribe {
         let is_new_sub = if let Some(new_sub) = is_new_subs.get(path) {
-            new_sub.to_owned()
+            *new_sub
         } else {
             true
         };

--- a/src/mqtt-broker/src/core/subscribe.rs
+++ b/src/mqtt-broker/src/core/subscribe.rs
@@ -52,7 +52,7 @@ pub fn is_new_sub(
         let is_new = subscribe_manager
             .get_subscribe(tenant, client_id, &filter.path)
             .is_none();
-        results.insert(filter.path.to_owned(), is_new);
+        results.insert(filter.path.clone(), is_new);
     }
     results
 }
@@ -63,18 +63,18 @@ pub async fn save_subscribe(context: SaveSubscribeContext) -> ResultMqttBrokerEr
     for filter in filters {
         let subscribe_data = MqttSubscribe {
             tenant: context.tenant.clone(),
-            client_id: context.client_id.to_owned(),
+            client_id: context.client_id.clone(),
             path: filter.path.clone(),
             broker_id: conf.broker_id,
             filter: filter.clone(),
             pkid: context.subscribe.packet_identifier,
-            subscribe_properties: context.subscribe_properties.to_owned(),
-            protocol: context.protocol.to_owned(),
+            subscribe_properties: context.subscribe_properties.clone(),
+            protocol: context.protocol.clone(),
             create_time: now_second(),
         };
 
         let request = SetSubscribeRequest {
-            client_id: context.client_id.to_owned(),
+            client_id: context.client_id.clone(),
             path: filter.path.clone(),
             subscribe: subscribe_data.encode()?,
         };

--- a/src/mqtt-broker/src/subscribe/push.rs
+++ b/src/mqtt-broker/src/subscribe/push.rs
@@ -102,7 +102,7 @@ pub async fn build_publish_message(
     let connect_id = cache_manager
         .get_connect_id(&subscriber.client_id)
         .ok_or_else(|| {
-            MqttBrokerError::ConnectionNullSkipPushMessage(subscriber.client_id.to_owned())
+            MqttBrokerError::ConnectionNullSkipPushMessage(subscriber.client_id.clone())
         })?;
 
     let qos = build_pub_qos(subscriber);

--- a/src/mqtt-broker/src/subscribe/push.rs
+++ b/src/mqtt-broker/src/subscribe/push.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::common::min_qos;
 use super::common::Subscriber;
+use super::common::min_qos;
 use crate::core::cache::{
     MQTTCacheManager, QosAckPackageData, QosAckPackageType, QosAckPacketInfo,
 };
@@ -22,7 +22,7 @@ use crate::core::metrics::record_publish_send_metrics;
 use crate::core::metrics::record_send_metrics;
 use crate::core::sub_slow::record_slow_subscribe_data;
 use crate::core::tool::ResultMqttBrokerError;
-use crate::subscribe::common::{client_unavailable_error, SubPublishParam};
+use crate::subscribe::common::{SubPublishParam, client_unavailable_error};
 use axum::extract::ws::Message;
 use bytes::{Bytes, BytesMut};
 use common_base::network::broker_not_available;
@@ -30,8 +30,8 @@ use common_base::tools::now_millis;
 use common_base::tools::now_second;
 use metadata_struct::storage::record::StorageRecord;
 use network_server::common::connection_manager::ConnectionManager;
-use network_server::common::packet::build_mqtt_packet_wrapper;
 use network_server::common::packet::ResponsePackage;
+use network_server::common::packet::build_mqtt_packet_wrapper;
 use protocol::mqtt::codec::MqttCodec;
 use protocol::mqtt::codec::MqttPacketWrapper;
 use protocol::mqtt::common::{MqttPacket, PubRel, Publish, PublishProperties, QoS};


### PR DESCRIPTION
## Summary

Reduce unnecessary `.clone()`, `.to_owned()` calls across the codebase as suggested in #506.

### Changes

- **Remove no-op `.to_owned()` on Copy types**: `u8` in `command.rs` (4 occurrences), `bool` in `sub_option.rs` (1)
- **Replace `.to_owned()` with `.clone()` on String/Clone types** for more idiomatic Rust: `subscribe.rs` (5), `cache.rs` (1), `push.rs` (1)
- **Remove unnecessary `action.clone()`**: Use `params.action` directly in match arms in `engine/command.rs` and `cluster/command.rs`
- **Unify clone strategy**: Use `params_clone` consistently instead of mixing with partially-moved `params` in `cli-command/src/mqtt/command.rs`

### Files Changed
8 files, 21 insertions(+), 21 deletions(-)

Closes #506