### PR TITLE
fix(mqtt): correct publish QoS reason code mapping (#1734)

### DIFF
--- a/src/mqtt-broker/src/core/error.rs
+++ b/src/mqtt-broker/src/core/error.rs
@@ -207,6 +207,9 @@ pub enum MqttBrokerError {
     #[error("Tenant [{0}] does not exist.")]
     TenantNotFound(String),
 
+    #[error("Schema validation failed for topic {0}: {1}")]
+    SchemaValidationFailed(String, String),
+
     #[error("ACL authentication failed. Access denied for topic: {0}")]
     NotAclAuth(String),
 

--- a/src/mqtt-broker/src/mqtt/publish.rs
+++ b/src/mqtt-broker/src/mqtt/publish.rs
@@ -77,6 +77,10 @@ impl MqttService {
                     MqttBrokerError::NotAclAuth(_) | MqttBrokerError::NotBlacklistAuth => {
                         (PubRecReason::NotAuthorized, PubAckReason::NotAuthorized)
                     }
+                    MqttBrokerError::SchemaValidationFailed(_, _) => (
+                        PubRecReason::PayloadFormatInvalid,
+                        PubAckReason::PayloadFormatInvalid,
+                    ),
                     _ => (
                         PubRecReason::UnspecifiedError,
                         PubAckReason::UnspecifiedError,
@@ -193,10 +197,10 @@ impl MqttService {
                 self.schema_manager
                     .validate(&connection.tenant, &topic_name, &publish.payload)?;
             if !valid {
-                return Err(MqttBrokerError::CommonError(format!(
-                    "Payload does not match schema for topic {}",
-                    topic_name
-                )));
+                return Err(MqttBrokerError::SchemaValidationFailed(
+                    topic_name,
+                    "Payload does not match schema".to_string(),
+                ));
             }
         }
 
@@ -561,8 +565,8 @@ async fn publish_validator(
     ) as usize;
     if publish.payload.len() > max_packet_size {
         return Some((
-            PubRecReason::PayloadFormatInvalid,
-            PubAckReason::PayloadFormatInvalid,
+            PubRecReason::QuotaExceeded,
+            PubAckReason::QuotaExceeded,
             MqttBrokerError::PacketLengthError(max_packet_size, publish.payload.len()).to_string(),
         ));
     }
@@ -711,8 +715,8 @@ mod tests {
         let result = publish_validator(&cache_manager, &connection, &publish, &None).await;
         assert!(result.is_some());
         let (reason_rec, reason_ack, _) = result.unwrap();
-        assert_eq!(reason_rec, PubRecReason::PayloadFormatInvalid);
-        assert_eq!(reason_ack, PubAckReason::PayloadFormatInvalid);
+        assert_eq!(reason_rec, PubRecReason::QuotaExceeded);
+        assert_eq!(reason_ack, PubAckReason::QuotaExceeded);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What's changed and what's your intention?

Fix two incorrect QoS reason code mappings in the `publish` flow:

### 1. Schema validation failure → PayloadFormatInvalid (was UnspecifiedError)

When schema validation fails, `process_publish0` returns a generic `CommonError`, which upstream `publish` maps to `UnspecifiedError`. Clients cannot distinguish schema validation failures from internal errors.

**Fix**:
- Add `MqttBrokerError::SchemaValidationFailed` variant (`error.rs`)
- Return this error from `process_publish0` on schema validation failure
- Map it to `PubRecReason::PayloadFormatInvalid` / `PubAckReason::PayloadFormatInvalid` in `publish`

### 2. Payload too large → QuotaExceeded (was PayloadFormatInvalid)

`publish_validator` returns `PayloadFormatInvalid` for oversized payloads, but MQTT 5.0 spec requires `QuotaExceeded` (0x97).

**Fix**:
- Change reason code to `QuotaExceeded` for this scenario
- Update `test_payload_too_large` assertions accordingly

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR does not require documentation updates.

## Refer to a related PR or issue link

Closes #1734
Closes #1733