### PR TITLE
fix(mqtt): preserve shared subscription topic filters

### DIFF
--- a/src/mqtt-broker/src/core/sub_share.rs
+++ b/src/mqtt-broker/src/core/sub_share.rs
@@ -26,19 +26,27 @@ pub fn is_mqtt_share_subscribe(path: &str) -> bool {
 }
 
 pub fn decode_share_info(path: &str) -> (String, String) {
-    let parts: Vec<&str> = path.split('/').collect();
-
-    if parts.len() < 3 || parts[0] != "$share" {
+    let mut parts = path.splitn(3, '/');
+    if parts.next() != Some(SHARE_SUB_PREFIX) {
         return (String::new(), String::new());
     }
 
-    let group_name = parts[1].to_string();
-    let topic_path = format!("/{}", parts[2..].join("/"));
-    (group_name, topic_path)
+    let Some(group_name) = parts.next() else {
+        return (String::new(), String::new());
+    };
+    let Some(topic_filter) = parts.next() else {
+        return (String::new(), String::new());
+    };
+
+    (group_name.to_string(), topic_filter.to_string())
 }
 
+/// Build the stable share-group key as `<group>/<topic-filter>`.
+///
+/// The separator is explicit because `decode_share_info` preserves whether the
+/// MQTT topic filter itself starts with `/`.
 pub fn full_group_name(group_name: &str, sub_name: &str) -> String {
-    format!("{group_name}{sub_name}")
+    format!("{group_name}/{sub_name}")
 }
 
 pub async fn is_share_sub_leader(
@@ -106,14 +114,18 @@ mod tests {
     fn test_decode_share_info() {
         assert_eq!(
             decode_share_info("$share/consumer1/sport/tennis/+"),
-            ("consumer1".to_string(), "/sport/tennis/+".to_string())
+            ("consumer1".to_string(), "sport/tennis/+".to_string())
         );
         assert_eq!(
             decode_share_info("$share/group/a/b/c"),
-            ("group".to_string(), "/a/b/c".to_string())
+            ("group".to_string(), "a/b/c".to_string())
         );
         assert_eq!(
             decode_share_info("$share/g/t"),
+            ("g".to_string(), "t".to_string())
+        );
+        assert_eq!(
+            decode_share_info("$share/g//t"),
             ("g".to_string(), "/t".to_string())
         );
         assert_eq!(decode_share_info(""), ("".to_string(), "".to_string()));
@@ -129,6 +141,12 @@ mod tests {
             decode_share_info("share/g/t"),
             ("".to_string(), "".to_string())
         );
+    }
+
+    #[test]
+    fn test_full_group_name() {
+        assert_eq!(full_group_name("g", "a/b"), "g/a/b");
+        assert_eq!(full_group_name("g", "/a/b"), "g//a/b");
     }
 
     #[test]

--- a/src/mqtt-broker/src/subscribe/common.rs
+++ b/src/mqtt-broker/src/subscribe/common.rs
@@ -253,19 +253,20 @@ mod tests {
             ("/sensor/+/temperature", "/sensor/temperature3", false),
             ("/sensor/+", "/sensor/temperature3", true),
             ("/sensor/#", "/sensor/temperature3/tmpq", true),
-            ("$share/group/topic/test", "/topic/test", true),
+            ("$share/group/topic/test", "topic/test", true),
             (
                 "$share/group/sensor/+/temperature",
-                "/sensor/1/temperature",
+                "sensor/1/temperature",
                 true,
             ),
             (
                 "$share/group/sensor/+/temperature",
-                "/sensor/1/2/temp",
+                "sensor/1/2/temp",
                 false,
             ),
-            ("$share/group/sensor/+", "/sensor/temperature3", true),
-            ("$share/group/sensor/#", "/sensor/temperature3/tmpq", true),
+            ("$share/group/sensor/+", "sensor/temperature3", true),
+            ("$share/group/sensor/#", "sensor/temperature3/tmpq", true),
+            ("$share/group//sensor/+", "/sensor/temperature3", true),
             ("y/+/z/#", "y/a/z/b", true),
         ];
 
@@ -291,25 +292,25 @@ mod tests {
 
         let (group_name, topic_name) = decode_share_info(&sub1);
         assert_eq!(group_name, "consumer1".to_string());
-        assert_eq!(topic_name, "/sport/tennis/+".to_string());
+        assert_eq!(topic_name, "sport/tennis/+".to_string());
 
         let (group_name, topic_name) = decode_share_info(&sub2);
         assert_eq!(group_name, "consumer2".to_string());
-        assert_eq!(topic_name, "/sport/tennis/+".to_string());
+        assert_eq!(topic_name, "sport/tennis/+".to_string());
 
         let (group_name, topic_name) = decode_share_info(&sub3);
         assert_eq!(group_name, "consumer1".to_string());
-        assert_eq!(topic_name, "/sport/#".to_string());
+        assert_eq!(topic_name, "sport/#".to_string());
 
         let (group_name, topic_name) = decode_share_info(&sub4);
         assert_eq!(group_name, "comsumer1".to_string());
-        assert_eq!(topic_name, "/finance/#".to_string());
+        assert_eq!(topic_name, "finance/#".to_string());
     }
 
     #[tokio::test]
     async fn decode_sub_path_sub_test() {
         let path = "$share/group1/topic1/1".to_string();
-        assert_eq!(decode_sub_path(&path), "/topic1/1".to_string());
+        assert_eq!(decode_sub_path(&path), "topic1/1".to_string());
 
         let path = "/topic1/1".to_string();
         assert_eq!(decode_sub_path(&path), "/topic1/1".to_string());

--- a/tests/tests/mqtt/protocol/share_sub_test.rs
+++ b/tests/tests/mqtt/protocol/share_sub_test.rs
@@ -83,17 +83,17 @@ mod tests {
 
     #[tokio::test]
     async fn share_single_subscribe_test() {
-        let topic = format!("/share_single_subscribe_test/{}", unique_id());
+        let topic = format!("share_single_subscribe_test/{}", unique_id());
         let group_name = unique_id();
-        let sub_topic = format!("$share/{group_name}{topic}");
+        let sub_topic = format!("$share/{group_name}/{topic}");
         single_test(topic, sub_topic, group_name, "share_single_subscribe_test").await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     async fn share_multi_subscribe_test() {
-        let topic = format!("/share_multi_subscribe_test/{}", unique_id());
+        let topic = format!("share_multi_subscribe_test/{}", unique_id());
         let group_name = unique_id();
-        let sub_topic = format!("$share/{group_name}{topic}");
+        let sub_topic = format!("$share/{group_name}/{topic}");
         multi_test(
             topic.clone(),
             sub_topic.clone(),


### PR DESCRIPTION
## What changed

- preserve the MQTT topic filter exactly as encoded after `$share/<group>/`
- make the `/` separator in the internal full share-group name explicit
- cover both standard filters (`foo/bar`) and filters that intentionally start with `/`
- update shared-subscription protocol tests to use the standard no-leading-slash form

## Why

`decode_share_info` previously added a leading `/` to every shared topic filter. Standard SDK subscriptions such as `$share/group/foo/bar` therefore became `/foo/bar` internally and did not match publications to `foo/bar`.

The full share-group name previously depended on that injected slash. It now inserts its structural separator explicitly, preserving existing key shapes while keeping the real topic filter unchanged.

## Validation

- `cargo test -p mqtt-broker`: 109 passed, 1 ignored
- `cargo test -p mqtt-broker core::sub_share`: 3 passed
- `cargo test -p mqtt-broker subscribe::common::tests::`: 8 passed, 1 ignored
- `cargo fmt --all -- --check`
- `git diff --check`
- MQTT 5 end-to-end against a local RobustMQ broker:
  - mqtt.js 5.15.2: 30/30 messages, two same-group consumers split 15/15; independent group received 30/30
  - paho-mqtt Python 2.1.0: 30/30, split 15/15; independent group received 30/30
  - eclipse/paho.golang v0.23.0: 30/30, split 15/15; independent group received 30/30
  - leading-slash topic filter compatibility: 30/30, split 15/15
  - ordinary subscription control: 30/30 while the shared group split 15/15

`cargo test -p robustmq-test --no-run` was also attempted, but its unrelated `ort-sys` build step requires downloading ONNX Runtime and network access was unavailable in the test sandbox.
