### PR TITLE
fix(meta-service): fsync raft log and vote writes before reporting success

### DIFF
--- a/src/meta-service/src/raft/store/log.rs
+++ b/src/meta-service/src/raft/store/log.rs
@@ -23,7 +23,7 @@ use openraft::{
     AnyError, Entry, LogId, LogState, OptionalSend, RaftLogReader, StorageError, StorageIOError,
     Vote,
 };
-use rocksdb::{BoundColumnFamily, Direction, IteratorMode, ReadOptions, WriteBatch, DB};
+use rocksdb::{BoundColumnFamily, Direction, IteratorMode, ReadOptions, WriteBatch, WriteOptions, DB};
 use rocksdb_engine::storage::family::DB_COLUMN_FAMILY_META_RAFT;
 use std::fmt::Debug;
 use std::ops::RangeBounds;
@@ -58,6 +58,21 @@ fn sto_read_msg(msg: String) -> StorageError<NodeId> {
     StorageIOError::<NodeId>::read(AnyError::error(msg)).into()
 }
 
+/// Write options that fsync the WAL before the write returns.
+///
+/// Openraft requires every durable-state write to be on disk before the
+/// storage method reports success: `save_vote` "must be persisted on disk
+/// before returning", and the entries handed to `append` must be on disk
+/// before `LogFlushed::log_io_completed` fires. RocksDB's default write
+/// options only put the record in the OS page cache, which a machine crash or
+/// kernel panic discards — losing a vote lets a node vote twice in one term,
+/// and losing acknowledged entries drops already-committed data.
+fn sync_write_opts() -> WriteOptions {
+    let mut opts = WriteOptions::default();
+    opts.set_sync(true);
+    opts
+}
+
 #[derive(Debug, Clone)]
 pub struct LogStore {
     pub machine: String,
@@ -89,7 +104,12 @@ impl LogStore {
     fn set_last_purged_(&self, log_id: LogId<NodeId>) -> StorageResult<()> {
         let data = serialize(&log_id).map_err(|e| sto_write(&*e))?;
         self.db
-            .put_cf(&self.store(), key_last_purged_log_id(&self.machine), data)
+            .put_cf_opt(
+                &self.store(),
+                key_last_purged_log_id(&self.machine),
+                data,
+                &sync_write_opts(),
+            )
             .map_err(|e| sto_write(&e))?;
         Ok(())
     }
@@ -99,13 +119,22 @@ impl LogStore {
             Some(log_id) => {
                 let data = serialize(log_id).map_err(|e| sto_write(&*e))?;
                 self.db
-                    .put_cf(&self.store(), key_committed(&self.machine), data)
+                    .put_cf_opt(
+                        &self.store(),
+                        key_committed(&self.machine),
+                        data,
+                        &sync_write_opts(),
+                    )
                     .map_err(|e| sto_write(&e))?;
                 Ok(())
             }
             None => {
                 self.db
-                    .delete_cf(&self.store(), key_committed(&self.machine))
+                    .delete_cf_opt(
+                        &self.store(),
+                        key_committed(&self.machine),
+                        &sync_write_opts(),
+                    )
                     .map_err(|e| sto_write(&e))?;
                 Ok(())
             }
@@ -127,7 +156,12 @@ impl LogStore {
     fn set_vote_(&self, vote: &Vote<NodeId>) -> StorageResult<()> {
         let data = serialize(vote).map_err(|e| sto_write_vote(&*e))?;
         self.db
-            .put_cf(&self.store(), key_vote(&self.machine), data)
+            .put_cf_opt(
+                &self.store(),
+                key_vote(&self.machine),
+                data,
+                &sync_write_opts(),
+            )
             .map_err(|e| sto_write_vote(&e))?;
         Ok(())
     }
@@ -261,7 +295,9 @@ impl RaftLogStorage<TypeConfig> for LogStore {
         }
 
         if has_entries {
-            self.db.write(batch).map_err(|e| sto_write_logs(&e))?;
+            self.db
+                .write_opt(batch, &sync_write_opts())
+                .map_err(|e| sto_write_logs(&e))?;
         }
 
         let batch_ms = batch_start.elapsed().as_secs_f64() * 1000.0;
@@ -275,7 +311,7 @@ impl RaftLogStorage<TypeConfig> for LogStore {
         let from = key_raft_log(&self.machine, log_id.index);
         let to = key_raft_log(&self.machine, u64::MAX);
         self.db
-            .delete_range_cf(&self.store(), &from, &to)
+            .delete_range_cf_opt(&self.store(), &from, &to, &sync_write_opts())
             .map_err(|e| sto_write_logs(&e))?;
         Ok(())
     }
@@ -285,7 +321,7 @@ impl RaftLogStorage<TypeConfig> for LogStore {
         let to = key_raft_log(&self.machine, log_id.index + 1);
 
         self.db
-            .delete_range_cf(&self.store(), &from, &to)
+            .delete_range_cf_opt(&self.store(), &from, &to, &sync_write_opts())
             .map_err(|e| sto_write_logs(&e))?;
 
         self.set_last_purged_(log_id)?;


### PR DESCRIPTION
## What's changed and what's your intention?

The raft log store (`src/meta-service/src/raft/store/log.rs`) writes to RocksDB with the default `WriteOptions`, which return once the record is in the OS page cache. Openraft treats a successful storage call as *"this data is on disk"* and advances commit on that basis — [`RaftLogStorage::save_vote`](https://docs.rs/openraft/0.9/openraft/storage/trait.RaftLogStorage.html#tymethod.save_vote) is documented as *"The vote must be persisted on disk before returning"*, and entries handed to `append` must be on disk before `LogFlushed::log_io_completed` fires.

So the guarantee openraft is built on does not currently hold. Two concrete failure modes on power loss or kernel panic (a clean shutdown is fine — RocksDB flushes on close):

1. **Double vote in one term.** `save_vote` returns `Ok` while `vote_<machine>` is still in the page cache. After the crash the node reads back an older vote and grants its vote again in the same term. Two candidates can then each collect a majority and both become leader for that term.
2. **Loss of acknowledged data.** The leader returns success to the client once a quorum — including this node — reports the append durable. If several nodes lose power together (same rack, rolling restart of a whole cluster), entries that were reported committed are simply gone.

Neither shows up in normal testing: everything works on a graceful shutdown, and this node's own tests pass.

### How the PR works

Adds a `sync_write_opts()` helper returning `WriteOptions` with `set_sync(true)`, and routes every durable-state write in the raft log CF through it:

| write | before | after |
|---|---|---|
| `set_vote_` | `put_cf` | `put_cf_opt` |
| `set_committed_` | `put_cf` / `delete_cf` | `put_cf_opt` / `delete_cf_opt` |
| `set_last_purged_` | `put_cf` | `put_cf_opt` |
| `append` | `db.write(batch)` | `db.write_opt(batch, …)` |
| `truncate` | `delete_range_cf` | `delete_range_cf_opt` |
| `purge` | `delete_range_cf` | `delete_range_cf_opt` |

Notes on the two that may look optional:

- **`truncate` / `purge`** need durability too. If a crash loses a truncation, the conflicting tail reappears and `get_log_state` reports a `last_log_id` this node never accepted from the current leader.
- **`append`** pays **one fsync per batch, not per entry** — openraft already batches entries, and one fsync per append batch is the normal cost of a raft log. If throughput on slow disks becomes a concern, the follow-up is group commit (openraft explicitly allows `log_io_completed` to be called *after* `append` returns, so several batches can share one fsync), not dropping the fsync.

Nothing outside `DB_COLUMN_FAMILY_META_RAFT` is touched, so the MQTT/journal data paths are unaffected.

### Related: `loosen-follower-log-revert`

`src/meta-service/Cargo.toml` enables openraft's `loosen-follower-log-revert` feature. That feature exists to *silence* the safety check that fires when a follower's log goes backwards — which is exactly the symptom missing fsync produces. Worth re-testing whether it is still needed once this lands; if the answer is no, removing it restores a useful safety net. Happy to do that in a separate PR.

Verified with `cargo check -p meta-service`.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

Durability is not observable from inside the process, so there is no unit test that can assert it — a test would have to kill the machine, not the process. The change is instead scoped so that every write to the raft CF goes through one helper.

By submitting this pull request, you agree to the terms of the [Apache License 2.0](https://github.com/robustmq/robustmq/blob/main/LICENSE), the [LICENSE](https://github.com/robustmq/robustmq/blob/main/LICENSING.md), and the [Contributor License Agreement (CLA)](https://github.com/robustmq/robustmq/blob/main/CLA.md).

## Refer to a related PR or issue link

Found while reviewing how projects use openraft (I maintain [openraft](https://github.com/databendlabs/openraft)). No existing issue — happy to open one if you'd prefer that first.