### PR TITLE
fix: expose /health/* at root without authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
  "storage-engine",
  "thiserror 2.0.18",
  "tokio",
+ "tower 0.5.3",
  "tower-http 0.6.8",
  "tracing",
  "validator",

--- a/src/admin-server/Cargo.toml
+++ b/src/admin-server/Cargo.toml
@@ -59,3 +59,4 @@ pprof.workspace = true
 
 [dev-dependencies]
 mockall.workspace = true
+tower = { workspace = true, features = ["util"] }

--- a/src/admin-server/src/client.rs
+++ b/src/admin-server/src/client.rs
@@ -575,7 +575,8 @@ impl AdminHttpClient {
 
     /// Get cluster health status
     pub async fn get_cluster_healthy(&self) -> Result<String, HttpClientError> {
-        self.get_raw(&api_path(HEALTH_CLUSTER_PATH)).await
+        // Health checks are mounted at `/health/*` (not under `/api`).
+        self.get_raw(HEALTH_CLUSTER_PATH).await
     }
 
     /// Get cluster status / info

--- a/src/admin-server/src/path.rs
+++ b/src/admin-server/src/path.rs
@@ -177,5 +177,12 @@ mod tests {
         // Verify paths don't already contain /api prefix
         assert!(!MQTT_OVERVIEW_PATH.starts_with("/api"));
         assert!(!CLUSTER_CONFIG_GET_PATH.starts_with("/api"));
+        assert!(!HEALTH_READY_PATH.starts_with("/api"));
+        assert!(!HEALTH_NODE_PATH.starts_with("/api"));
+        assert!(!HEALTH_CLUSTER_PATH.starts_with("/api"));
+
+        assert_eq!(HEALTH_READY_PATH, "/health/ready");
+        assert_eq!(HEALTH_NODE_PATH, "/health/node");
+        assert_eq!(HEALTH_CLUSTER_PATH, "/health/cluster");
     }
 }

--- a/src/admin-server/src/server.rs
+++ b/src/admin-server/src/server.rs
@@ -96,8 +96,12 @@ impl AdminServer {
         // static fallback so the SPA's index.html (login page) is served.
         // The cluster info JSON previously exposed on `/` is still available
         // at `/api/info`.
+        //
+        // Health checks are mounted on the root router (not under `/api`) so
+        // Kubernetes probes can hit `/health/*` without a Bearer token.
         let route = Router::new()
             .merge(mcp_route())
+            .merge(health_route())
             .route(DEBUG_PPROF_FLAMEGRAPH_PATH, get(pprof_flamegraph))
             .route(METRICS_PATH, get(|| async { dump_metrics() }))
             .merge(auth_router())
@@ -141,9 +145,6 @@ impl AdminServer {
 
     fn common_route(&self) -> Router<Arc<HttpState>> {
         Router::new()
-            .route(HEALTH_READY_PATH, get(health_ready))
-            .route(HEALTH_NODE_PATH, get(health_node))
-            .route(HEALTH_CLUSTER_PATH, get(health_cluster))
             // config
             .route(CLUSTER_CONFIG_SET_PATH, post(cluster_config_set))
             .route(CLUSTER_CONFIG_GET_PATH, get(cluster_config_get))
@@ -272,6 +273,17 @@ impl AdminServer {
     fn kafka_route(&self) -> Router<Arc<HttpState>> {
         Router::new()
     }
+}
+
+/// Public health endpoints served at `/health/*` (no `/api` prefix, no auth).
+fn health_route<S>() -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    Router::new()
+        .route(HEALTH_READY_PATH, get(health_ready))
+        .route(HEALTH_NODE_PATH, get(health_node))
+        .route(HEALTH_CLUSTER_PATH, get(health_cluster))
 }
 
 async fn rate_limit_middleware(
@@ -512,5 +524,50 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-real-ip", "192.168.1.200".parse().unwrap());
         assert_eq!(extract_client_ip(&headers, socket_addr), "192.168.1.200");
+    }
+
+    #[tokio::test]
+    async fn health_endpoints_are_public_at_root() {
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use common_config::broker::{default_broker_config, init_broker_conf_by_config};
+        use tower::ServiceExt;
+
+        init_broker_conf_by_config(default_broker_config());
+
+        let app = health_route::<()>();
+        for path in [HEALTH_READY_PATH, HEALTH_NODE_PATH, HEALTH_CLUSTER_PATH] {
+            let response = app
+                .clone()
+                .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert!(
+                response.status() == StatusCode::OK
+                    || response.status() == StatusCode::SERVICE_UNAVAILABLE,
+                "unexpected status {} for {}",
+                response.status(),
+                path
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn health_endpoints_are_not_nested_under_api() {
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use tower::ServiceExt;
+
+        let app = health_route::<()>();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/health/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

Mount `GET /health/ready`, `/health/node`, and `/health/cluster` on the Admin HTTP root router (next to `/metrics`) so they are no longer nested under `/api` and no longer go through `auth_middleware`. This matches the documented probe paths and the AUTH exempt-path list.

Also point `AdminHttpClient::get_cluster_healthy` at `/health/cluster` instead of `/api/health/cluster`.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR does not require documentation updates.

By submitting this pull request, you agree to the terms of the [Apache License 2.0](https://github.com/robustmq/robustmq/blob/main/LICENSE), the [LICENSE](https://github.com/robustmq/robustmq/blob/main/LICENSING.md), and the [Contributor License Agreement (CLA)](https://github.com/robustmq/robustmq/blob/main/CLA.md).

## Refer to a related PR or issue link

close #2034


Made with [Cursor](https://cursor.com)