### PR TITLE
fix: give storage_runtime.data_path a real default so a single node can start

### DIFF
--- a/config/server.toml
+++ b/config/server.toml
@@ -28,3 +28,9 @@ meta_addrs = { 1 = "127.0.0.1:1228" }
 [log]
 log_config = "./config/logger.toml"
 log_path = "./data/logs"
+
+# Data folders the storage engine writes segments into. Required whenever the
+# "engine" role is enabled -- a node registered without any storage folder
+# cannot host a shard replica.
+[storage_runtime]
+data_path = ["./data/engine"]

--- a/config/server.toml
+++ b/config/server.toml
@@ -28,9 +28,3 @@ meta_addrs = { 1 = "127.0.0.1:1228" }
 [log]
 log_config = "./config/logger.toml"
 log_path = "./data/logs"
-
-# Data folders the storage engine writes segments into. Required whenever the
-# "engine" role is enabled -- a node registered without any storage folder
-# cannot host a shard replica.
-[storage_runtime]
-data_path = ["./data/engine"]

--- a/docs/en/Configuration/BROKER.md
+++ b/docs/en/Configuration/BROKER.md
@@ -170,7 +170,7 @@ Journal storage engine runtime configuration.
 tcp_port = 1778
 max_segment_size = 1073741824
 io_thread_num = 8
-data_path = []
+data_path = ["./data/engine"]
 expire_scan_task_num = 10
 offset_enable_cache = true
 ```
@@ -180,7 +180,7 @@ offset_enable_cache = true
 | `tcp_port` | `u32` | `1778` | Storage engine TCP port |
 | `max_segment_size` | `u32` | `1073741824` (1 GB) | Maximum segment file size (bytes) |
 | `io_thread_num` | `u32` | `8` | IO processing thread count |
-| `data_path` | `array` | `[]` | Data storage path list |
+| `data_path` | `array` | `["./data/engine"]` | Data storage path list. Must not be empty when the `engine` role is enabled, otherwise the node cannot host any shard replica |
 | `expire_scan_task_num` | `usize` | `10` | Concurrent expired data scan tasks |
 | `offset_enable_cache` | `bool` | `true` | Whether to enable consumer offset caching |
 

--- a/docs/zh/Configuration/BROKER.md
+++ b/docs/zh/Configuration/BROKER.md
@@ -170,7 +170,7 @@ Journal 存储引擎运行时配置。
 tcp_port = 1778
 max_segment_size = 1073741824
 io_thread_num = 8
-data_path = []
+data_path = ["./data/engine"]
 expire_scan_task_num = 10
 offset_enable_cache = true
 ```
@@ -180,7 +180,7 @@ offset_enable_cache = true
 | `tcp_port` | `u32` | `1778` | 存储引擎 TCP 端口 |
 | `max_segment_size` | `u32` | `1073741824` (1 GB) | 单个 Segment 文件最大大小（字节） |
 | `io_thread_num` | `u32` | `8` | IO 处理线程数 |
-| `data_path` | `array` | `[]` | 数据存储路径列表 |
+| `data_path` | `array` | `["./data/engine"]` | 数据存储路径列表。启用 `engine` 角色时不能为空，否则该节点无法承载任何分片副本 |
 | `expire_scan_task_num` | `usize` | `10` | 过期数据扫描并发任务数 |
 | `offset_enable_cache` | `bool` | `true` | 是否启用消费 Offset 缓存 |
 

--- a/src/common/config/src/config.rs
+++ b/src/common/config/src/config.rs
@@ -38,16 +38,16 @@ use super::default::{
     default_receive_max, default_roles, default_runtime, default_schema_echo_log,
     default_schema_enable, default_schema_failed_operation, default_schema_log_level,
     default_schema_strategy, default_session_expiry_interval, default_slow_subscribe_delay_type,
-    default_slow_subscribe_record_time, default_storage_expire_scan_task_num,
-    default_storage_io_thread_num, default_storage_isr_maintain_interval_ms,
-    default_storage_max_segment_size, default_storage_metadata_reconcile_interval_ms,
-    default_storage_num_replica_fetchers, default_storage_offset_enable_cache,
-    default_storage_replica_fetch_backoff_ms, default_storage_replica_fetch_max_wait_ms,
-    default_storage_replica_fetch_min_bytes, default_storage_replica_lag_time_max_ms,
-    default_storage_tcp_port, default_system_monitor_cpu_watermark,
-    default_system_monitor_memory_watermark, default_system_monitor_topic_interval_ms,
-    default_tls_cert, default_tls_key, default_topic_alias_max, default_topic_partition_num,
-    default_topic_replica_num,
+    default_slow_subscribe_record_time, default_storage_data_path,
+    default_storage_expire_scan_task_num, default_storage_io_thread_num,
+    default_storage_isr_maintain_interval_ms, default_storage_max_segment_size,
+    default_storage_metadata_reconcile_interval_ms, default_storage_num_replica_fetchers,
+    default_storage_offset_enable_cache, default_storage_replica_fetch_backoff_ms,
+    default_storage_replica_fetch_max_wait_ms, default_storage_replica_fetch_min_bytes,
+    default_storage_replica_lag_time_max_ms, default_storage_tcp_port,
+    default_system_monitor_cpu_watermark, default_system_monitor_memory_watermark,
+    default_system_monitor_topic_interval_ms, default_tls_cert, default_tls_key,
+    default_topic_alias_max, default_topic_partition_num, default_topic_replica_num,
 };
 use crate::common::default_log;
 use crate::common::Log;
@@ -668,7 +668,7 @@ pub struct StorageRuntime {
     pub max_segment_size: u32,
     #[serde(default = "default_storage_io_thread_num")]
     pub io_thread_num: u32,
-    #[serde(default)]
+    #[serde(default = "default_storage_data_path")]
     pub data_path: Vec<String>,
     #[serde(default = "default_storage_offset_enable_cache")]
     pub offset_enable_cache: bool,
@@ -987,6 +987,29 @@ mod tests {
         assert_eq!(
             default_max_connection_per_ip(),
             ClusterLimit::default().max_connection_per_ip
+        );
+    }
+
+    // An engine node registered with an empty storage_fold is accepted by the
+    // meta service and only fails later, when a shard replica has to be placed
+    // on it (issue #2043). So data_path must fall back to a usable folder
+    // whether the whole section or just the key is missing.
+    #[test]
+    fn storage_data_path_defaults_and_overrides() {
+        let parse = |body: &str| {
+            toml::from_str::<BrokerConfig>(body)
+                .unwrap()
+                .storage_runtime
+        };
+
+        assert_eq!(parse("broker_id = 1").data_path, vec!["./data/engine"]);
+        assert_eq!(
+            parse("[storage_runtime]\ntcp_port = 1778").data_path,
+            vec!["./data/engine"]
+        );
+        assert_eq!(
+            parse("[storage_runtime]\ndata_path = [\"/mnt/d1\"]").data_path,
+            vec!["/mnt/d1"]
         );
     }
 }

--- a/src/common/config/src/config.rs
+++ b/src/common/config/src/config.rs
@@ -990,10 +990,6 @@ mod tests {
         );
     }
 
-    // An engine node registered with an empty storage_fold is accepted by the
-    // meta service and only fails later, when a shard replica has to be placed
-    // on it (issue #2043). So data_path must fall back to a usable folder
-    // whether the whole section or just the key is missing.
     #[test]
     fn storage_data_path_defaults_and_overrides() {
         let parse = |body: &str| {

--- a/src/common/config/src/default.rs
+++ b/src/common/config/src/default.rs
@@ -186,7 +186,7 @@ pub fn default_engine_runtime() -> StorageRuntime {
     StorageRuntime {
         tcp_port: 1778,
         max_segment_size: 1073741824,
-        data_path: vec![],
+        data_path: default_storage_data_path(),
         io_thread_num: 8,
         offset_enable_cache: true,
         expire_scan_task_num: 16,
@@ -357,6 +357,9 @@ pub fn default_storage_max_segment_size() -> u32 {
 }
 pub fn default_storage_io_thread_num() -> u32 {
     8
+}
+pub fn default_storage_data_path() -> Vec<String> {
+    vec!["./data/engine".to_string()]
 }
 pub fn default_storage_offset_enable_cache() -> bool {
     true

--- a/src/meta-service/src/core/cache.rs
+++ b/src/meta-service/src/core/cache.rs
@@ -202,11 +202,8 @@ impl MetaCacheManager {
         results
     }
 
-    /// Engine nodes that can actually hold a shard replica, i.e. the ones that
-    /// registered at least one storage folder. A folder-less node passes the
-    /// role check but is rejected later by `calc_node_fold`, so every replica
-    /// placement decision must be made against this list rather than
-    /// `get_engine_node_list`.
+    /// Engine nodes eligible for replica placement. A node with no storage
+    /// folder passes the role check but is rejected later by `calc_node_fold`.
     pub fn get_storage_ready_engine_node_ids(&self) -> Vec<u64> {
         self.node_list
             .iter()
@@ -390,9 +387,6 @@ mod tests {
         }
     }
 
-    // Replica placement must ignore engine nodes that registered no storage
-    // folder: they pass the role check but calc_node_fold rejects them, which
-    // would fail the whole allocation instead of just skipping the node.
     #[test]
     fn storage_ready_engine_nodes_skip_folderless_and_non_engine_nodes() {
         let cache_manager = MetaCacheManager::new(test_rocksdb_instance());

--- a/src/meta-service/src/core/cache.rs
+++ b/src/meta-service/src/core/cache.rs
@@ -202,6 +202,19 @@ impl MetaCacheManager {
         results
     }
 
+    /// Engine nodes that can actually hold a shard replica, i.e. the ones that
+    /// registered at least one storage folder. A folder-less node passes the
+    /// role check but is rejected later by `calc_node_fold`, so every replica
+    /// placement decision must be made against this list rather than
+    /// `get_engine_node_list`.
+    pub fn get_storage_ready_engine_node_ids(&self) -> Vec<u64> {
+        self.node_list
+            .iter()
+            .filter(|node| is_engine_node(&node.roles) && !node.storage_fold.is_empty())
+            .map(|node| node.node_id)
+            .collect()
+    }
+
     // Heartbeat
     pub fn report_broker_heart(&self, node_id: u64) {
         let data = NodeHeartbeatData {
@@ -359,4 +372,36 @@ pub fn load_cache_by_rocksdb(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MetaCacheManager;
+    use common_base::role::{ROLE_BROKER, ROLE_ENGINE};
+    use metadata_struct::meta::node::BrokerNode;
+    use rocksdb_engine::test::test_rocksdb_instance;
+
+    fn node(node_id: u64, roles: &[&str], storage_fold: &[&str]) -> BrokerNode {
+        BrokerNode {
+            node_id,
+            roles: roles.iter().map(|r| r.to_string()).collect(),
+            storage_fold: storage_fold.iter().map(|f| f.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    // Replica placement must ignore engine nodes that registered no storage
+    // folder: they pass the role check but calc_node_fold rejects them, which
+    // would fail the whole allocation instead of just skipping the node.
+    #[test]
+    fn storage_ready_engine_nodes_skip_folderless_and_non_engine_nodes() {
+        let cache_manager = MetaCacheManager::new(test_rocksdb_instance());
+
+        cache_manager.add_broker_node(node(1, &[ROLE_ENGINE], &["./data/engine"]));
+        cache_manager.add_broker_node(node(2, &[ROLE_ENGINE], &[]));
+        cache_manager.add_broker_node(node(3, &[ROLE_BROKER], &["./data/engine"]));
+
+        assert_eq!(cache_manager.get_engine_node_list().len(), 2);
+        assert_eq!(cache_manager.get_storage_ready_engine_node_ids(), vec![1]);
+    }
 }

--- a/src/meta-service/src/core/node_decommission.rs
+++ b/src/meta-service/src/core/node_decommission.rs
@@ -61,13 +61,7 @@ pub async fn decommission_node_segments(
         return Ok(());
     }
 
-    let alive_ids: Arc<Vec<u64>> = Arc::new(
-        meta_cache
-            .get_engine_node_list()
-            .iter()
-            .map(|n| n.node_id)
-            .collect(),
-    );
+    let alive_ids: Arc<Vec<u64>> = Arc::new(meta_cache.get_storage_ready_engine_node_ids());
     let load = Arc::new(Mutex::new(replica_load(meta_cache, &alive_ids)));
 
     let mut handles = Vec::new();

--- a/src/meta-service/src/core/segment_replica.rs
+++ b/src/meta-service/src/core/segment_replica.rs
@@ -94,9 +94,8 @@ pub async fn build_segment(
 
     let alive = cache_manager.get_storage_ready_engine_node_ids();
 
-    // "No engine node at all" and "engine nodes exist but none of them has a
-    // storage folder" are both `alive == 0`, but only the second one is a
-    // config mistake, and effective_replica_num cannot tell them apart.
+    // effective_replica_num sees only `alive.len() == 0` and cannot tell a
+    // cluster with no engine node from this misconfiguration.
     if alive.is_empty() && !cache_manager.get_engine_node_list().is_empty() {
         return Err(MetaServiceError::CommonError(
             "no engine node has a storage folder configured, set [storage_runtime] data_path"

--- a/src/meta-service/src/core/segment_replica.rs
+++ b/src/meta-service/src/core/segment_replica.rs
@@ -92,11 +92,17 @@ pub async fn build_segment(
         return Ok(segment);
     }
 
-    let alive: Vec<u64> = cache_manager
-        .get_engine_node_list()
-        .iter()
-        .map(|n| n.node_id)
-        .collect();
+    let alive = cache_manager.get_storage_ready_engine_node_ids();
+
+    // "No engine node at all" and "engine nodes exist but none of them has a
+    // storage folder" are both `alive == 0`, but only the second one is a
+    // config mistake, and effective_replica_num cannot tell them apart.
+    if alive.is_empty() && !cache_manager.get_engine_node_list().is_empty() {
+        return Err(MetaServiceError::CommonError(
+            "no engine node has a storage folder configured, set [storage_runtime] data_path"
+                .to_string(),
+        ));
+    }
 
     let target_replicas = effective_replica_num(
         shard_info.config.is_inner_topic,
@@ -232,11 +238,7 @@ async fn fill_inner_topic_replicas_once(
         return;
     }
 
-    let alive: Vec<u64> = cache_manager
-        .get_engine_node_list()
-        .iter()
-        .map(|n| n.node_id)
-        .collect();
+    let alive = cache_manager.get_storage_ready_engine_node_ids();
     if alive.is_empty() {
         return;
     }

--- a/src/meta-service/src/raft/store/log.rs
+++ b/src/meta-service/src/raft/store/log.rs
@@ -23,7 +23,9 @@ use openraft::{
     AnyError, Entry, LogId, LogState, OptionalSend, RaftLogReader, StorageError, StorageIOError,
     Vote,
 };
-use rocksdb::{BoundColumnFamily, Direction, IteratorMode, ReadOptions, WriteBatch, WriteOptions, DB};
+use rocksdb::{
+    BoundColumnFamily, Direction, IteratorMode, ReadOptions, WriteBatch, WriteOptions, DB,
+};
 use rocksdb_engine::storage::family::DB_COLUMN_FAMILY_META_RAFT;
 use std::fmt::Debug;
 use std::ops::RangeBounds;

--- a/src/meta-service/src/server/services/engine/shard.rs
+++ b/src/meta-service/src/server/services/engine/shard.rs
@@ -76,9 +76,6 @@ pub async fn create_shard_by_req(
     // orphan shard. Inner/system topics are exempt: they may start
     // under-replicated and are topped up by the background fill task.
     if !shard_config.is_inner_topic {
-        // Count only nodes that can host a replica, otherwise this pre-check
-        // passes and create_segment still fails, leaving the orphan shard it
-        // is meant to prevent.
         let engine_node_num = cache_manager.get_storage_ready_engine_node_ids().len() as u32;
         if engine_node_num < shard_config.replica_num {
             return Err(MetaServiceError::NotEnoughEngineNodes(

--- a/src/meta-service/src/server/services/engine/shard.rs
+++ b/src/meta-service/src/server/services/engine/shard.rs
@@ -76,7 +76,10 @@ pub async fn create_shard_by_req(
     // orphan shard. Inner/system topics are exempt: they may start
     // under-replicated and are topped up by the background fill task.
     if !shard_config.is_inner_topic {
-        let engine_node_num = cache_manager.get_engine_node_list().len() as u32;
+        // Count only nodes that can host a replica, otherwise this pre-check
+        // passes and create_segment still fails, leaving the orphan shard it
+        // is meant to prevent.
+        let engine_node_num = cache_manager.get_storage_ready_engine_node_ids().len() as u32;
         if engine_node_num < shard_config.replica_num {
             return Err(MetaServiceError::NotEnoughEngineNodes(
                 "CreateShard".to_string(),

--- a/src/storage-engine/src/filesegment/mod.rs
+++ b/src/storage-engine/src/filesegment/mod.rs
@@ -160,9 +160,11 @@ mod tests {
         assert!(!sf2.exists(), "segment file must be physically deleted");
     }
 
-    // delete_by_shard wipes everything: RocksDB keys + physical directory.
+    // delete_by_shard drops every RocksDB key under the shard prefix: meta,
+    // shard-level indices and each segment's keys. Its physical-directory pass
+    // iterates the configured data_path and is not covered here.
     #[tokio::test]
-    async fn filesegment_delete_shard_clears_all() {
+    async fn filesegment_delete_shard_clears_index() {
         let (seg, cache, _fold, db) = setup_and_write(5).await;
 
         // Sanity: data is readable before deletion.
@@ -188,14 +190,6 @@ mod tests {
             gone_tag.is_empty(),
             "tag index must be gone after shard delete"
         );
-
-        // Note: delete_by_shard removes physical files by iterating
-        // broker_config().storage_runtime.data_path, which in unit tests is the
-        // built-in default ("./data/engine"), while the test data actually
-        // lives under /tmp/tests/<id> (test_build_data_fold). So the directory
-        // removal loop is a no-op here. The meaningful unit-test invariant is
-        // that the RocksDB index is cleared, which the key/tag assertions above
-        // already cover.
     }
 
     // Records written with expire_at in the past must be filtered out at read time.

--- a/src/storage-engine/src/filesegment/mod.rs
+++ b/src/storage-engine/src/filesegment/mod.rs
@@ -190,10 +190,11 @@ mod tests {
         );
 
         // Note: delete_by_shard removes physical files by iterating
-        // broker_config().storage_runtime.data_path. In unit tests that field
-        // is empty (default_broker_config sets no data_path), so the directory
-        // removal loop is a no-op. The meaningful unit-test invariant is that
-        // the RocksDB index is cleared, which the key/tag assertions above
+        // broker_config().storage_runtime.data_path, which in unit tests is the
+        // built-in default ("./data/engine"), while the test data actually
+        // lives under /tmp/tests/<id> (test_build_data_fold). So the directory
+        // removal loop is a no-op here. The meaningful unit-test invariant is
+        // that the RocksDB index is cleared, which the key/tag assertions above
         // already cover.
     }
 

--- a/src/storage-engine/src/filesegment/mod.rs
+++ b/src/storage-engine/src/filesegment/mod.rs
@@ -160,7 +160,6 @@ mod tests {
         assert!(!sf2.exists(), "segment file must be physically deleted");
     }
 
-    // Index only; delete_by_shard's data_path cleanup is not exercised here.
     #[tokio::test]
     async fn filesegment_delete_shard_clears_index() {
         let (seg, cache, _fold, db) = setup_and_write(5).await;

--- a/src/storage-engine/src/filesegment/mod.rs
+++ b/src/storage-engine/src/filesegment/mod.rs
@@ -160,9 +160,7 @@ mod tests {
         assert!(!sf2.exists(), "segment file must be physically deleted");
     }
 
-    // delete_by_shard drops every RocksDB key under the shard prefix: meta,
-    // shard-level indices and each segment's keys. Its physical-directory pass
-    // iterates the configured data_path and is not covered here.
+    // Index only; delete_by_shard's data_path cleanup is not exercised here.
     #[tokio::test]
     async fn filesegment_delete_shard_clears_index() {
         let (seg, cache, _fold, db) = setup_and_write(5).await;


### PR DESCRIPTION
## What's changed and what's your intention?

Fixes #2043 — `ghcr.io/robustmq/robustmq:latest` exits immediately on startup:

### Root cause

`StorageRuntime.data_path` was the only field in the struct whose code default is an empty vec (`default.rs`), even though `config/server.toml.template` and `docs/{zh,en}/Configuration/BROKER.md` both document the default as `["./data/engine"]`.

`config/server.toml` — the minimal single-node config that ships in the release tarball and therefore in the Docker image — has no `[storage_runtime]` section, so:

1. the node registers with `storage_fold: []` (`broker-core/src/cluster.rs`), and nothing validates it;
2. startup Phase 7 creates the inner topics, `$retain-message` first;
3. `create_shard_to_place` → `EngineService/CreateShard` → `create_segment` → `calc_node_fold` (`meta-service/src/core/segment.rs`) rejects the node;
4. `broker-server/src/lib.rs` logs and `exit(1)` — Phase 8 never runs, so no MQTT listener is ever opened.

Every user starting RobustMQ from the Docker image or the release package hits this 100% of the time. CI did not catch it because the integration tests start a 3-node cluster from `config/cluster/server-{1,2,3}.toml`, and all three set `data_path` explicitly — the shipped single-node config is never actually started.

### The change

- **`default.rs` / `config.rs`** — add `default_storage_data_path()` returning `["./data/engine"]` and wire it through `#[serde(default = "...")]`, so both "section missing" and "key missing" resolve to a usable folder.
- **`docs/{zh,en}/Configuration/BROKER.md`** — these documented `data_path = []`, i.e. the bug itself; corrected to match.
- **meta service hardening** — new `MetaCacheManager::get_storage_ready_engine_node_ids()`; all four replica-placement sites use it:
  - `build_segment` skips folder-less nodes instead of failing the whole allocation, and reports a config-specific error when engine nodes exist but none has a storage folder (`effective_replica_num` cannot distinguish that from "no engine node at all");
  - `create_shard_by_req`'s capacity pre-check no longer counts folder-less nodes — it could otherwise pass and still leave behind the orphan shard it exists to prevent;
  - the inner-topic replica fill task and node decommission no longer target such nodes.

`config/server.toml` is deliberately left untouched: its header states that everything in it is all that's needed to start and that every other setting has a built-in default, so pinning `data_path` there would just be a redundant override of the default this PR fixes. The knob stays documented in `config/server.toml.template` and in `BROKER.md`.

Also included, as its own commit: **`src/meta-service/src/raft/store/log.rs`** — a 101-character `use rocksdb::{…}` line, over `max_width = 100`. This is unrelated to #2043 and pre-exists on `main` (`Code Style / rustfmt` has been failing on `main` since 8bd49dc, c74868c), but it is the sole reason this PR's `rustfmt` check was red, so it is fixed here rather than left blocking.

### Verification

- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` are clean.
- `make test` (the Unit Test job's command) reports 779 passed / 1 failed. The two tests that fail here — `llm-engine embedding::fastembed::tests::test_embed` and `admin-server client::tests::test_get_with_params` — fail identically on `main` (4c59e9a) with the same panic sites, so they are environmental, not from this change: the first needs the `Xenova/all-MiniLM-L6-v2` model that the Unit Test job pre-downloads in a dedicated step, and the second gets a 502 reaching its own local axum server.
- Single-node startup re-tested against the *unmodified* `config/server.toml` — the actual #2043 repro, and now the only thing standing between a fresh install and the crash, since nothing in that file pins `data_path` any more. With no `[storage_runtime]` section at all, the dumped effective config shows `data_path: ["./data/engine"]`; the inner topics that used to abort startup are created (`Creating shard: … topic_name=$retain-message` → `Creating new segment` → `Shard … created successfully`); Phase 8 runs and opens MQTT 1883, Kafka 9092, AMQP 5672, NATS 4222, storage-engine 1778; and an MQTT 3.1.1 client gets `CONNACK rc=0` plus a `PUBACK` for a QoS 1 publish. The process was still healthy on shutdown.
  Note `./data/engine` itself is not created by a bare startup — the inner topics use `EngineRocksDB` (`storage_type: EngineRocksDB` in the shard config) and live under `data/_rocksdb`; the folder is materialised by the first file-segment write. What the fix restores is a non-empty `storage_fold` at registration, which is what `calc_node_fold` was rejecting.
- `filesegment_delete_shard_clears_all` is renamed to `filesegment_delete_shard_clears_index`, which is what it actually asserts.

### CI status

Three checks fail for reasons that pre-date this branch, verified against `main`:

| Check | Status |
|---|---|
| `Ig Test Core` | `meta::agent_test::tests::test_agent_search_vector_and_fts` fails identically on `main`; each of the last 6 `main` runs failed. |
| `Ig Test MQ9` | `mq9::agent_discover::tests::mq9_agent_discover_{text,semantic}_test` fail identically on `main`; each of the last 6 `main` runs failed. |
| `Ig Test Kafka` | Flake — `BrokerTransportFailure` on `localhost:9092`. The same SHA `78309aa` on another branch failed once and passed on re-run. `MQTT` / `NATS` / `AMQP` all passed on this commit, so the 3-node cluster starts and shard placement works. |

Happy to open separate issues for the Core / MQ9 failures if they aren't already tracked.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

By submitting this pull request, you agree to the terms of the [Apache License 2.0](https://github.com/robustmq/robustmq/blob/main/LICENSE), the [LICENSE](https://github.com/robustmq/robustmq/blob/main/LICENSING.md), and the [Contributor License Agreement (CLA)](https://github.com/robustmq/robustmq/blob/main/CLA.md).

## Refer to a related PR or issue link

Closes #2043

